### PR TITLE
fix(version): load & write project root lockfile v2 only once

### DIFF
--- a/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
@@ -527,3 +527,61 @@ index SHA..SHA 100644
 -    \\"package-4\\": \\"^1.0.0\\"
 +    \\"package-4\\": \\"^2.0.0\\""
 `;
+
+exports[`VersionCommand with lockfile version 2 should have updated project root lockfile version 2 for every necessary properties 1`] = `
+Object {
+  "dependencies": Object {
+    "@my-workspace/package-1": Object {
+      "requires": Object {
+        "tiny-tarball": "^1.0.0",
+      },
+      "version": "file:packages/package-1",
+    },
+    "@my-workspace/package-2": Object {
+      "requires": Object {
+        "@my-workspace/package-1": "^3.0.0",
+      },
+      "version": "file:packages/package-2",
+    },
+  },
+  "lockfileVersion": 2,
+  "name": "my-workspace",
+  "packages": Object {
+    "": Object {
+      "license": "MIT",
+      "name": "my-workspace",
+      "workspaces": Array [
+        "./packages/package-1",
+        "./packages/package-2",
+      ],
+    },
+    "node_modules/package-1": Object {
+      "link": true,
+      "resolved": "packages/package-1",
+    },
+    "node_modules/package-2": Object {
+      "link": true,
+      "resolved": "packages/package-2",
+    },
+    "packages/package-1": Object {
+      "license": "MIT",
+      "name": "@my-workspace/package-1",
+      "tiny-tarball": Object {
+        "integrity": "sha1-u/EC1a5zr+LFUyleD7AiMCFvZbE=",
+        "resolved": "https://registry.npmjs.org/tiny-tarball/-/tiny-tarball-1.0.0.tgz",
+        "version": "1.0.0",
+      },
+      "version": "3.0.0",
+    },
+    "packages/package-2": Object {
+      "dependencies": Object {
+        "@my-workspace/package-1": "^3.0.0",
+      },
+      "license": "MIT",
+      "name": "@my-workspace/package-2",
+      "version": "3.0.0",
+    },
+  },
+  "requires": true,
+}
+`;

--- a/packages/version/src/__tests__/version-lifecycle-scripts.spec.ts
+++ b/packages/version/src/__tests__/version-lifecycle-scripts.spec.ts
@@ -82,7 +82,7 @@ describe("lifecycle scripts", () => {
     expect(Array.from(loadJsonFile.registry.keys())).toStrictEqual([
       "/packages/package-1",
       "/packages/package-2",
-      "/" // TODO: investigate why the original Lerna doesn't have this extra one in the root
+      "/" // `package-lock.json` project root location
     ]);
   });
 


### PR DESCRIPTION
- previous code was opening the project root lockfile over and over (for every workspace package) and this was causing perf issue but also in some cases potential racing condition because the processes of loading/writing json are `async` however that should really be done only once (loading lockfile once, looping through all pkg, then writing final json once)
- this code is only useful when the project has a `package-lock.json` (v2 lockfile) in the project root (when created from an NPM Workspace), which is exactly the structure of Lerna-Lite 