### PR TITLE
fix(core): replace `npm-lifecycle` with `@npmcli/run-script`, fixes #60

### DIFF
--- a/jest/setup-unit-test-timeout.js
+++ b/jest/setup-unit-test-timeout.js
@@ -1,4 +1,4 @@
 'use strict';
 
-// allow 15s timeout in an attempt to lessen flakiness of unit tests...
-jest.setTimeout(15e3);
+// allow 30s timeout in an attempt to lessen flakiness of unit tests...
+jest.setTimeout(30e3);

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "normalize-path": "^3.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
-        "tacks": "^1.3.0",
+        "tacks": "^1.2.6",
         "tempy": "^1.0.1",
         "ts-jest": "^28.0.2",
         "tsm": "^2.2.1",
@@ -1664,9 +1664,12 @@
       }
     },
     "node_modules/@npmcli/node-gyp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz",
-      "integrity": "sha512-fnkhw+fmX65kiLqk6E3BFLXNC26rUhK90zVwe2yncPliVT/Qos3xjhTLE59Df8KnPlcwIERXKVlU1bXoUQ+liA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-2.0.0.tgz",
+      "integrity": "sha512-doNI35wIe3bBaEgrlPfdJPaCpUR89pJWep4Hq3aRdh6gKazIVWfs0jHttvSSoq47ZXgC7h73kDsUl8AoIQUB+A==",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/@npmcli/promise-spawn": {
       "version": "1.3.2",
@@ -1677,17 +1680,28 @@
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-3.0.1.tgz",
-      "integrity": "sha512-o2fkld5hYwu9sKYzoXTpqEocMnDLaigobaPzLaGB63k/ExmLBTaB+KpfKlpcIePPnuP8RFR+0GDI4KopJCM6Xg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-3.0.2.tgz",
+      "integrity": "sha512-vdjD/PMBl+OX9j9C9irx5sCCIKfp2PWkpPNH9zxvlJAfSZ3Qp5aU412v+O3PFJl3R1PFNwuyChCqHg4ma6ci2Q==",
       "dependencies": {
-        "@npmcli/node-gyp": "^1.0.3",
-        "@npmcli/promise-spawn": "^1.3.2",
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
         "node-gyp": "^9.0.0",
         "read-package-json-fast": "^2.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/@npmcli/promise-spawn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-3.0.0.tgz",
+      "integrity": "sha512-s9SgS+p3a9Eohe68cSI3fi+hpcZUmXq5P7w0kMlAsWVtR7XbK3ptkZqKT2cK1zLDObJ3sR+8P59sJE0w/KTL1g==",
+      "dependencies": {
+        "infer-owner": "^1.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -2403,6 +2417,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2541,37 +2556,8 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.3",
-      "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
       "license": "MIT"
     },
     "node_modules/babel-jest": {
@@ -2687,13 +2673,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
       "license": "Apache-2.0"
@@ -2808,13 +2787,6 @@
         "semver": "^7.0.0"
       }
     },
-    "node_modules/byline": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cacache": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.3.tgz",
@@ -2906,10 +2878,6 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3049,7 +3017,9 @@
     },
     "node_modules/code-point-at": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3101,16 +3071,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/compare-func": {
@@ -3328,16 +3288,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/dateformat": {
       "version": "3.0.3",
       "license": "MIT",
@@ -3450,13 +3400,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "license": "MIT"
@@ -3539,14 +3482,6 @@
     "node_modules/duplexer": {
       "version": "0.1.2",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.129",
@@ -4485,10 +4420,6 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "license": "MIT",
@@ -4501,15 +4432,9 @@
         "node": ">=4"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4538,6 +4463,7 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4636,25 +4562,6 @@
       "version": "3.2.5",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -4861,13 +4768,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/git-raw-commits": {
       "version": "2.0.11",
       "license": "MIT",
@@ -5042,24 +4942,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "license": "MIT",
@@ -5150,19 +5032,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -5344,6 +5213,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ip": {
@@ -5655,10 +5533,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -6680,10 +6554,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6704,12 +6574,9 @@
       "version": "2.3.1",
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6764,19 +6631,6 @@
         "node": "*"
       }
     },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "license": "MIT",
@@ -6791,6 +6645,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "dependencies": {
+        "invert-kv": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/leven": {
@@ -7225,23 +7091,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.51.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.34",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.51.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "license": "MIT",
@@ -7578,230 +7427,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm-lifecycle": {
-      "version": "3.1.5",
-      "license": "Artistic-2.0",
-      "dependencies": {
-        "byline": "^5.0.0",
-        "graceful-fs": "^4.1.15",
-        "node-gyp": "^5.0.2",
-        "resolve-from": "^4.0.0",
-        "slide": "^1.1.6",
-        "uid-number": "0.0.6",
-        "umask": "^1.1.0",
-        "which": "^1.3.1"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/aproba": {
-      "version": "1.2.0",
-      "license": "ISC"
-    },
-    "node_modules/npm-lifecycle/node_modules/are-we-there-yet": {
-      "version": "1.1.7",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC"
-    },
-    "node_modules/npm-lifecycle/node_modules/fs-minipass": {
-      "version": "1.2.7",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^2.6.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/gauge": {
-      "version": "2.7.4",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/minipass": {
-      "version": "2.9.0",
-      "license": "ISC",
-      "dependencies": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/minizlib": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^2.9.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/node-gyp": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
-        "mkdirp": "^0.5.1",
-        "nopt": "^4.0.1",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.0",
-        "rimraf": "^2.6.3",
-        "semver": "^5.7.1",
-        "tar": "^4.4.12",
-        "which": "^1.3.1"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/nopt": {
-      "version": "4.0.3",
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/npmlog": {
-      "version": "4.1.2",
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/npm-lifecycle/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/rimraf": {
-      "version": "2.7.1",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/npm-lifecycle/node_modules/string-width": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/tar": {
-      "version": "4.4.19",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=4.5"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/which": {
-      "version": "1.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/npm-lifecycle/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
-    },
     "node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
       "license": "ISC"
@@ -8102,21 +7727,9 @@
     },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8240,9 +7853,14 @@
       "version": "0.1.2",
       "license": "MIT"
     },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "license": "MIT",
+    "node_modules/os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "dependencies": {
+        "lcid": "^1.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8252,14 +7870,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/osenv": {
-      "version": "0.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
       }
     },
     "node_modules/p-finally": {
@@ -8492,10 +8102,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -8695,10 +8301,6 @@
     },
     "node_modules/protocols": {
       "version": "1.4.8",
-      "license": "MIT"
-    },
-    "node_modules/psl": {
-      "version": "1.8.0",
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -8998,42 +8600,6 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
@@ -9258,13 +8824,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/slide": {
-      "version": "1.1.6",
-      "license": "ISC",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "license": "MIT",
@@ -9387,29 +8946,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "node_modules/sshpk": {
-      "version": "1.17.0",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/ssri": {
       "version": "8.0.1",
@@ -9545,7 +9081,9 @@
     },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -9555,7 +9093,9 @@
     },
     "node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9644,145 +9184,67 @@
       }
     },
     "node_modules/tacks": {
-      "version": "1.3.0",
-      "bundleDependencies": [
-        "@iarna/cli",
-        "mkdirp",
-        "rimraf"
-      ],
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/tacks/-/tacks-1.2.6.tgz",
+      "integrity": "sha1-BL9htjbT0KkcyFP+W1w6ulUt1F0=",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "@iarna/cli": "^2.0.0",
+        "graceful-fs": "^4.1.2",
         "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.2"
+        "rimraf": "^2.5.1",
+        "yargs": "^3.32.0"
       },
       "bin": {
         "tacks": "cmdline.js"
       }
     },
-    "node_modules/tacks/node_modules/@iarna/cli": {
-      "version": "2.0.0",
+    "node_modules/tacks/node_modules/camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
       "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "signal-exit": "^3.0.2"
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/tacks/node_modules/balanced-match": {
-      "version": "1.0.0",
+    "node_modules/tacks/node_modules/cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/tacks/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
-    "node_modules/tacks/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/tacks/node_modules/fs.realpath": {
+    "node_modules/tacks/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/tacks/node_modules/glob": {
-      "version": "7.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "number-is-nan": "^1.0.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=0.10.0"
       }
-    },
-    "node_modules/tacks/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/tacks/node_modules/inherits": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/tacks/node_modules/minimatch": {
-      "version": "3.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tacks/node_modules/minimist": {
-      "version": "0.0.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/tacks/node_modules/mkdirp": {
-      "version": "0.5.1",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
-      "inBundle": true,
-      "license": "MIT",
       "dependencies": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/tacks/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/tacks/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/tacks/node_modules/rimraf": {
       "version": "2.6.2",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.0.5"
@@ -9791,17 +9253,53 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/tacks/node_modules/signal-exit": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/tacks/node_modules/wrappy": {
+    "node_modules/tacks/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
-      "inBundle": true,
-      "license": "ISC"
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tacks/node_modules/wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tacks/node_modules/y18n": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+      "dev": true
+    },
+    "node_modules/tacks/node_modules/yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^2.0.1",
+        "cliui": "^3.0.3",
+        "decamelize": "^1.1.1",
+        "os-locale": "^1.4.0",
+        "string-width": "^1.0.1",
+        "window-size": "^0.1.4",
+        "y18n": "^3.2.0"
+      }
     },
     "node_modules/tar": {
       "version": "6.1.11",
@@ -9970,17 +9468,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tr46": {
       "version": "3.0.0",
       "license": "MIT",
@@ -10114,20 +9601,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -10185,17 +9658,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/uid-number": {
-      "version": "0.0.6",
-      "license": "ISC",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/umask": {
-      "version": "1.1.0",
-      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
@@ -10257,6 +9719,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -10321,22 +9784,6 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -10405,6 +9852,18 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true,
+      "bin": {
+        "window-size": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/word-wrap": {
@@ -10671,6 +10130,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "@npmcli/run-script": "^3.0.2",
         "@octokit/plugin-enterprise-rest": "^6.0.1",
         "@octokit/rest": "^18.12.0",
         "async": "^3.2.3",
@@ -10695,7 +10155,6 @@
         "load-json-file": "^6.2.0",
         "minimatch": "^5.1.0",
         "node-fetch": "^2.6.7",
-        "npm-lifecycle": "^3.1.5",
         "npm-package-arg": "^9.0.2",
         "npm-packlist": "^5.0.4",
         "npm-registry-fetch": "^13.1.1",
@@ -11879,6 +11338,7 @@
     "@lerna-lite/core": {
       "version": "file:packages/core",
       "requires": {
+        "@npmcli/run-script": "^3.0.2",
         "@octokit/plugin-enterprise-rest": "^6.0.1",
         "@octokit/rest": "^18.12.0",
         "@types/async": "^3.2.13",
@@ -11921,7 +11381,6 @@
         "load-json-file": "^6.2.0",
         "minimatch": "^5.1.0",
         "node-fetch": "^2.6.7",
-        "npm-lifecycle": "^3.1.5",
         "npm-package-arg": "^9.0.2",
         "npm-packlist": "^5.0.4",
         "npm-registry-fetch": "^13.1.1",
@@ -12351,9 +11810,9 @@
       }
     },
     "@npmcli/node-gyp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz",
-      "integrity": "sha512-fnkhw+fmX65kiLqk6E3BFLXNC26rUhK90zVwe2yncPliVT/Qos3xjhTLE59Df8KnPlcwIERXKVlU1bXoUQ+liA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-2.0.0.tgz",
+      "integrity": "sha512-doNI35wIe3bBaEgrlPfdJPaCpUR89pJWep4Hq3aRdh6gKazIVWfs0jHttvSSoq47ZXgC7h73kDsUl8AoIQUB+A=="
     },
     "@npmcli/promise-spawn": {
       "version": "1.3.2",
@@ -12364,14 +11823,24 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-3.0.1.tgz",
-      "integrity": "sha512-o2fkld5hYwu9sKYzoXTpqEocMnDLaigobaPzLaGB63k/ExmLBTaB+KpfKlpcIePPnuP8RFR+0GDI4KopJCM6Xg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-3.0.2.tgz",
+      "integrity": "sha512-vdjD/PMBl+OX9j9C9irx5sCCIKfp2PWkpPNH9zxvlJAfSZ3Qp5aU412v+O3PFJl3R1PFNwuyChCqHg4ma6ci2Q==",
       "requires": {
-        "@npmcli/node-gyp": "^1.0.3",
-        "@npmcli/promise-spawn": "^1.3.2",
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
         "node-gyp": "^9.0.0",
         "read-package-json-fast": "^2.0.3"
+      },
+      "dependencies": {
+        "@npmcli/promise-spawn": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-3.0.0.tgz",
+          "integrity": "sha512-s9SgS+p3a9Eohe68cSI3fi+hpcZUmXq5P7w0kMlAsWVtR7XbK3ptkZqKT2cK1zLDObJ3sR+8P59sJE0w/KTL1g==",
+          "requires": {
+            "infer-owner": "^1.0.4"
+          }
+        }
       }
     },
     "@octokit/auth-token": {
@@ -12926,6 +12395,7 @@
     },
     "ajv": {
       "version": "6.12.6",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13006,26 +12476,8 @@
     "arrify": {
       "version": "1.0.1"
     },
-    "asn1": {
-      "version": "0.2.6",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0"
-    },
     "async": {
       "version": "3.2.3"
-    },
-    "asynckit": {
-      "version": "0.4.0"
-    },
-    "aws-sign2": {
-      "version": "0.7.0"
-    },
-    "aws4": {
-      "version": "1.11.0"
     },
     "babel-jest": {
       "version": "28.1.0",
@@ -13103,12 +12555,6 @@
     "base64-js": {
       "version": "1.5.1"
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "before-after-hook": {
       "version": "2.2.2"
     },
@@ -13180,9 +12626,6 @@
         "semver": "^7.0.0"
       }
     },
-    "byline": {
-      "version": "5.0.0"
-    },
     "cacache": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.3.tgz",
@@ -13241,9 +12684,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
       "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0"
     },
     "chalk": {
       "version": "4.1.2",
@@ -13330,7 +12770,10 @@
       "dev": true
     },
     "code-point-at": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -13365,12 +12808,6 @@
             "ansi-regex": "^5.0.1"
           }
         }
-      }
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "requires": {
-        "delayed-stream": "~1.0.0"
       }
     },
     "compare-func": {
@@ -13526,12 +12963,6 @@
     "dargs": {
       "version": "7.0.0"
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "dateformat": {
       "version": "3.0.3"
     },
@@ -13601,9 +13032,6 @@
         "slash": "^3.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0"
-    },
     "delegates": {
       "version": "1.0.0"
     },
@@ -13654,13 +13082,6 @@
     },
     "duplexer": {
       "version": "0.1.2"
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "electron-to-chromium": {
       "version": "1.4.129",
@@ -14245,9 +13666,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.2"
-    },
     "external-editor": {
       "version": "3.1.0",
       "requires": {
@@ -14256,11 +13674,9 @@
         "tmp": "^0.0.33"
       }
     },
-    "extsprintf": {
-      "version": "1.3.0"
-    },
     "fast-deep-equal": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -14281,7 +13697,8 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -14345,17 +13762,6 @@
     "flatted": {
       "version": "3.2.5",
       "dev": true
-    },
-    "forever-agent": {
-      "version": "0.6.1"
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
     },
     "fs-extra": {
       "version": "10.1.0",
@@ -14500,12 +13906,6 @@
         "get-intrinsic": "^1.1.1"
       }
     },
-    "getpass": {
-      "version": "0.1.7",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "git-raw-commits": {
       "version": "2.0.11",
       "requires": {
@@ -14617,16 +14017,6 @@
         "wordwrap": "^1.0.0"
       }
     },
-    "har-schema": {
-      "version": "2.0.0"
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
     "hard-rejection": {
       "version": "2.1.0"
     },
@@ -14677,14 +14067,6 @@
         "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -14796,6 +14178,12 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5"
@@ -14958,9 +14346,6 @@
     },
     "isobject": {
       "version": "3.0.1"
-    },
-    "isstream": {
-      "version": "0.1.2"
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -15736,9 +15121,6 @@
         "argparse": "^2.0.1"
       }
     },
-    "jsbn": {
-      "version": "0.1.1"
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -15751,11 +15133,9 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1"
     },
-    "json-schema": {
-      "version": "0.4.0"
-    },
     "json-schema-traverse": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -15790,15 +15170,6 @@
         "through": ">=2.2.7 <3"
       }
     },
-    "jsprim": {
-      "version": "1.4.2",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      }
-    },
     "kind-of": {
       "version": "6.0.3"
     },
@@ -15807,6 +15178,15 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
     },
     "leven": {
       "version": "3.1.0",
@@ -16098,15 +15478,6 @@
         "picomatch": "^2.2.3"
       }
     },
-    "mime-db": {
-      "version": "1.51.0"
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "requires": {
-        "mime-db": "1.51.0"
-      }
-    },
     "mimic-fn": {
       "version": "2.1.0"
     },
@@ -16318,179 +15689,6 @@
       "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
       "requires": {
         "semver": "^7.1.1"
-      }
-    },
-    "npm-lifecycle": {
-      "version": "3.1.5",
-      "requires": {
-        "byline": "^5.0.0",
-        "graceful-fs": "^4.1.15",
-        "node-gyp": "^5.0.2",
-        "resolve-from": "^4.0.0",
-        "slide": "^1.1.6",
-        "uid-number": "0.0.6",
-        "umask": "^1.1.0",
-        "which": "^1.3.1"
-      },
-      "dependencies": {
-        "aproba": {
-          "version": "1.2.0"
-        },
-        "are-we-there-yet": {
-          "version": "1.1.7",
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "chownr": {
-          "version": "1.1.4"
-        },
-        "fs-minipass": {
-          "version": "1.2.7",
-          "requires": {
-            "minipass": "^2.6.0"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "minipass": {
-          "version": "2.9.0",
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.3.3",
-          "requires": {
-            "minipass": "^2.9.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "node-gyp": {
-          "version": "5.1.1",
-          "requires": {
-            "env-paths": "^2.2.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.0",
-            "rimraf": "^2.6.3",
-            "semver": "^5.7.1",
-            "tar": "^4.4.12",
-            "which": "^1.3.1"
-          }
-        },
-        "nopt": {
-          "version": "4.0.3",
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2"
-            }
-          }
-        },
-        "resolve-from": {
-          "version": "4.0.0"
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1"
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2"
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "tar": {
-          "version": "4.4.19",
-          "requires": {
-            "chownr": "^1.1.4",
-            "fs-minipass": "^1.2.7",
-            "minipass": "^2.9.0",
-            "minizlib": "^1.3.3",
-            "mkdirp": "^0.5.5",
-            "safe-buffer": "^5.2.1",
-            "yallist": "^3.1.1"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1"
-        }
       }
     },
     "npm-normalize-package-bin": {
@@ -16706,13 +15904,10 @@
       }
     },
     "number-is-nan": {
-      "version": "1.0.1"
-    },
-    "oauth-sign": {
-      "version": "0.9.0"
-    },
-    "object-assign": {
-      "version": "4.1.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.0"
@@ -16789,18 +15984,17 @@
     "os": {
       "version": "0.1.2"
     },
-    "os-homedir": {
-      "version": "1.0.2"
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2"
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
     },
     "p-finally": {
       "version": "1.0.0"
@@ -16946,9 +16140,6 @@
     "path-type": {
       "version": "4.0.0"
     },
-    "performance-now": {
-      "version": "2.1.0"
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -17065,9 +16256,6 @@
     },
     "protocols": {
       "version": "1.4.8"
-    },
-    "psl": {
-      "version": "1.8.0"
     },
     "punycode": {
       "version": "2.1.1"
@@ -17254,36 +16442,6 @@
       "version": "3.2.0",
       "dev": true
     },
-    "request": {
-      "version": "2.88.2",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.3"
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1"
     },
@@ -17402,9 +16560,6 @@
     "slash": {
       "version": "3.0.0"
     },
-    "slide": {
-      "version": "1.1.6"
-    },
     "smart-buffer": {
       "version": "4.2.0"
     },
@@ -17487,20 +16642,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.17.0",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "ssri": {
       "version": "8.0.1",
@@ -17598,12 +16739,18 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
         }
       }
     },
@@ -17651,124 +16798,100 @@
       "version": "1.0.0"
     },
     "tacks": {
-      "version": "1.3.0",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/tacks/-/tacks-1.2.6.tgz",
+      "integrity": "sha1-BL9htjbT0KkcyFP+W1w6ulUt1F0=",
       "dev": true,
       "requires": {
-        "@iarna/cli": "^2.0.0",
+        "graceful-fs": "^4.1.2",
         "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.2"
+        "rimraf": "^2.5.1",
+        "yargs": "^3.32.0"
       },
       "dependencies": {
-        "@iarna/cli": {
-          "version": "2.0.0",
-          "bundled": true,
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "signal-exit": "^3.0.2"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
-        "balanced-match": {
+        "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
+            "number-is-nan": "^1.0.0"
           }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.6"
           }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
           }
         },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
           "dev": true
         },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
         }
       }
     },
@@ -17884,13 +17007,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tr46": {
       "version": "3.0.0",
       "requires": {
@@ -17970,15 +17086,6 @@
         }
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5"
-    },
     "type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -18007,12 +17114,6 @@
     "uglify-js": {
       "version": "3.15.0",
       "optional": true
-    },
-    "uid-number": {
-      "version": "0.0.6"
-    },
-    "umask": {
-      "version": "1.1.0"
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -18054,6 +17155,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -18105,19 +17207,6 @@
         "builtins": "^5.0.0"
       }
     },
-    "verror": {
-      "version": "1.10.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "dependencies": {
-        "core-util-is": {
-          "version": "1.0.2"
-        }
-      }
-    },
     "walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -18165,6 +17254,12 @@
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "normalize-path": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
-    "tacks": "^1.3.0",
+    "tacks": "^1.2.6",
     "tempy": "^1.0.1",
     "ts-jest": "^28.0.2",
     "tsm": "^2.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "npm": ">=8.0.0"
   },
   "dependencies": {
+    "@npmcli/run-script": "^3.0.2",
     "@octokit/plugin-enterprise-rest": "^6.0.1",
     "@octokit/rest": "^18.12.0",
     "async": "^3.2.3",
@@ -55,7 +56,6 @@
     "load-json-file": "^6.2.0",
     "minimatch": "^5.1.0",
     "node-fetch": "^2.6.7",
-    "npm-lifecycle": "^3.1.5",
     "npm-package-arg": "^9.0.2",
     "npm-packlist": "^5.0.4",
     "npm-registry-fetch": "^13.1.1",

--- a/packages/core/src/utils/__tests__/run-lifecycle.spec.ts
+++ b/packages/core/src/utils/__tests__/run-lifecycle.spec.ts
@@ -10,6 +10,10 @@ const { runLifecycle, createRunner } = require("../run-lifecycle");
 describe("runLifecycle()", () => {
   const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => { });
 
+  beforeEach(() => {
+    log.level = 'silent';
+  });
+
   it("skips packages without scripts", async () => {
     const pkg = {
       name: "no-scripts",
@@ -67,6 +71,29 @@ describe("runLifecycle()", () => {
         args: [],
       })
     );
+  });
+
+  it("calls npm-lifecycle with prepared arguments and expect print banner be called and show a console log of the ran script", async () => {
+    log.level = 'info';
+    const pkg = new Package(
+      {
+        name: "test-name",
+        version: "1.0.0-test",
+        scripts: {
+          preversion: "test",
+        },
+        engines: {
+          node: ">= 8.9.0",
+        },
+      },
+      "/test/location"
+    );
+    const stage = "preversion";
+    const opts = npmConf({ "custom-cli-flag": true });
+
+    await runLifecycle(pkg, stage, opts);
+
+    expect(consoleSpy).toHaveBeenCalledWith(`\n> test-name@1.0.0-test preversion /test/location\n> test\n`);
   });
 
   it("passes through the value for script-shell from npm config", async () => {

--- a/packages/core/src/utils/defaults.ts
+++ b/packages/core/src/utils/defaults.ts
@@ -146,7 +146,7 @@ Object.defineProperty(exports, 'defaults', {
       'save-prefix': '^',
       'save-prod': false,
       scope: '',
-      'script-shell': null,
+      'script-shell': undefined,
       'scripts-prepend-node-path': 'warn-only',
       searchopts: '',
       searchexclude: null,

--- a/packages/core/src/utils/run-lifecycle.ts
+++ b/packages/core/src/utils/run-lifecycle.ts
@@ -1,5 +1,5 @@
 import log from 'npmlog';
-import runScript from 'npm-lifecycle';
+import runScript from '@npmcli/run-script';
 
 import { npmConf } from '../utils/npm-conf';
 import { LifecycleConfig } from '../models';
@@ -10,16 +10,25 @@ import { Package } from '../package';
  * @param {LifecycleConfig} obj
  * @returns {LifecycleConfig}
  */
-function flattenOptions(obj: any) {
+function flattenOptions(obj: LifecycleConfig) {
   return {
     ignorePrepublish: obj['ignore-prepublish'],
     ignoreScripts: obj['ignore-scripts'],
     nodeOptions: obj['node-options'],
     scriptShell: obj['script-shell'],
     scriptsPrependNodePath: obj['scripts-prepend-node-path'],
-    unsafePerm: obj['unsafe-perm'],
+    // unsafePerm: obj['unsafe-perm'],
     ...obj,
   };
+}
+
+/**
+ * Adapted from https://github.com/npm/run-script/blob/bb5156063ea3a7e167a6d5435847d9389146ec89/lib/run-script-pkg.js#L9
+ * Modified to add back "path" and make it behave more like "npm-lifecycle"
+ */
+function printCommandBanner(id: string, event: string, cmd: string, path: string) {
+  // eslint-disable-next-line no-console
+  return console.log(`\n> ${id ? `${id} ` : ''}${event} ${path}\n> ${cmd.trim().replace(/\n/g, '\n> ')}\n`);
 }
 
 /**
@@ -42,7 +51,8 @@ export function runLifecycle(pkg: Package, stage: string, options: LifecycleConf
     ...flattenOptions(options),
   };
   const dir = pkg.location;
-  const config = {};
+  const id = `${pkg.name}@${pkg.version}`;
+  const config: LifecycleConfig = {};
 
   if (opts.ignoreScripts) {
     opts.log.verbose('lifecycle', '%j ignored in %j', stage, pkg.name);
@@ -79,39 +89,54 @@ export function runLifecycle(pkg: Package, stage: string, options: LifecycleConf
     pkg = pkg.toJSON() as Package;
   }
 
-  // TODO: remove pkg._id when npm-lifecycle no longer relies on it
-  pkg._id = `${pkg.name}@${pkg.version}`; // eslint-disable-line
+  // _id is needed by @npmcli/run-script
+  // eslint-disable-next-line no-underscore-dangle
+  pkg._id = id;
 
   opts.log.silly('lifecycle', '%j starting in %j', stage, pkg.name);
 
-  return runScript(pkg, stage, dir, {
-    config,
-    dir,
-    failOk: false,
-    log: opts.log,
-    // bring along camelCased aliases
-    nodeOptions: opts.nodeOptions,
-    scriptShell: opts.scriptShell,
-    scriptsPrependNodePath: opts.scriptsPrependNodePath,
-    unsafePerm: opts.unsafePerm,
+  // info log here to reproduce previous behavior when this was powered by "npm-lifecycle"
+  opts.log.info('lifecycle', `${id}~${stage}: ${id}`);
+
+  /**
+   * In order to match the previous behavior of 'npm-lifecycle', we have to disable the writing
+   * to the parent process and print the command banner ourself.
+   */
+  const stdio = 'pipe';
+  if (log.level !== 'silent') {
+    printCommandBanner(id, stage, pkg.scripts[stage], dir);
+  }
+
+  return runScript({
+    event: stage,
+    path: dir,
+    pkg,
+    args: [],
+    stdio,
+    banner: false,
+    scriptShell: config.scriptShell,
   }).then(
-    () => {
+    ({ stdout }) => {
+      /**
+       * This adjustment is based on trying to match the existing integration test outputs when migrating
+       * from 'npm-lifecycle' to '@npmcli/run-script'.
+       */
+      // eslint-disable-next-line no-console
+      console.log(stdout.toString().trimEnd());
+
       opts.log.silly('lifecycle', '%j finished in %j', stage, pkg.name);
     },
-    (err: any) => {
+    (err) => {
       // propagate the exit code
-      const exitCode = err.errno || 1;
+      const exitCode = err.code || 1;
 
       // error logging has already occurred on stderr, but we need to stop the chain
       log.error('lifecycle', '%j errored in %j, exiting %d', stage, pkg.name, exitCode);
-
       // ensure clean logging, avoiding spurious log dump
       err.name = 'ValidationError';
-
       // our yargs.fail() handler expects a numeric .exitCode, not .errno
       err.exitCode = exitCode;
       process.exitCode = exitCode;
-
       // stop the chain
       throw err;
     }


### PR DESCRIPTION
## Description
Fixes #60 by following PR [#3134](https://github.com/lerna/lerna/pull/3134) it follows the same code change as original Lerna PR, as they quoted:
> We are classing this as a breaking change because the APIs of npm-lifecycle and @npmcli/run-script are significantly different, despite @npmcli/run-script being the official successor to npm-lifecycle.

> We have successfully made the integration test suite we inherited pass with this change, but there may potentially be aspects related to it which are not covered by the tests and are breaking. If you encounter any issues you believe are related to this change please open a new issue with a dedicated reproduction for us to look into!

Side note, I will not do a `major` bump for this, I decided to go with a simple `minor` (feature) bump
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
added same unit tests as Lerna

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
