### PR TITLE
fix(run): add double quotes around script target containing colon

### DIFF
--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -43,6 +43,8 @@
   "devDependencies": {
     "@types/execa": "^2.0.0",
     "@types/p-map": "^2.0.0",
+    "globby": "^11.1.0",
+    "jest-circus": "^28.1.2",
     "perf_hooks": "^0.0.1",
     "yargs-parser": "^21.0.1"
   }

--- a/packages/run/src/__fixtures__/powered-by-nx/packages/package-1/package.json
+++ b/packages/run/src/__fixtures__/powered-by-nx/packages/package-1/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "fail": "exit 1",
-    "my-script": "echo package-1"
+    "my-script": "echo package-1",
+    "another-script:but-with-colons": "echo package-1-script-with-colons"
   }
 }

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -383,6 +383,13 @@ describe('RunCommand', () => {
       expect(collectedOutput).toContain('Successfully ran target');
     });
 
+    it('runs a script with a colon in the script name', async () => {
+      collectedOutput = '';
+      await lernaRun(testDir)('another-script:but-with-colons');
+      expect(collectedOutput).toContain('package-1-script-with-colons');
+      expect(collectedOutput).toContain('Successfully ran target');
+    });
+
     it('runs a script only in scoped packages', async () => {
       collectedOutput = '';
       await lernaRun(testDir)('my-script', '--scope', 'package-1');

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -205,6 +205,11 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
     return chain;
   }
 
+  /** Nx requires quotes around script names of the form script:name*/
+  escapeScriptNameQuotes(scriptName: string) {
+    return scriptName.includes(':') ? `"${scriptName}"` : scriptName;
+  }
+
   async runScriptsUsingNx() {
     if (this.options.ci) {
       process.env.CI = 'true';
@@ -214,7 +219,8 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
     const { targetDependencies, options } = await this.prepNxOptions();
     if (this.packagesWithScript.length === 1) {
       const { runOne } = await import('nx/src/command-line/run-one');
-      const fullQualifiedTarget = this.packagesWithScript.map((p) => p.name)[0] + ':' + this.script;
+      const fullQualifiedTarget =
+        this.packagesWithScript.map((p) => p.name)[0] + ':' + this.escapeScriptNameQuotes(this.script);
       return (runOne as any)(
         process.cwd(),
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,6 +549,8 @@ importers:
       '@types/execa': ^2.0.0
       '@types/p-map': ^2.0.0
       fs-extra: ^10.1.0
+      globby: ^11.1.0
+      jest-circus: ^28.1.2
       multimatch: ^5.0.0
       npmlog: ^6.0.2
       p-map: ^4.0.0
@@ -568,6 +570,8 @@ importers:
     devDependencies:
       '@types/execa': 2.0.0
       '@types/p-map': 2.0.0
+      globby: 11.1.0
+      jest-circus: 28.1.2
       perf_hooks: 0.0.1
       yargs-parser: 21.0.1
 
@@ -6727,7 +6731,7 @@ packages:
       strip-ansi: 6.0.1
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   /write-file-atomic/2.4.3:
     resolution: {integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds double-quotes around script target when running with Nx (for example `"dev:build": "tsc build"`)

## Motivation and Context

follows bug fix pushed in original Lerna [PR 3218](https://github.com/lerna/lerna/pull/3218)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
