### PR TITLE
chore: add error stack to optional command when cmd pkg is not install

### DIFF
--- a/packages/cli/src/cli-commands/__tests__/cli-changed-commands.spec.ts
+++ b/packages/cli/src/cli-commands/__tests__/cli-changed-commands.spec.ts
@@ -8,7 +8,8 @@ describe('ChangedCommand CLI options', () => {
     await cliChanged.handler(undefined as any);
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"@lerna-lite/changed" is optional and was not found.')
+      expect.stringContaining('"@lerna-lite/changed" is optional and was not found.'),
+      expect.anything()
     );
   });
 });

--- a/packages/cli/src/cli-commands/__tests__/cli-exec-commands.spec.ts
+++ b/packages/cli/src/cli-commands/__tests__/cli-exec-commands.spec.ts
@@ -8,7 +8,8 @@ describe('ExecCommand CLI options', () => {
     await cliExec.handler(undefined as any);
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"@lerna-lite/exec" is optional and was not found.')
+      expect.stringContaining('"@lerna-lite/exec" is optional and was not found.'),
+      expect.anything()
     );
   });
 });

--- a/packages/cli/src/cli-commands/__tests__/cli-list-commands.spec.ts
+++ b/packages/cli/src/cli-commands/__tests__/cli-list-commands.spec.ts
@@ -8,7 +8,8 @@ describe('ListCommand CLI options', () => {
     await cliList.handler(undefined as any);
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"@lerna-lite/list" is optional and was not found.')
+      expect.stringContaining('"@lerna-lite/list" is optional and was not found.'),
+      expect.anything()
     );
   });
 });

--- a/packages/cli/src/cli-commands/__tests__/cli-run-commands.spec.ts
+++ b/packages/cli/src/cli-commands/__tests__/cli-run-commands.spec.ts
@@ -8,7 +8,8 @@ describe('RunCommand CLI options', () => {
     await cliRun.handler(undefined as any);
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"@lerna-lite/run" is optional and was not found.')
+      expect.stringContaining('"@lerna-lite/run" is optional and was not found.'),
+      expect.anything()
     );
   });
 });

--- a/packages/cli/src/cli-commands/cli-changed-commands.ts
+++ b/packages/cli/src/cli-commands/cli-changed-commands.ts
@@ -48,9 +48,10 @@ export default {
       // eslint-disable-next-line import/no-unresolved
       const { ChangedCommand } = await import('@lerna-lite/changed');
       new ChangedCommand(argv);
-    } catch (e) {
+    } catch (err: unknown) {
       console.error(
-        '"@lerna-lite/changed" is optional and was not found. Please install it with `npm install @lerna-lite/changed -D -W`'
+        `"@lerna-lite/changed" is optional and was not found. Please install it with "npm install @lerna-lite/changed -D -W".`,
+        err
       );
     }
   },

--- a/packages/cli/src/cli-commands/cli-exec-commands.ts
+++ b/packages/cli/src/cli-commands/cli-exec-commands.ts
@@ -81,9 +81,10 @@ export default {
       // eslint-disable-next-line import/no-unresolved
       const { ExecCommand } = await import('@lerna-lite/exec');
       new ExecCommand(argv);
-    } catch (e) {
+    } catch (err: unknown) {
       console.error(
-        '"@lerna-lite/exec" is optional and was not found. Please install it with `npm install @lerna-lite/exec -D -W`'
+        `"@lerna-lite/exec" is optional and was not found. Please install it with "npm install @lerna-lite/exec -D -W".`,
+        err
       );
     }
   },

--- a/packages/cli/src/cli-commands/cli-list-commands.ts
+++ b/packages/cli/src/cli-commands/cli-list-commands.ts
@@ -22,9 +22,10 @@ export default {
       // eslint-disable-next-line import/no-unresolved
       const { ListCommand } = await import('@lerna-lite/list');
       new ListCommand(argv);
-    } catch (e) {
+    } catch (err: unknown) {
       console.error(
-        '"@lerna-lite/list" is optional and was not found. Please install it with `npm install @lerna-lite/list -D -W`'
+        `"@lerna-lite/list" is optional and was not found. Please install it with "npm install @lerna-lite/list -D -W".`,
+        err
       );
     }
   },

--- a/packages/cli/src/cli-commands/cli-run-commands.ts
+++ b/packages/cli/src/cli-commands/cli-run-commands.ts
@@ -87,9 +87,10 @@ export default {
       // eslint-disable-next-line import/no-unresolved
       const { RunCommand } = await import('@lerna-lite/run');
       new RunCommand(argv);
-    } catch (e) {
+    } catch (err: unknown) {
       console.error(
-        '"@lerna-lite/run" is optional and was not found. Please install it with `npm install @lerna-lite/run -D -W`'
+        `"@lerna-lite/run" is optional and was not found. Please install it with "npm install @lerna-lite/run -D -W".`,
+        err
       );
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add error stack when displaying missing install on optional commands

## Motivation and Context

adding the error stack can be useful when the error is not actually coming from the missing optional command install, this is actually what happened in previous issue #265 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
