### PR TITLE
fix(core): catch of error should work with `exitCode` and/or `code`

### DIFF
--- a/packages/core/src/__tests__/child-process.spec.ts
+++ b/packages/core/src/__tests__/child-process.spec.ts
@@ -6,7 +6,7 @@ import { Package } from '../package';
 describe('childProcess', () => {
   describe('.execSync()', () => {
     it('should execute a command in a child process and return the result', () => {
-      expect(execSync('echo', ['execSync'])).toBe(`"execSync"`);
+      expect(execSync('echo', ['execSync'])).toContain(`execSync`);
     });
 
     it('should execute a command in dry-run and log the command', () => {
@@ -25,7 +25,7 @@ describe('childProcess', () => {
       const { stderr, stdout } = await exec('echo', ['foo']) as any;
 
       expect(stderr).toBe('');
-      expect(stdout).toBe(`"foo"`);
+      expect(stdout).toContain(`foo`);
     });
 
     it('should execute a command in dry-run and log the command', () => {
@@ -49,8 +49,8 @@ describe('childProcess', () => {
       expect(getChildProcessCount()).toBe(2);
 
       const [one, two] = await Promise.all([echoOne, echoTwo]) as any;
-      expect(one.stdout).toBe(`"one"`);
-      expect(two.stdout).toBe(`"two"`);
+      expect(one.stdout).toContain(`one`);
+      expect(two.stdout).toContain(`two`);
     });
 
     it('decorates opts.pkg on error if caught', async () => {

--- a/packages/core/src/__tests__/child-process.spec.ts
+++ b/packages/core/src/__tests__/child-process.spec.ts
@@ -1,0 +1,89 @@
+import npmlog from 'npmlog';
+// file under test
+import { exec, execSync, getChildProcessCount, spawn } from '../child-process';
+import { Package } from '../package';
+
+describe('childProcess', () => {
+  describe('.execSync()', () => {
+    it('should execute a command in a child process and return the result', () => {
+      expect(execSync('echo', ['execSync'])).toBe(`"execSync"`);
+    });
+
+    it('should execute a command in dry-run and log the command', () => {
+      const logSpy = jest.spyOn(npmlog, 'info');
+      execSync('echo', ['execSync'], undefined, true);
+      expect(logSpy).toHaveBeenCalledWith('dry-run>', 'echo execSync');
+    });
+
+    it('does not error when stdout is ignored', () => {
+      expect(() => execSync('echo', ['ignored'], { stdio: 'ignore' })).not.toThrow();
+    });
+  });
+
+  describe('.exec()', () => {
+    it('returns an execa Promise', async () => {
+      const { stderr, stdout } = await exec('echo', ['foo']) as any;
+
+      expect(stderr).toBe('');
+      expect(stdout).toBe(`"foo"`);
+    });
+
+    it('rejects on undefined command', async () => {
+      const result = exec('nowImTheModelOfAModernMajorGeneral', undefined);
+
+      await expect(result).rejects.toThrow(/\bnowImTheModelOfAModernMajorGeneral\b/);
+      expect(getChildProcessCount()).toBe(0);
+    });
+
+    it('registers child processes that are created', async () => {
+      const echoOne = exec('echo', ['one']);
+      expect(getChildProcessCount()).toBe(1);
+
+      const echoTwo = exec('echo', ['two']);
+      expect(getChildProcessCount()).toBe(2);
+
+      const [one, two] = await Promise.all([echoOne, echoTwo]) as any;
+      expect(one.stdout).toBe(`"one"`);
+      expect(two.stdout).toBe(`"two"`);
+    });
+
+    xit('decorates opts.pkg on error if caught', async () => {
+      const result = exec(
+        'theVeneratedVirginianVeteranWhoseMenAreAll',
+        ['liningUpToPutMeUpOnAPedestal'],
+        { pkg: { name: 'hamilton' } as Package }
+      );
+
+      await expect(result).rejects.toThrow(
+        expect.objectContaining({
+          pkg: { name: 'hamilton' },
+        })
+      );
+    });
+  });
+
+  describe('.spawn()', () => {
+    it('should spawn a command in a child process that always inherits stdio', async () => {
+      const child = spawn('echo', ['-n']) as any;
+      expect(child.stdio).toEqual([null, null, null]);
+
+      const { exitCode, signal } = await child;
+      expect(exitCode).toBe(0);
+      expect(signal).toBe(undefined);
+    });
+
+    it('decorates opts.pkg on error if caught', async () => {
+      const result = spawn('exit', ['123'], {
+        pkg: { name: 'shelled' } as Package,
+        shell: true,
+      });
+
+      await expect(result).rejects.toThrow(
+        expect.objectContaining({
+          exitCode: 123,
+          pkg: { name: 'shelled' },
+        })
+      );
+    });
+  });
+});

--- a/packages/core/src/__tests__/child-process.spec.ts
+++ b/packages/core/src/__tests__/child-process.spec.ts
@@ -28,6 +28,12 @@ describe('childProcess', () => {
       expect(stdout).toBe(`"foo"`);
     });
 
+    it('should execute a command in dry-run and log the command', () => {
+      const logSpy = jest.spyOn(npmlog, 'info');
+      exec('echo', ['exec'], undefined, true);
+      expect(logSpy).toHaveBeenCalledWith('dry-run>', 'echo exec');
+    });
+
     it('rejects on undefined command', async () => {
       const result = exec('nowImTheModelOfAModernMajorGeneral', undefined);
 
@@ -47,7 +53,7 @@ describe('childProcess', () => {
       expect(two.stdout).toBe(`"two"`);
     });
 
-    xit('decorates opts.pkg on error if caught', async () => {
+    it('decorates opts.pkg on error if caught', async () => {
       const result = exec(
         'theVeneratedVirginianVeteranWhoseMenAreAll',
         ['liningUpToPutMeUpOnAPedestal'],
@@ -70,6 +76,12 @@ describe('childProcess', () => {
       const { exitCode, signal } = await child;
       expect(exitCode).toBe(0);
       expect(signal).toBe(undefined);
+    });
+
+    it('should execute a command in dry-run and log the command', () => {
+      const logSpy = jest.spyOn(npmlog, 'info');
+      spawn('echo', ['-n'], undefined, true);
+      expect(logSpy).toHaveBeenCalledWith('dry-run>', 'echo -n');
     });
 
     it('decorates opts.pkg on error if caught', async () => {

--- a/packages/core/src/child-process.ts
+++ b/packages/core/src/child-process.ts
@@ -16,29 +16,53 @@ const NUM_COLORS = colorWheel.length;
 // ever-increasing index ensures colors are always sequential
 let currentColor = 0;
 
-export function exec(command: string, args: string[], opts?: execa.Options & { pkg?: Package }, cmdDryRun = false) {
+/**
+ * Execute a command asynchronously, piping stdio by default.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {import("execa").Options} [opts]
+ */
+export function exec(command: string, args: string[], opts?: execa.Options & { pkg?: Package }, cmdDryRun = false): Promise<any> {
   const options = Object.assign({ stdio: 'pipe' }, opts);
   const spawned = spawnProcess(command, args, options, cmdDryRun);
 
   return cmdDryRun ? Promise.resolve() : wrapError(spawned);
 }
 
-// resultCallback?: (processResult: ChildProcessResult) => void
+/**
+ * Execute a command synchronously.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {import("execa").SyncOptions} [opts]
+ */
 export function execSync(command: string, args?: string[], opts?: execa.SyncOptions<string>, cmdDryRun = false) {
   return cmdDryRun
     ? logExecCommand(command, args)
     : execa.sync(command, args, opts).stdout;
 }
 
-export function spawn(command: string, args: string[], opts?: execa.Options & { pkg?: Package }, cmdDryRun = false) {
+/**
+ * Spawn a command asynchronously, _always_ inheriting stdio.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {import("execa").Options} [opts]
+ */
+export function spawn(command: string, args: string[], opts?: execa.Options & { pkg?: Package }, cmdDryRun = false): Promise<any> {
   const options = Object.assign({}, opts, { stdio: 'inherit' });
   const spawned = spawnProcess(command, args, options, cmdDryRun);
 
   return wrapError(spawned);
 }
 
+/**
+ * Spawn a command asynchronously, streaming stdio with optional prefix.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {import("execa").Options} [opts]
+ * @param {string} [prefix]
+ */
 // istanbul ignore next
-export function spawnStreaming(command: string, args: string[], opts?: execa.Options & { pkg?: Package }, prefix?: string | boolean, cmdDryRun = false) {
+export function spawnStreaming(command: string, args: string[], opts?: execa.Options & { pkg?: Package }, prefix?: string | boolean, cmdDryRun = false): Promise<any> {
   const options: any = Object.assign({}, opts);
   options.stdio = ['ignore', 'pipe', 'pipe'];
 
@@ -69,7 +93,7 @@ export function spawnStreaming(command: string, args: string[], opts?: execa.Opt
   return wrapError(spawned);
 }
 
-export function getChildProcessCount() {
+export function getChildProcessCount(): number {
   return children.size;
 }
 
@@ -89,6 +113,11 @@ export function getExitCode(result: any) {
   throw new TypeError(`Received unexpected exit code value ${JSON.stringify(result.code ?? result.exitCode)}`);
 }
 
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {import("execa").Options} opts
+ */
 export function spawnProcess(command: string, args: string[], opts: execa.Options & { pkg?: Package }, cmdDryRun = false) {
   if (cmdDryRun) {
     return logExecCommand(command, args);
@@ -115,6 +144,12 @@ export function spawnProcess(command: string, args: string[], opts: execa.Option
   return child;
 }
 
+/**
+ * Spawn a command asynchronously, _always_ inheriting stdio.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {import("execa").Options} [opts]
+ */
 export function wrapError(spawned: execa.ExecaChildProcess & { pkg?: Package }) {
   if (spawned.pkg) {
     return spawned.catch((err: any) => {
@@ -131,6 +166,11 @@ export function wrapError(spawned: execa.ExecaChildProcess & { pkg?: Package }) 
   return spawned;
 }
 
+/**
+ * Log the child-process command and its arguments as dry-run (without executing the process)
+ * @param {string} command
+ * @param {string[]} args
+ */
 export function logExecCommand(command: string, args?: string[]) {
   const argStr = (Array.isArray(args) ? args.join(' ') : args) ?? '';
 

--- a/packages/core/src/utils/check-working-tree.ts
+++ b/packages/core/src/utils/check-working-tree.ts
@@ -3,7 +3,7 @@ import { describeRef } from './describe-ref';
 import { ValidationError } from '../validation-error';
 
 export function checkWorkingTree({ cwd } = {} as any, gitDryRun = false) {
-  let chain = Promise.resolve();
+  let chain: Promise<any> = Promise.resolve();
 
   chain = chain.then(() => describeRef({ cwd }, undefined, gitDryRun));
 

--- a/packages/core/src/utils/collect-uncommitted.ts
+++ b/packages/core/src/utils/collect-uncommitted.ts
@@ -43,7 +43,7 @@ export function collectUncommitted({ cwd, log = npmlog }, gitDryRun = false) {
  * @param {UncommittedConfig} options
  * @returns {string[]} A list of uncommitted files
  */
-export function collectUncommittedSync({ cwd, log = npmlog }, gitDryRun = false) {
+export function collectUncommittedSync({ cwd, log = npmlog }: { cwd: string; log: typeof npmlog }, gitDryRun = false) {
   log.silly('collect-uncommitted', 'git status --porcelain (sync)');
 
   const stdout = execSync('git', ['status', '--porcelain'], { cwd }, gitDryRun);

--- a/packages/publish/src/publishCommand.ts
+++ b/packages/publish/src/publishCommand.ts
@@ -20,6 +20,7 @@ import {
   runTopologically,
   throwIfUncommitted,
   ValidationError,
+  PackageGraphNode,
 } from '@lerna-lite/core';
 import { getCurrentTags } from './lib/get-current-tags';
 import { getTaggedPackages } from './lib/get-tagged-packages';
@@ -262,7 +263,7 @@ export class PublishCommand extends Command {
         return taggedPackageNames.map((name) => this.packageGraph?.get(name));
       }
 
-      const updates = await getTaggedPackages(this.packageGraph, this.project?.rootPath, this.execOpts, this.options.gitDryRun);
+      const updates = await getTaggedPackages(this.packageGraph, this.project?.rootPath, this.execOpts, this.options.gitDryRun) as PackageGraphNode[];
 
       // private packages are never published, full stop.
       updates.filter((node) => !node.pkg.private);


### PR DESCRIPTION
- add child-process unit tests