### PR TITLE
fix(version): remove `workspace:` prefix on peerDeps & few refactor

### DIFF
--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -251,11 +251,12 @@ export class Package {
 
   /**
    * Mutate given dependency (could be local/external) spec according to type
+   * @param {String} pkgName - package name
    * @param {Object} resolved npa metadata
    */
   removeDependencyWorkspaceProtocolPrefix(pkgName: string, resolved: NpaResolveResult) {
     const depName = resolved.name as string;
-    const depCollection = this.retrievePackageDependencies(depName);
+    const depCollection = this.retrievePackageDependencies(depName, true);
     const workspaceTarget = resolved?.workspaceTarget ?? '';
 
     if (
@@ -359,7 +360,13 @@ export class Package {
     }
   }
 
-  private retrievePackageDependencies(depName: string): string[] {
+  /**
+   * Retrieve the dependencies collection which contain the dependency name provided, we'll search in all type of dependencies/devDependencies/...
+   * @param {String} depName - dependency name
+   * @param {Boolean} [includePeerDepsFallback] - should we include peerDependencies as fallback?
+   * @returns {Array<String>} - array of dependencies that contains the dependency name provided
+   */
+  private retrievePackageDependencies(depName: string, includePeerDepsFallback = false): string[] {
     // first, try runtime dependencies
     let depCollection = this.dependencies;
 
@@ -371,6 +378,11 @@ export class Package {
     // fall back to devDependencies
     if (!depCollection || !depCollection[depName]) {
       depCollection = this.devDependencies;
+    }
+
+    // fall back to peerDependencies (when enabled)
+    if (includePeerDepsFallback && (!depCollection || !depCollection[depName])) {
+      depCollection = this.peerDependencies;
     }
 
     return depCollection;

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -615,11 +615,9 @@ export class PublishCommand extends Command<PublishCommandOption> {
       }
 
       // 2. remove any "workspace:" prefix from the package to be published any of external dependencies (without anything being bumped)
-      // we will only accept "workspace:" with semver version, for example "workspace:1.2.3" is ok but "workspace:*" will throw
+      // we will only accept "workspace:" with semver version, for example "workspace:1.2.3" is ok but "workspace:*" will log an error
       for (const [_depName, resolved] of node.externalDependencies) {
-        if (/^(workspace:)+(.*)$/.test(resolved.workspaceTarget)) {
-          node.pkg.removeDependencyWorkspaceProtocolPrefix(node.name, resolved);
-        }
+        node.pkg.removeDependencyWorkspaceProtocolPrefix(node.name, resolved);
       }
 
       // writing changes to disk handled in serializeChanges()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
expand on #219 and also remove `workspace:` prefix on external peerDependencies as well

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
