### PR TITLE
fix(version): add better msg for missing `npmClient` with sync lock, fixes #214

### DIFF
--- a/packages/version/src/__tests__/update-lockfile-version.spec.js
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.js
@@ -149,7 +149,9 @@ describe('run install lockfile-only', () => {
 
       expect(logSpy).toHaveBeenCalledWith(
         'lock',
-        expect.stringContaining('we could not sync or locate "pnpm-lock.yaml" from path')
+        expect.stringContaining(
+          `we could not sync or locate "pnpm-lock.yaml" by using "pnpm" client at location ${cwd}`
+        )
       );
       expect(lockFileOutput).toBe(undefined);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
provide better error message when trying to sync a different lock file than expected when using a different client other than npm, fixes #214

## Motivation and Context
issue #214 was open for a potential problem but it turns out that `npmClient` was missing and the error message was not clear and concise enough to help the user, this PR should make it clearer

![image](https://user-images.githubusercontent.com/643976/172772181-d5b7dc8e-54b9-49b1-b29c-6d37f97a212c.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
