### PR TITLE
fix(version): `--sync-workspace-lock` flag no longer work because of pnpm regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "new-publish": "lerna publish from-package",
     "pack-tarball": "lerna run pack-tarball",
     "jest": "jest --runInBand --coverage=true --config ./jest/jest.config.js",
-    "jest:ci": "jest --maxWorkers=2 --coverage=true --ci --config ./jest/jest.config.js",
+    "jest:ci": "jest --runInBand --coverage=true --ci --config ./jest/jest.config.js",
     "jest:watch": "jest --watch --coverage=false --config ./jest/jest.config.js",
     "outdated:ws": "pnpm -r --stream outdated"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "new-publish": "lerna publish from-package",
     "pack-tarball": "lerna run pack-tarball",
     "jest": "jest --runInBand --coverage=true --config ./jest/jest.config.js",
-    "jest:ci": "jest --runInBand --coverage=true --ci --config ./jest/jest.config.js",
+    "jest:ci": "jest --maxWorkers=2 --coverage=true --ci --config ./jest/jest.config.js",
     "jest:watch": "jest --watch --coverage=false --config ./jest/jest.config.js",
     "outdated:ws": "pnpm -r --stream outdated"
   },

--- a/packages/version/src/__tests__/update-lockfile-version.spec.js
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.js
@@ -165,7 +165,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('pnpm', cwd);
 
-      expect(execSpy).toHaveBeenCalledWith('pnpm', ['install', '--lockfile-only'], { cwd });
+      expect(execSpy).toHaveBeenCalledWith('pnpm', ['install', '--lockfile-only', '--fix-lockfile'], { cwd });
       expect(lockFileOutput).toBe('pnpm-lock.yaml');
     });
   });

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -888,7 +888,7 @@ describe('VersionCommand', () => {
         );
 
         const changedFiles = await showCommit(cwd, '--name-only');
-        // expect(changedFiles).toContain('pnpm-lock.yaml');
+        expect(changedFiles).toContain('pnpm-lock.yaml');
 
         const lockfileResponse: any = await loadYamlFile(path.join(cwd, 'pnpm-lock.yaml'));
         const { lockfileVersion, importers } = lockfileResponse;
@@ -908,7 +908,7 @@ describe('VersionCommand', () => {
         await new VersionCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--sync-workspace-lock'));
 
         const changedFiles = await showCommit(cwd, '--name-only');
-        // expect(changedFiles).toContain('pnpm-lock.yaml');
+        expect(changedFiles).toContain('pnpm-lock.yaml');
         expect(writePkg.updatedVersions()).toEqual({
           '@my-workspace/package-1': '2.4.0',
           '@my-workspace/package-2': '2.4.0',

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -881,14 +881,14 @@ describe('VersionCommand', () => {
         expect(changedFiles).not.toContain('package-lock.json');
       });
 
-      it.skip(`should call runInstallLockFileOnly() when --sync-workspace-lock is provided and expect lockfile to be added to git`, async () => {
+      it(`should call runInstallLockFileOnly() when --sync-workspace-lock is provided and expect lockfile to be added to git`, async () => {
         const cwd = await initFixture('lockfile-pnpm');
         await new VersionCommand(
           createArgv(cwd, '--bump', 'major', '--yes', '--sync-workspace-lock', '--npm-client', 'pnpm')
         );
 
         const changedFiles = await showCommit(cwd, '--name-only');
-        expect(changedFiles).toContain('pnpm-lock.yaml');
+        // expect(changedFiles).toContain('pnpm-lock.yaml');
 
         const lockfileResponse: any = await loadYamlFile(path.join(cwd, 'pnpm-lock.yaml'));
         const { lockfileVersion, importers } = lockfileResponse;
@@ -903,12 +903,12 @@ describe('VersionCommand', () => {
         expect(importers['packages/package-4'].specifiers['@my-workspace/package-2']).toBe('workspace:~');
       });
 
-      it.skip(`should call runInstallLockFileOnly() when --sync-workspace-lock is provided and expect lockfile to be added to git even without npmClient`, async () => {
+      it(`should call runInstallLockFileOnly() when --sync-workspace-lock is provided and expect lockfile to be added to git even without npmClient`, async () => {
         const cwd = await initFixture('lockfile-pnpm');
         await new VersionCommand(createArgv(cwd, '--bump', 'minor', '--yes', '--sync-workspace-lock'));
 
         const changedFiles = await showCommit(cwd, '--name-only');
-        expect(changedFiles).toContain('pnpm-lock.yaml');
+        // expect(changedFiles).toContain('pnpm-lock.yaml');
         expect(writePkg.updatedVersions()).toEqual({
           '@my-workspace/package-1': '2.4.0',
           '@my-workspace/package-2': '2.4.0',

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -134,7 +134,7 @@ export async function runInstallLockFileOnly(
       inputLockfileName = 'pnpm-lock.yaml';
       if (await validateFileExists(path.join(cwd, inputLockfileName))) {
         log.verbose('lock', `updating lock file via "pnpm install --lockfile-only"`);
-        await exec('pnpm', ['install', '--lockfile-only'], { cwd });
+        await exec('pnpm', ['install', '--lockfile-only', '--fix-lockfile'], { cwd });
         outputLockfileName = inputLockfileName;
       }
       break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Last version of pnpm [v7.4.0](https://github.com/pnpm/pnpm/releases/tag/v7.4.0) has a change to exit early on `install --lockfile-only` and that is impacting (aka failing) the `version` unit tests which use pnpm, it seems to be exiting too early and skipping the lock file update which defeat the purpose of the `--sync-workspace-lock` flag.

Adding `--fix-lockfile` to pnpm seems to be help to get previous pnpm behavior. I wish that `--lockfile-only` would still work but the `--fix-lockfile` flag is a quick fix for now until pnpm addresses this regression [issue](https://github.com/pnpm/pnpm/issues/4951) that I opened in the pnpm project.

```ts
# adding the fix extra flag helps get previous pnpm behavior
pnpm install --lockfile-only --fix-lockfile
```

quick (patch) fix for issue #234 

## Motivation and Context
re-enable previously failing unit tests with pnpm and find a way to bypass new pnpm regression caused in latest pnpm 7.4.0

## How Has This Been Tested?
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
