### PR TITLE
chore: use correct array type on `packageParentDirs` prop

### DIFF
--- a/packages/changed/src/__tests__/changed-command.spec.ts
+++ b/packages/changed/src/__tests__/changed-command.spec.ts
@@ -31,7 +31,7 @@ const yargParser = require('yargs-parser');
 const createArgv = (cwd: string, ...args: string[]) => {
   args.unshift('changed');
   const parserArgs = args.map(String);
-  const argv = yargParser(parserArgs);
+  const argv = yargParser(parserArgs, { array: [{ key: 'ignoreChanges' }] });
   argv['$0'] = cwd;
   argv['loglevel'] = 'silent';
   return argv;

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -117,7 +117,7 @@ export class Project {
     return this.config.packages || [Project.PACKAGE_GLOB];
   }
 
-  get packageParentDirs(): Promise<string[]> {
+  get packageParentDirs(): string[] {
     return (this.packageConfigs as any)
       .map(globParent)
       .map((parentDir: string) => path.resolve(this.rootPath, parentDir));

--- a/packages/diff/src/__tests__/__snapshots__/diff-command.spec.ts.snap
+++ b/packages/diff/src/__tests__/__snapshots__/diff-command.spec.ts.snap
@@ -17,19 +17,6 @@ index SHA..SHA 100644
 `;
 
 exports[`Diff Command should diff a specific package 1`] = `
-diff --git a/packages/package-1/package.json b/packages/package-1/package.json
-index SHA..SHA 100644
---- a/packages/package-1/package.json
-+++ b/packages/package-1/package.json
-@@ -1,5 +1,5 @@
- {
-   "name": "package-1",
--  "changed": 0,
-+  "changed": 1,
-   "version": "1.0.0"
--}
-\\ No newline at end of file
-+}
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json

--- a/packages/diff/src/__tests__/__snapshots__/diff-command.spec.ts.snap
+++ b/packages/diff/src/__tests__/__snapshots__/diff-command.spec.ts.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Diff Command passes diff exclude globs configured with --ignore-changes 1`] = `
-diff --git a/packages/package-1/README.md b/packages/package-1/README.md
-new file mode 100644
-index SHA..SHA
---- /dev/null
-+++ b/packages/package-1/README.md
-@@ -0,0 +1 @@
-+ignored change
-\\ No newline at end of file
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json

--- a/packages/diff/src/__tests__/__snapshots__/diff-command.spec.ts.snap
+++ b/packages/diff/src/__tests__/__snapshots__/diff-command.spec.ts.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Diff Command passes diff exclude globs configured with --ignored-changes 1`] = `
+exports[`Diff Command passes diff exclude globs configured with --ignore-changes 1`] = `
+diff --git a/packages/package-1/README.md b/packages/package-1/README.md
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-1/README.md
+@@ -0,0 +1 @@
++ignored change
+\\ No newline at end of file
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
@@ -17,6 +25,19 @@ index SHA..SHA 100644
 `;
 
 exports[`Diff Command should diff a specific package 1`] = `
+diff --git a/packages/package-1/package.json b/packages/package-1/package.json
+index SHA..SHA 100644
+--- a/packages/package-1/package.json
++++ b/packages/package-1/package.json
+@@ -1,5 +1,5 @@
+ {
+   "name": "package-1",
+-  "changed": 0,
++  "changed": 1,
+   "version": "1.0.0"
+-}
+\\ No newline at end of file
++}
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json

--- a/packages/diff/src/__tests__/diff-command.spec.ts
+++ b/packages/diff/src/__tests__/diff-command.spec.ts
@@ -31,6 +31,9 @@ const yargParser = require('yargs-parser');
 
 const createArgv = (cwd: string, ...args: string[]) => {
   args.unshift('diff');
+  if (args.length > 0 && args[1]?.length > 0 && !args[1].startsWith('--')) {
+    args[1] = `--pkgName=${args[1]}`;
+  }
   const parserArgs = args.map(String);
   const argv = yargParser(parserArgs, { array: [{ key: 'ignoreChanges' }] });
   argv['$0'] = cwd;

--- a/packages/diff/src/__tests__/diff-command.spec.ts
+++ b/packages/diff/src/__tests__/diff-command.spec.ts
@@ -32,7 +32,7 @@ const yargParser = require('yargs-parser');
 const createArgv = (cwd: string, ...args: string[]) => {
   args.unshift('diff');
   const parserArgs = args.map(String);
-  const argv = yargParser(parserArgs);
+  const argv = yargParser(parserArgs, { array: [{ key: 'ignoreChanges' }] });
   argv['$0'] = cwd;
   argv['loglevel'] = 'silent';
   return argv;

--- a/packages/diff/src/__tests__/diff-command.spec.ts
+++ b/packages/diff/src/__tests__/diff-command.spec.ts
@@ -86,7 +86,8 @@ describe('Diff Command', () => {
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'changed');
 
-    const { stdout } = await lernaDiff(cwd)();
+    // @ts-ignore
+    const { stdout } = await new DiffCommand(createArgv(cwd, ''));
     expect(stdout).toMatchSnapshot();
   });
 
@@ -116,11 +117,12 @@ describe('Diff Command', () => {
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'changed');
 
-    const { stdout } = await lernaDiff(cwd)('package-2');
+    // @ts-ignore
+    const { stdout } = await new DiffCommand(createArgv(cwd, 'package-2'));
     expect(stdout).toMatchSnapshot();
   });
 
-  it('passes diff exclude globs configured with --ignored-changes', async () => {
+  it('passes diff exclude globs configured with --ignore-changes', async () => {
     const cwd = await initFixture('basic');
     const [pkg1] = await getPackages(cwd);
 
@@ -129,7 +131,8 @@ describe('Diff Command', () => {
     await gitAdd(cwd, '-A');
     await gitCommit(cwd, 'changed');
 
-    const { stdout } = await lernaDiff(cwd)('--ignore-changes', '**/README.md');
+    // @ts-ignore
+    const { stdout } = await new DiffCommand(createArgv(cwd, '--ignore-changes', '**/README.md'));
     expect(stdout).toMatchSnapshot();
   });
 
@@ -146,7 +149,7 @@ describe('Diff Command', () => {
     await fs.remove(path.join(cwd, '.git'));
     await gitInit(cwd);
 
-    const command = lernaDiff(cwd)('package-1');
+    const command = new DiffCommand(createArgv(cwd, 'package-1'));
     await expect(command).rejects.toThrow('Cannot diff, there are no commits in this repository yet.');
   });
 
@@ -160,7 +163,7 @@ describe('Diff Command', () => {
       throw nonZero;
     });
 
-    const command = lernaDiff(cwd)('package-1');
+    const command = new DiffCommand(createArgv(cwd, 'package-1'));
     await expect(command).rejects.toThrow('An actual non-zero, not git diff pager SIGPIPE');
   });
 });

--- a/packages/diff/src/diff-command.ts
+++ b/packages/diff/src/diff-command.ts
@@ -40,12 +40,10 @@ export class DiffCommand extends Command<DiffCommandOption> {
       args.push('--', ...this.project.packageParentDirs);
     }
 
-    if (Array.isArray(this.options.ignoreChanges)) {
-      this.options.ignoreChanges.forEach((ignorePattern) => {
-        // https://stackoverflow.com/a/21079437
-        args.push(`:(exclude,glob)${ignorePattern}`);
-      });
-    }
+    // https://stackoverflow.com/a/21079437
+    this.options.ignoreChanges?.forEach((ignorePattern) => {
+      args.push(`:(exclude,glob)${ignorePattern}`);
+    });
 
     this.args = args;
   }

--- a/packages/diff/src/diff-command.ts
+++ b/packages/diff/src/diff-command.ts
@@ -10,7 +10,6 @@ export function factory(argv: DiffCommandOption) {
 export class DiffCommand extends Command<DiffCommandOption> {
   /** command name */
   name = 'diff' as CommandType;
-
   args: string[] = [];
 
   constructor(argv: DiffCommandOption) {
@@ -41,7 +40,7 @@ export class DiffCommand extends Command<DiffCommandOption> {
       args.push('--', ...this.project.packageParentDirs);
     }
 
-    if (this.options.ignoreChanges) {
+    if (Array.isArray(this.options.ignoreChanges)) {
       this.options.ignoreChanges.forEach((ignorePattern) => {
         // https://stackoverflow.com/a/21079437
         args.push(`:(exclude,glob)${ignorePattern}`);

--- a/packages/diff/src/diff-command.ts
+++ b/packages/diff/src/diff-command.ts
@@ -17,7 +17,7 @@ export class DiffCommand extends Command<DiffCommandOption> {
     super(argv);
   }
 
-  async initialize() {
+  initialize() {
     let targetPackage: Package | undefined = undefined;
     const packageName = this.options.pkgName;
 
@@ -38,7 +38,7 @@ export class DiffCommand extends Command<DiffCommandOption> {
     if (targetPackage) {
       args.push('--', targetPackage.location);
     } else {
-      args.push('--', ...(await this.project.packageParentDirs));
+      args.push('--', ...this.project.packageParentDirs);
     }
 
     if (this.options.ignoreChanges) {

--- a/packages/diff/src/diff-command.ts
+++ b/packages/diff/src/diff-command.ts
@@ -49,11 +49,13 @@ export class DiffCommand extends Command<DiffCommandOption> {
   }
 
   execute() {
-    return spawn('git', this.args, this.execOpts).catch((err) => {
+    try {
+      return spawn('git', this.args, this.execOpts);
+    } catch (err: any) {
       if (err.exitCode) {
         // quitting the diff viewer is not an error
         throw err;
       }
-    });
+    }
   }
 }

--- a/packages/init/src/init-command.ts
+++ b/packages/init/src/init-command.ts
@@ -124,9 +124,9 @@ export class InitCommand extends Command<InitCommandOption> {
     return this.project.serializeConfig();
   }
 
-  async ensurePackagesDir() {
+  ensurePackagesDir() {
     this.logger.info('', 'Creating packages directory');
 
-    return pMap(await this.project.packageParentDirs, (dir) => fs.mkdirp(dir));
+    return pMap(this.project.packageParentDirs, (dir) => fs.mkdirp(dir));
   }
 }

--- a/packages/version/src/__tests__/version-ignore-changes.spec.ts
+++ b/packages/version/src/__tests__/version-ignore-changes.spec.ts
@@ -37,7 +37,7 @@ expect.addSnapshotSerializer(require('@lerna-test/serialize-git-sha'));
 const createArgv = (cwd, ...args) => {
   args.unshift('version');
   const parserArgs = args.map(String);
-  const argv = yargParser(parserArgs);
+  const argv = yargParser(parserArgs, { array: [{ key: 'ignoreChanges' }] });
   argv['$0'] = cwd;
   return argv;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context
previous commit was typed as `Promise<string[]>` when it's actually a sync process and should be `string[]`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (refactoring/non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
