### PR TITLE
fix(version): rollback previous patch on pnpm lockfile update

### DIFF
--- a/packages/version/src/__tests__/update-lockfile-version.spec.js
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.js
@@ -161,7 +161,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('pnpm', cwd);
 
-      expect(execSpy).toHaveBeenCalledWith('pnpm', ['install', '--lockfile-only', '--no-frozen-lockfile'], { cwd });
+      expect(execSpy).toHaveBeenCalledWith('pnpm', ['install', '--lockfile-only'], { cwd });
       expect(lockFileOutput).toBe('pnpm-lock.yaml');
     });
   });

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -131,7 +131,7 @@ export async function runInstallLockFileOnly(
       inputLockfileName = 'pnpm-lock.yaml';
       if (await validateFileExists(path.join(cwd, inputLockfileName))) {
         log.verbose('lock', `updating lock file via "pnpm install --lockfile-only"`);
-        await exec('pnpm', ['install', '--lockfile-only', '--no-frozen-lockfile'], { cwd });
+        await exec('pnpm', ['install', '--lockfile-only'], { cwd });
         outputLockfileName = inputLockfileName;
       }
       break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- rollback PR #236 since the regression introduced in pnpm 7.4.0 was fixed in pnpm 7.4.1 and it should be safe to rollback to previous code without the need for `--no-frozen-lockfile` flag anymore to update the lock file after executing a new `version`

## Motivation and Context

simpler code to update lock file to keep the same approach that it was before the recent pnpm regression

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (refactoring/non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
