### PR TITLE
chore(deps): add missing peer dependency "jest/types"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "pnpm": "7"
   },
   "devDependencies": {
+    "@jest/types": "^28.1.3",
     "@lerna-lite/changed": "workspace:*",
     "@lerna-lite/cli": "workspace:*",
     "@lerna-lite/core": "workspace:*",
@@ -85,7 +86,7 @@
     "rimraf": "^3.0.2",
     "tacks": "^1.2.6",
     "tempy": "^1.0.1",
-    "ts-jest": "^28.0.5",
+    "ts-jest": "^28.0.6",
     "tsm": "^2.2.1",
     "typescript": "^4.7.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ importers:
 
   .:
     specifiers:
+      '@jest/types': ^28.1.3
       '@lerna-lite/changed': workspace:*
       '@lerna-lite/cli': workspace:*
       '@lerna-lite/core': workspace:*
@@ -43,10 +44,11 @@ importers:
       rimraf: ^3.0.2
       tacks: ^1.2.6
       tempy: ^1.0.1
-      ts-jest: ^28.0.5
+      ts-jest: ^28.0.6
       tsm: ^2.2.1
       typescript: ^4.7.4
     devDependencies:
+      '@jest/types': 28.1.3
       '@lerna-lite/changed': link:packages/changed
       '@lerna-lite/cli': link:packages/cli
       '@lerna-lite/core': link:packages/core
@@ -86,7 +88,7 @@ importers:
       rimraf: 3.0.2
       tacks: 1.3.0
       tempy: 1.0.1
-      ts-jest: 28.0.5_bi2kohzqnxavgozw3csgny5hju
+      ts-jest: 28.0.6_lhw3xkmzugq5tscs3x2ndm4sby
       tsm: 2.2.1
       typescript: 4.7.4
 
@@ -4588,18 +4590,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-util/28.1.1:
-    resolution: {integrity: sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/types': 28.1.3
-      '@types/node': 18.0.0
-      chalk: 4.1.2
-      ci-info: 3.3.1
-      graceful-fs: 4.2.10
-      picomatch: 2.3.1
-    dev: true
-
   /jest-util/28.1.3:
     resolution: {integrity: sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -6376,12 +6366,13 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /ts-jest/28.0.5_bi2kohzqnxavgozw3csgny5hju:
-    resolution: {integrity: sha512-Sx9FyP9pCY7pUzQpy4FgRZf2bhHY3za576HMKJFs+OnQ9jS96Du5vNsDKkyedQkik+sEabbKAnCliv9BEsHZgQ==}
+  /ts-jest/28.0.6_lhw3xkmzugq5tscs3x2ndm4sby:
+    resolution: {integrity: sha512-yLAWoaSJ6c9o+IT7+nyutp5uvwGzhMYb/LD5WEQAi2tBq4ZSAPay4Lf69pP/IU+GFYg87pdg5eADSzuNAFSK4g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^28.0.0
       babel-jest: ^28.0.0
       esbuild: '*'
       jest: ^28.0.0
@@ -6394,10 +6385,11 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@jest/types': 28.1.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 28.1.3_@types+node@18.0.0
-      jest-util: 28.1.1
+      jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

fix failure identified by Renovate because "@jest/types" is now a peer dependency in "ts-jest"

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
