### PR TITLE
fix(version): remove `workspace:` prefix on external deps, fixes #200

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,5 +76,7 @@ jobs:
         run: pnpm jest:ci
 
       - name: Upload Jest coverage to Codecov
-        if: "!contains(github.event.head_commit.message, 'chore(release)')"
+        if: |
+          !contains(github.event.head_commit.message, 'chore(release)') &&
+          contains(matrix.node, 18)
         run: bash <(curl -s https://codecov.io/bash)

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import loadJsonFile from 'load-json-file';
 import npa from 'npm-package-arg';
+import npmlog from 'npmlog';
 import writePkg from 'write-pkg';
 
 jest.mock('load-json-file');
@@ -310,24 +311,30 @@ describe('Package', () => {
     });
   });
 
-  describe(".updateLocalDependency()", () => {
+  describe('.updateLocalDependency()', () => {
     describe('gitCommittish', () => {
       it("works with a resolved 'gitCommittish'", () => {
         const pkg = factory({
           dependencies: {
-            a: "^1.0.0",
-            b: "^1.0.0",
+            a: '^1.0.0',
+            b: '^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
         resolved.type = undefined as any;
         resolved.registry = undefined as any;
         resolved.gitCommittish = '1.2.3';
-        resolved.hosted = { committish: '', domain: 'localhost', noGitPlus: false, noCommittish: false, saveSpec: true } as any;
+        resolved.hosted = {
+          committish: '',
+          domain: 'localhost',
+          noGitPlus: false,
+          noCommittish: false,
+          saveSpec: true,
+        } as any;
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect((resolved.hosted as any).committish).toBe('2.0.0');
       });
@@ -337,40 +344,46 @@ describe('Package', () => {
       it("works with a resolved 'gitRange'", () => {
         const pkg = factory({
           dependencies: {
-            a: "^1.0.0",
-            b: "^1.0.0",
+            a: '^1.0.0',
+            b: '^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
         resolved.type = undefined as any;
         resolved.registry = undefined as any;
         resolved.gitRange = '1.2.3';
-        resolved.hosted = { committish: '', domain: 'localhost', noGitPlus: false, noCommittish: false, saveSpec: true } as any;
+        resolved.hosted = {
+          committish: '',
+          domain: 'localhost',
+          noGitPlus: false,
+          noCommittish: false,
+          saveSpec: true,
+        } as any;
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect((resolved.hosted as any).committish).toBe('semver:^2.0.0');
       });
     });
 
     describe('Version with `workspace:` protocol', () => {
-      it("works with `workspace:` protocol range", () => {
+      it('works with `workspace:` protocol range', () => {
         const pkg = factory({
           dependencies: {
-            a: "workspace:^1.0.0",
-            b: "workspace:>=1.0.0",
-            c: "workspace:./foo",
-            d: "file:./foo",
-            e: "^1.0.0",
+            a: 'workspace:^1.0.0',
+            b: 'workspace:>=1.0.0',
+            c: 'workspace:./foo',
+            d: 'file:./foo',
+            e: '^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -385,19 +398,19 @@ describe('Package', () => {
         `);
       });
 
-      it("works with star workspace input target `workspace:*` and will keep same output target", () => {
+      it('works with star workspace input target `workspace:*` and will keep same output target', () => {
         const pkg = factory({
           devDependencies: {
-            a: "workspace:*",
-            b: "workspace:^1.0.0",
+            a: 'workspace:*',
+            b: 'workspace:^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
         resolved.workspaceTarget = 'workspace:*';
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -409,19 +422,19 @@ describe('Package', () => {
         `);
       });
 
-      it("works with caret workspace input target `workspace:^` and will keep same output target", () => {
+      it('works with caret workspace input target `workspace:^` and will keep same output target', () => {
         const pkg = factory({
           optionalDependencies: {
-            a: "workspace:^",
-            b: "workspace:^1.0.0",
+            a: 'workspace:^',
+            b: 'workspace:^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
         resolved.workspaceTarget = 'workspace:^';
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -433,19 +446,19 @@ describe('Package', () => {
         `);
       });
 
-      it("works with tilde workspace input target `workspace:~` and will keep same output target", () => {
+      it('works with tilde workspace input target `workspace:~` and will keep same output target', () => {
         const pkg = factory({
           dependencies: {
-            a: "workspace:~",
-            b: "workspace:^1.0.0",
+            a: 'workspace:~',
+            b: 'workspace:^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
         resolved.workspaceTarget = 'workspace:~';
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -457,19 +470,19 @@ describe('Package', () => {
         `);
       });
 
-      it("works with workspace fixed version input target `workspace:X.Y.Z` and will keep same output target", () => {
+      it('works with workspace fixed version input target `workspace:X.Y.Z` and will keep same output target', () => {
         const pkg = factory({
           dependencies: {
-            a: "workspace:1.0.0",
-            b: "workspace:^1.0.0",
+            a: 'workspace:1.0.0',
+            b: 'workspace:^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
         resolved.workspaceTarget = 'workspace:1.0.0';
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -481,19 +494,19 @@ describe('Package', () => {
         `);
       });
 
-      it("works with operator symbols like >= and workspace input target `workspace:>=X.Y.Z` and will be bumped", () => {
+      it('works with operator symbols like >= and workspace input target `workspace:>=X.Y.Z` and will be bumped', () => {
         const pkg = factory({
           dependencies: {
-            a: "workspace:>=1.2.0",
-            b: "workspace:^1.0.0",
+            a: 'workspace:>=1.2.0',
+            b: 'workspace:^1.0.0',
           },
         });
 
-        const resolved: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.explicitWorkspace = true;
         resolved.workspaceTarget = 'workspace:>=1.2.0';
 
-        pkg.updateLocalDependency(resolved, "2.0.0", "^");
+        pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -507,23 +520,23 @@ describe('Package', () => {
     });
 
     describe('Publish with `workspace:` protocol', () => {
-      it("should transform `workspace:*` protocol to exact range when calling a publish", () => {
+      it('should transform `workspace:*` protocol to exact range when calling a publish', () => {
         const pkg = factory({
           dependencies: {
-            a: "workspace:*",
-            b: "workspace:^1.0.0",
+            a: 'workspace:*',
+            b: 'workspace:^1.0.0',
           },
         });
 
-        const resolvedA: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolvedA.explicitWorkspace = true;
         resolvedA.workspaceTarget = 'workspace:*';
-        const resolvedB: NpaResolveResult = npa.resolve("b", "^1.0.0", ".");
+        const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.explicitWorkspace = true;
         resolvedB.workspaceTarget = 'workspace:^1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, "2.0.0", "^", true, 'publish');
-        pkg.updateLocalDependency(resolvedB, "1.1.0", "^", true, 'publish');
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, 'publish');
+        pkg.updateLocalDependency(resolvedB, '1.1.0', '^', true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -535,23 +548,23 @@ describe('Package', () => {
         `);
       });
 
-      it("should transform `workspace:^` protocol to semver range when calling a publish", () => {
+      it('should transform `workspace:^` protocol to semver range when calling a publish', () => {
         const pkg = factory({
           dependencies: {
-            a: "workspace:^",
-            b: "workspace:~1.0.0",
+            a: 'workspace:^',
+            b: 'workspace:~1.0.0',
           },
         });
 
-        const resolvedA: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolvedA.explicitWorkspace = true;
         resolvedA.workspaceTarget = 'workspace:^';
-        const resolvedB: NpaResolveResult = npa.resolve("b", "^1.0.0", ".");
+        const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.explicitWorkspace = true;
         resolvedB.workspaceTarget = 'workspace:~1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, "2.0.0", "^", true, 'publish');
-        pkg.updateLocalDependency(resolvedB, "1.1.0", "~", true, 'publish');
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, 'publish');
+        pkg.updateLocalDependency(resolvedB, '1.1.0', '~', true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
@@ -563,29 +576,66 @@ describe('Package', () => {
         `);
       });
 
-      it("should transform `workspace:~` protocol to semver range when calling a publish", () => {
+      it('should transform `workspace:~` protocol to semver range when calling a publish', () => {
         const pkg = factory({
           dependencies: {
-            a: "workspace:~",
-            b: "workspace:^1.0.0",
+            a: 'workspace:~',
+            b: 'workspace:^1.0.0',
           },
         });
 
-        const resolvedA: NpaResolveResult = npa.resolve("a", "^1.0.0", ".");
+        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolvedA.explicitWorkspace = true;
         resolvedA.workspaceTarget = 'workspace:~';
-        const resolvedB: NpaResolveResult = npa.resolve("b", "^1.0.0", ".");
+        const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.explicitWorkspace = true;
         resolvedB.workspaceTarget = 'workspace:^1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, "2.0.0", "^", true, 'publish');
-        pkg.updateLocalDependency(resolvedB, "1.1.0", "^", true, 'publish');
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, 'publish');
+        pkg.updateLocalDependency(resolvedB, '1.1.0', '^', true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           Object {
             "dependencies": Object {
               "a": "~2.0.0",
               "b": "^1.1.0",
+            },
+          }
+        `);
+      });
+
+      it('should remove `workspace:` prefix on external dependencies without any version bump applied', () => {
+        const logErrorSpy = jest.spyOn(npmlog, 'error');
+        const pkg = factory({
+          dependencies: {
+            a: 'workspace:*',
+            b: 'workspace:^2.2.4',
+          },
+        });
+
+        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
+        resolvedA.explicitWorkspace = true;
+        resolvedA.workspaceTarget = 'workspace:*';
+        resolvedA.fetchSpec = 'latest';
+        const resolvedB: NpaResolveResult = npa.resolve('b', '^2.2.4', '.');
+        resolvedB.explicitWorkspace = true;
+        resolvedB.workspaceTarget = 'workspace:^2.2.4';
+
+        pkg.removeDependencyWorkspaceProtocolPrefix('package-1', resolvedA);
+        pkg.removeDependencyWorkspaceProtocolPrefix('package-2', resolvedB);
+
+        expect(logErrorSpy).toHaveBeenCalledWith(
+          'publish',
+          [
+            `Your package named "package-1" has external dependencies not handled by Lerna-Lite and without workspace version suffix, `,
+            `we recommend using defined versions with workspace protocol. Your dependency is currently being published with "a": "latest".`,
+          ].join('')
+        );
+        expect(pkg.toJSON()).toMatchInlineSnapshot(`
+          Object {
+            "dependencies": Object {
+              "a": "latest",
+              "b": "^2.2.4",
             },
           }
         `);

--- a/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-6/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-6/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "package-1": "workspace:>=1.0.0",
-    "tiny-tarball": "^1.0.0"
+    "tiny-registry": "workspace:*",
+    "tiny-tarball": "workspace:^2.3.4"
   }
 }

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.test.js
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.test.js
@@ -1,19 +1,27 @@
-"use strict";
+'use strict';
 
 // FIXME: better mock for version command
-jest.mock("../../../version/dist/lib/git-push", () => jest.requireActual("../../../version/src/lib/__mocks__/git-push"));
-jest.mock("../../../version/dist/lib/is-anything-committed", () => jest.requireActual("../../../version/src/lib/__mocks__/is-anything-committed"));
-jest.mock("../../../version/dist/lib/is-behind-upstream", () => jest.requireActual("../../../version/src/lib/__mocks__/is-behind-upstream"));
-jest.mock("../../../version/dist/lib/remote-branch-exists", () => jest.requireActual("../../../version/src/lib/__mocks__/remote-branch-exists"));
+jest.mock('../../../version/dist/lib/git-push', () =>
+  jest.requireActual('../../../version/src/lib/__mocks__/git-push')
+);
+jest.mock('../../../version/dist/lib/is-anything-committed', () =>
+  jest.requireActual('../../../version/src/lib/__mocks__/is-anything-committed')
+);
+jest.mock('../../../version/dist/lib/is-behind-upstream', () =>
+  jest.requireActual('../../../version/src/lib/__mocks__/is-behind-upstream')
+);
+jest.mock('../../../version/dist/lib/remote-branch-exists', () =>
+  jest.requireActual('../../../version/src/lib/__mocks__/remote-branch-exists')
+);
 
 // mocked modules of @lerna-lite/core
 jest.mock('@lerna-lite/core', () => ({
   ...jest.requireActual('@lerna-lite/core'), // return the other real methods, below we'll mock only 2 of the methods
   collectUpdates: jest.requireActual('../../../core/src/__mocks__/collect-updates').collectUpdates,
   throwIfUncommitted: jest.requireActual('../../../core/src/__mocks__/check-working-tree').throwIfUncommitted,
-  getOneTimePassword: () => Promise.resolve("654321"),
+  getOneTimePassword: () => Promise.resolve('654321'),
   logOutput: jest.requireActual('../../../core/src/__mocks__/output').logOutput,
-  promptConfirmation: jest.requireActual("../../../core/src/__mocks__/prompt").promptConfirmation,
+  promptConfirmation: jest.requireActual('../../../core/src/__mocks__/prompt').promptConfirmation,
   promptSelectOne: jest.requireActual('../../../core/src/__mocks__/prompt').promptSelectOne,
   promptTextInput: jest.requireActual('../../../core/src/__mocks__/prompt').promptTextInput,
 }));
@@ -22,28 +30,34 @@ jest.mock('@lerna-lite/core', () => ({
 jest.mock('@lerna-lite/publish', () => jest.requireActual('../publish-command'));
 
 // local modules _must_ be explicitly mocked
-jest.mock("../lib/get-packages-without-license", () => jest.requireActual('../lib/__mocks__/get-packages-without-license'));
-jest.mock("../lib/verify-npm-package-access", () => jest.requireActual('../lib/__mocks__/verify-npm-package-access'));
-jest.mock("../lib/get-npm-username", () => jest.requireActual('../lib/__mocks__/get-npm-username'));
-jest.mock("../lib/get-two-factor-auth-required", () => jest.requireActual('../lib/__mocks__/get-two-factor-auth-required'));
-jest.mock("../lib/pack-directory", () => jest.requireActual('../lib/__mocks__/pack-directory'));
-jest.mock("../lib/npm-publish", () => jest.requireActual('../lib/__mocks__/npm-publish'));
+jest.mock('../lib/get-packages-without-license', () =>
+  jest.requireActual('../lib/__mocks__/get-packages-without-license')
+);
+jest.mock('../lib/verify-npm-package-access', () =>
+  jest.requireActual('../lib/__mocks__/verify-npm-package-access')
+);
+jest.mock('../lib/get-npm-username', () => jest.requireActual('../lib/__mocks__/get-npm-username'));
+jest.mock('../lib/get-two-factor-auth-required', () =>
+  jest.requireActual('../lib/__mocks__/get-two-factor-auth-required')
+);
+jest.mock('../lib/pack-directory', () => jest.requireActual('../lib/__mocks__/pack-directory'));
+jest.mock('../lib/npm-publish', () => jest.requireActual('../lib/__mocks__/npm-publish'));
 
-const fs = require("fs-extra");
-const path = require("path");
+const fs = require('fs-extra');
+const path = require('path');
+const npmlog = require('npmlog');
 
 // mocked modules
-const writePkg = require("write-pkg");
+const writePkg = require('write-pkg');
 
 // helpers
-const initFixture = require("@lerna-test/init-fixture")(__dirname);
-const { gitAdd } = require("@lerna-test/git-add");
-const { gitTag } = require("@lerna-test/git-tag");
-const { gitCommit } = require("@lerna-test/git-commit");
+const initFixture = require('@lerna-test/init-fixture')(__dirname);
+const { gitAdd } = require('@lerna-test/git-add');
+const { gitTag } = require('@lerna-test/git-tag');
+const { gitCommit } = require('@lerna-test/git-commit');
 
 // test command
-const { PublishCommand } = require("../index");
-const lernaPublish = require("@lerna-test/command-runner")(require("../../../cli/src/cli-commands/cli-publish-commands"));
+const { PublishCommand } = require('../index');
 
 const yargParser = require('yargs-parser');
 
@@ -56,170 +70,192 @@ const createArgv = (cwd, ...args) => {
 };
 
 describe("workspace protocol 'workspace:' specifiers", () => {
-  const setupChanges = async (cwd, pkgRoot = "packages") => {
-    await fs.outputFile(path.join(cwd, `${pkgRoot}/package-1/hello.js`), "world");
-    await gitAdd(cwd, ".");
-    await gitCommit(cwd, "setup");
+  const setupChanges = async (cwd, pkgRoot = 'packages') => {
+    await fs.outputFile(path.join(cwd, `${pkgRoot}/package-1/hello.js`), 'world');
+    await gitAdd(cwd, '.');
+    await gitCommit(cwd, 'setup');
   };
 
   describe('workspace-strict-match disabled', () => {
-    it("overwrites workspace protocol with local patch bump version before npm publish but after git commit", async () => {
-      const cwd = await initFixture("workspace-protocol-specs");
+    it('overwrites workspace protocol with local patch bump version before npm publish but after git commit', async () => {
+      const cwd = await initFixture('workspace-protocol-specs');
 
-      await gitTag(cwd, "v1.0.0");
+      await gitTag(cwd, 'v1.0.0');
       await setupChanges(cwd);
-      await new PublishCommand(createArgv(cwd, "--bump", "patch", "--yes", "--no-workspace-strict-match"));
+      await new PublishCommand(createArgv(cwd, '--bump', 'patch', '--yes', '--no-workspace-strict-match'));
 
       expect(writePkg.updatedVersions()).toEqual({
-        "package-1": "1.0.1",
-        "package-2": "1.0.1",
-        "package-3": "1.0.1",
-        "package-4": "1.0.1",
-        "package-5": "1.0.1",
-        "package-6": "1.0.1",
-        "package-7": "1.0.1",
+        'package-1': '1.0.1',
+        'package-2': '1.0.1',
+        'package-3': '1.0.1',
+        'package-4': '1.0.1',
+        'package-5': '1.0.1',
+        'package-6': '1.0.1',
+        'package-7': '1.0.1',
       });
 
       // notably missing is package-1, which has no relative file: dependencies
-      expect(writePkg.updatedManifest("package-2").dependencies).toMatchObject({
-        "package-1": "^1.0.1", // workspace:*
+      expect(writePkg.updatedManifest('package-2').dependencies).toMatchObject({
+        'package-1': '^1.0.1', // workspace:*
       });
-      expect(writePkg.updatedManifest("package-3").dependencies).toMatchObject({
-        "package-2": "^1.0.1", // workspace:^
+      expect(writePkg.updatedManifest('package-3').dependencies).toMatchObject({
+        'package-2': '^1.0.1', // workspace:^
       });
-      expect(writePkg.updatedManifest("package-4").optionalDependencies).toMatchObject({
-        "package-3": "^1.0.1", // workspace:~
+      expect(writePkg.updatedManifest('package-4').optionalDependencies).toMatchObject({
+        'package-3': '^1.0.1', // workspace:~
       });
-      expect(writePkg.updatedManifest("package-5").dependencies).toMatchObject({
+      expect(writePkg.updatedManifest('package-5').dependencies).toMatchObject({
         // all fixed versions are bumped when patch
-        "package-4": "^1.0.1", // workspace:^1.0.0
-        "package-6": "^1.0.1", // workspace:^1.0.0
+        'package-4': '^1.0.1', // workspace:^1.0.0
+        'package-6': '^1.0.1', // workspace:^1.0.0
       });
       // private packages do not need local version resolution
-      expect(writePkg.updatedManifest("package-7").dependencies).toMatchObject({
-        "package-1": "^1.0.1", // ^1.0.0
+      expect(writePkg.updatedManifest('package-7').dependencies).toMatchObject({
+        'package-1': '^1.0.1', // ^1.0.0
       });
     });
 
-    it("overwrites workspace protocol with local minor bump version before npm publish but after git commit", async () => {
-      const cwd = await initFixture("workspace-protocol-specs");
+    it('overwrites workspace protocol with local minor bump version before npm publish but after git commit', async () => {
+      const cwd = await initFixture('workspace-protocol-specs');
 
-      await gitTag(cwd, "v1.0.0");
+      await gitTag(cwd, 'v1.0.0');
       await setupChanges(cwd);
-      await new PublishCommand(createArgv(cwd, "--bump", "minor", "--yes", "--no-workspace-strict-match"));
+      await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--no-workspace-strict-match'));
 
       expect(writePkg.updatedVersions()).toEqual({
-        "package-1": "1.1.0",
-        "package-2": "1.1.0",
-        "package-3": "1.1.0",
-        "package-4": "1.1.0",
-        "package-5": "1.1.0",
-        "package-6": "1.1.0",
-        "package-7": "1.1.0",
+        'package-1': '1.1.0',
+        'package-2': '1.1.0',
+        'package-3': '1.1.0',
+        'package-4': '1.1.0',
+        'package-5': '1.1.0',
+        'package-6': '1.1.0',
+        'package-7': '1.1.0',
       });
 
       // notably missing is package-1, which has no relative file: dependencies
-      expect(writePkg.updatedManifest("package-2").dependencies).toMatchObject({
-        "package-1": "^1.1.0", // workspace:*
+      expect(writePkg.updatedManifest('package-2').dependencies).toMatchObject({
+        'package-1': '^1.1.0', // workspace:*
       });
-      expect(writePkg.updatedManifest("package-3").dependencies).toMatchObject({
-        "package-2": "^1.1.0", // workspace:^
+      expect(writePkg.updatedManifest('package-3').dependencies).toMatchObject({
+        'package-2': '^1.1.0', // workspace:^
       });
-      expect(writePkg.updatedManifest("package-4").optionalDependencies).toMatchObject({
-        "package-3": "^1.1.0", // workspace:~
+      expect(writePkg.updatedManifest('package-4').optionalDependencies).toMatchObject({
+        'package-3': '^1.1.0', // workspace:~
       });
-      expect(writePkg.updatedManifest("package-5").dependencies).toMatchObject({
+      expect(writePkg.updatedManifest('package-5').dependencies).toMatchObject({
         // all fixed versions are bumped when minor
-        "package-4": "^1.1.0", // workspace:^1.0.0
-        "package-6": "^1.1.0", // workspace:^1.0.0
+        'package-4': '^1.1.0', // workspace:^1.0.0
+        'package-6': '^1.1.0', // workspace:^1.0.0
       });
       // private packages do not need local version resolution
-      expect(writePkg.updatedManifest("package-7").dependencies).toMatchObject({
-        "package-1": "^1.1.0", // ^1.0.0
+      expect(writePkg.updatedManifest('package-7').dependencies).toMatchObject({
+        'package-1': '^1.1.0', // ^1.0.0
       });
     });
   });
 
   describe('workspace-strict-match enabled', () => {
-    it("overwrites workspace protocol with local minor bump version before npm publish but after git commit", async () => {
-      const cwd = await initFixture("workspace-protocol-specs");
+    it('overwrites workspace protocol with local minor bump version before npm publish but after git commit', async () => {
+      const cwd = await initFixture('workspace-protocol-specs');
 
-      await gitTag(cwd, "v1.0.0");
+      await gitTag(cwd, 'v1.0.0');
       await setupChanges(cwd);
-      await new PublishCommand(createArgv(cwd, "--bump", "minor", "--yes", "--workspace-strict-match"));
+      await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match'));
 
       expect(writePkg.updatedVersions()).toEqual({
-        "package-1": "1.1.0",
-        "package-2": "1.1.0",
-        "package-3": "1.1.0",
-        "package-4": "1.1.0",
-        "package-5": "1.1.0",
-        "package-6": "1.1.0",
-        "package-7": "1.1.0",
+        'package-1': '1.1.0',
+        'package-2': '1.1.0',
+        'package-3': '1.1.0',
+        'package-4': '1.1.0',
+        'package-5': '1.1.0',
+        'package-6': '1.1.0',
+        'package-7': '1.1.0',
       });
 
       // notably missing is package-1, which has no relative file: dependencies
-      expect(writePkg.updatedManifest("package-2").dependencies).toMatchObject({
-        "package-1": "1.1.0", // workspace:*
+      expect(writePkg.updatedManifest('package-2').dependencies).toMatchObject({
+        'package-1': '1.1.0', // workspace:*
       });
-      expect(writePkg.updatedManifest("package-3").dependencies).toMatchObject({
-        "package-2": "^1.1.0", // workspace:^
+      expect(writePkg.updatedManifest('package-3').dependencies).toMatchObject({
+        'package-2': '^1.1.0', // workspace:^
       });
-      expect(writePkg.updatedManifest("package-4").optionalDependencies).toMatchObject({
-        "package-3": "~1.1.0", // workspace:~
+      expect(writePkg.updatedManifest('package-4').optionalDependencies).toMatchObject({
+        'package-3': '~1.1.0', // workspace:~
       });
-      expect(writePkg.updatedManifest("package-5").dependencies).toMatchObject({
+      expect(writePkg.updatedManifest('package-5').dependencies).toMatchObject({
         // all fixed versions are bumped when minor
-        "package-4": "^1.1.0", // workspace:^1.0.0
-        "package-6": "~1.1.0", // workspace:~1.0.0
+        'package-4': '^1.1.0', // workspace:^1.0.0
+        'package-6': '~1.1.0', // workspace:~1.0.0
       });
-      expect(writePkg.updatedManifest("package-6").dependencies).toMatchObject({
-        "package-1": ">=1.1.0", // workspace:>=1.0.0
+      expect(writePkg.updatedManifest('package-6').dependencies).toMatchObject({
+        'package-1': '>=1.1.0', // workspace:>=1.0.0
       });
       // private packages do not need local version resolution
-      expect(writePkg.updatedManifest("package-7").dependencies).toMatchObject({
-        "package-1": "^1.1.0", // ^1.0.0
+      expect(writePkg.updatedManifest('package-7').dependencies).toMatchObject({
+        'package-1': '^1.1.0', // ^1.0.0
       });
     });
 
-    it("overwrites workspace protocol with local major bump version before npm publish but after git commit", async () => {
-      const cwd = await initFixture("workspace-protocol-specs");
+    it('overwrites workspace protocol with local major bump version before npm publish but after git commit', async () => {
+      const cwd = await initFixture('workspace-protocol-specs');
 
-      await gitTag(cwd, "v1.0.0");
+      await gitTag(cwd, 'v1.0.0');
       await setupChanges(cwd);
-      await new PublishCommand(createArgv(cwd, "--bump", "major", "--yes"));
+      await new PublishCommand(createArgv(cwd, '--bump', 'major', '--yes'));
 
       expect(writePkg.updatedVersions()).toEqual({
-        "package-1": "2.0.0",
-        "package-2": "2.0.0",
-        "package-3": "2.0.0",
-        "package-4": "2.0.0",
-        "package-5": "2.0.0",
-        "package-6": "2.0.0",
-        "package-7": "2.0.0",
+        'package-1': '2.0.0',
+        'package-2': '2.0.0',
+        'package-3': '2.0.0',
+        'package-4': '2.0.0',
+        'package-5': '2.0.0',
+        'package-6': '2.0.0',
+        'package-7': '2.0.0',
       });
 
       // notably missing is package-1, which has no relative file: dependencies
-      expect(writePkg.updatedManifest("package-2").dependencies).toMatchObject({
-        "package-1": "2.0.0", // workspace:*
+      expect(writePkg.updatedManifest('package-2').dependencies).toMatchObject({
+        'package-1': '2.0.0', // workspace:*
       });
-      expect(writePkg.updatedManifest("package-3").dependencies).toMatchObject({
-        "package-2": "^2.0.0", // workspace:^
+      expect(writePkg.updatedManifest('package-3').dependencies).toMatchObject({
+        'package-2': '^2.0.0', // workspace:^
       });
-      expect(writePkg.updatedManifest("package-4").optionalDependencies).toMatchObject({
-        "package-3": "~2.0.0", // workspace:~
+      expect(writePkg.updatedManifest('package-4').optionalDependencies).toMatchObject({
+        'package-3': '~2.0.0', // workspace:~
       });
-      expect(writePkg.updatedManifest("package-5").dependencies).toMatchObject({
+      expect(writePkg.updatedManifest('package-5').dependencies).toMatchObject({
         // all fixed versions are bumped when major
-        "package-4": "^2.0.0", // workspace:^1.0.0
-        "package-6": "~2.0.0", // workspace:~1.0.0
+        'package-4': '^2.0.0', // workspace:^1.0.0
+        'package-6': '~2.0.0', // workspace:~1.0.0
       });
-      expect(writePkg.updatedManifest("package-6").dependencies).toMatchObject({
-        "package-1": ">=2.0.0", // workspace:>=1.0.0
+      expect(writePkg.updatedManifest('package-6').dependencies).toMatchObject({
+        'package-1': '>=2.0.0', // workspace:>=1.0.0
       });
       // private packages do not need local version resolution
-      expect(writePkg.updatedManifest("package-7").dependencies).toMatchObject({
-        "package-1": "^2.0.0", // ^1.0.0
+      expect(writePkg.updatedManifest('package-7').dependencies).toMatchObject({
+        'package-1': '^2.0.0', // ^1.0.0
+      });
+    });
+
+    it('remove workspace protocol from external dependencies and minor bump other local dependencies with workspace protocol', async () => {
+      const cwd = await initFixture('workspace-protocol-specs');
+      const logErrorSpy = jest.spyOn(npmlog, 'error');
+
+      await gitTag(cwd, 'v1.0.0');
+      await setupChanges(cwd);
+      await new PublishCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match'));
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        'publish',
+        [
+          `Your package named "package-6" has external dependencies not handled by Lerna-Lite and without workspace version suffix, `,
+          `we recommend using defined versions with workspace protocol. Your dependency is currently being published with "tiny-registry": "latest".`,
+        ].join('')
+      );
+      expect(writePkg.updatedManifest('package-6').dependencies).toMatchObject({
+        'package-1': '>=1.1.0', // workspace:>=1.0.0
+        'tiny-registry': 'latest', // workspace:*
+        'tiny-tarball': '^2.3.4', // workspace:^2.3.4
       });
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`workspace:` prefix should be removed on every dependencies being published

## Motivation and Context
we shouldn't publish dependencies with `workspace:` even for external dependencies (not handled by Lerna-Lite), fixes #200

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
