### PR TITLE
fix(version): improve default git publish message, closes #185

### DIFF
--- a/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
@@ -188,7 +188,7 @@ index SHA..SHA 100644
 `;
 
 exports[`VersionCommand independent mode versions changed packages: commit 1`] = `
-"Publish
+"chore: Publish new release
 
  - package-1@1.0.1
  - package-2@2.1.0

--- a/packages/version/src/__tests__/__snapshots__/version-conventional-commits.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-conventional-commits.spec.ts.snap
@@ -39,7 +39,7 @@ packages/package-5/package.json"
 `;
 
 exports[`--conventional-commits independent should graduate prerelease version bumps and generate CHANGELOG 1`] = `
-"Publish
+"chore: Publish new release
 
  - package-1@1.0.1
  - package-2@2.1.0
@@ -62,7 +62,7 @@ packages/package-5/package.json"
 `;
 
 exports[`--conventional-commits independent should guess prerelease version bumps and generate CHANGELOG 1`] = `
-"Publish
+"chore: Publish new release
 
  - package-1@1.0.1-alpha.0
  - package-2@2.1.0-alpha.0
@@ -85,7 +85,7 @@ packages/package-5/package.json"
 `;
 
 exports[`--conventional-commits independent should use conventional-commits utility to guess version bump and generate CHANGELOG 1`] = `
-"Publish
+"chore: Publish new release
 
  - package-1@1.0.1
  - package-2@2.1.0

--- a/packages/version/src/__tests__/version-bump-prerelease.spec.ts
+++ b/packages/version/src/__tests__/version-bump-prerelease.spec.ts
@@ -180,7 +180,7 @@ test("independent version prerelease does not bump on every unrelated change", a
 
   const first = await getCommitMessage(cwd);
   expect(first).toMatchInlineSnapshot(`
-Publish
+chore: Publish new release
 
  - pkg-a@1.0.1
  - pkg-b@1.0.0-bumps.2
@@ -195,7 +195,7 @@ Publish
 
   const second = await getCommitMessage(cwd);
   expect(second).toMatchInlineSnapshot(`
-  Publish
+  chore: Publish new release
 
    - pkg-a@1.0.2
   `);
@@ -242,7 +242,7 @@ test("independent version prerelease respects --no-private", async () => {
 
   const changedFiles = await showCommit(cwd, "--name-only");
   expect(changedFiles).toMatchInlineSnapshot(`
-    Publish
+    chore: Publish new release
 
      - pkg-1@1.0.1-alpha.0
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -717,7 +717,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
   async gitCommitAndTagVersionForUpdates() {
     const tags = this.packagesToVersion.map((pkg) => `${pkg.name}@${this.updatesVersions?.get(pkg.name)}`);
-    const subject = this.options.message || 'Publish';
+    const subject = this.options.message || 'chore: Publish new release';
     const message = tags.reduce((msg, tag) => `${msg}${os.EOL} - ${tag}`, `${subject}${os.EOL}`);
 
     await gitCommit(message, this.gitOpts, this.execOpts, this.options.gitDryRun);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
improve default git publish message (when `message` isn't provided), closes #185

the previous default message was `"Publish"` and the new message is now `"chore: Publish new release"` to make it more aligned to conventional commits

## Motivation and Context
improve default message as requested in issue #185

## How Has This Been Tested?
modify current unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
