### PR TITLE
fix(version): Node14, import from "fs" instead of "node:fs", fixes #260

### DIFF
--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -7,7 +7,7 @@ jest.mock('@lerna-lite/core', () => ({
 import path from 'path';
 import fs from 'fs-extra';
 import core, { Package } from '@lerna-lite/core';
-import nodeFs from 'node:fs';
+import nodeFs from 'fs';
 import npmlog from 'npmlog';
 
 // mocked or stubbed modules

--- a/packages/version/src/__tests__/version-bump.spec.ts
+++ b/packages/version/src/__tests__/version-bump.spec.ts
@@ -1,4 +1,4 @@
-const nodeFs = require('node:fs');
+import nodeFs from 'fs';
 jest.spyOn(nodeFs, 'renameSync');
 
 // local modules _must_ be explicitly mocked

--- a/packages/version/src/__tests__/version-ignore-changes.spec.ts
+++ b/packages/version/src/__tests__/version-ignore-changes.spec.ts
@@ -1,4 +1,4 @@
-const nodeFs = require('node:fs');
+import nodeFs from 'fs';
 jest.spyOn(nodeFs, 'renameSync');
 
 // local modules _must_ be explicitly mocked

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -1,7 +1,7 @@
 import log from 'npmlog';
 import path from 'path';
 import loadJsonFile from 'load-json-file';
-import { promises as fsPromises, renameSync } from 'node:fs';
+import fs from 'fs';
 import os from 'os';
 import semver from 'semver';
 import writeJsonFile from 'write-json-file';
@@ -168,7 +168,7 @@ export async function runInstallLockFileOnly(
 
           // 2. rename "npm-shrinkwrap.json" back to "package-lock.json"
           log.verbose('lock', `renaming "npm-shrinkwrap.json" file back to "package-lock.json"`);
-          renameSync('npm-shrinkwrap.json', 'package-lock.json');
+          fs.renameSync('npm-shrinkwrap.json', 'package-lock.json');
         }
 
         outputLockfileName = inputLockfileName;
@@ -195,7 +195,7 @@ export async function runInstallLockFileOnly(
  */
 export async function validateFileExists(filePath: string) {
   try {
-    await fsPromises.access(filePath);
+    await fs.promises.access(filePath);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use `import fs from 'fs'` instead of `from 'node:fs'` to keep earlier Node 14 version compatibility

## Motivation and Context

fix issue #260 to keep Node 14 compatibility

## How Has This Been Tested?

same unit tests suite as before

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
