### PR TITLE
feat(version): provide custom format to include commit author fullname

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
       "createRelease": "github",
       "gitDryRun": false,
       "syncWorkspaceLock": true,
-      "changelogIncludeCommitAuthor": true,
+      "changelogIncludeCommitAuthorFullname": " by <%a>",
       "changelogHeaderMessage": "### Automate your Workspace Versions, Changelogs & Publish with [Lerna-Lite](https://github.com/ghiscoding/lerna-lite) 🚀",
       "message": "chore(release): publish new version %v"
     },

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -63,11 +63,12 @@ export default {
         requiresArg: true,
         type: 'string',
       },
-      'changelog-include-commit-author': {
+      'changelog-include-commit-author-fullname': {
         describe:
-          "Specify if we want to include the commit author's name when using conventional-commits with changelog",
+          "Specify if we want to include the commit author's name, when using conventional-commits with changelog. We can optionally provide a custom message or else a default format will be used.",
         group: 'Version Command Options:',
-        type: 'boolean',
+        requiresArg: false,
+        type: 'string',
       },
       'changelog-version-message': {
         describe:

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -189,10 +189,16 @@ export interface VersionCommandOption {
   /** Add a custom message at the top of your "changelog.md" which is located in the root of your project. This option only works when using --conventional-commits. */
   changelogHeaderMessage?: string;
 
-  /** Specify if we want to include the commit author's name when using conventional-commits with changelog */
-  changelogIncludeCommitAuthor?: boolean;
+  /**
+   * Specify if we want to include the commit author's name, when using conventional-commits with changelog.
+   * We can optionally provide a custom message or else a default format will be used.
+   */
+  changelogIncludeCommitAuthorFullname?: boolean | string;
 
-  /** Add a custom message as a prefix to each new version in your "changelog.md" which is located in the root of your project. This option only works when using --conventional-commits. */
+  /**
+   * Add a custom message as a prefix to each new version in your "changelog.md" which is located in the root of your project.
+   * This option only works when using --conventional-commits.
+   */
   changelogVersionMessage?: string;
 
   /** Defaults 'angular', custom conventional-changelog preset. */

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -74,7 +74,7 @@ export interface UpdateChangelogOption {
   changelogHeaderMessage?: string;
   changelogVersionMessage?: string;
   changelogPreset?: string;
-  changelogIncludeCommitAuthor?: boolean;
+  changelogIncludeCommitAuthorFullname?: boolean | string;
   rootPath?: string;
   tagPrefix?: string;
   version?: string;

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -76,7 +76,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
     - [`--conventional-commits`](#--conventional-commits)
     - [`--conventional-graduate`](#--conventional-graduate)
     - [`--conventional-prerelease`](#--conventional-prerelease)
-    - [`--changelog-include-commit-author`](#--changelog-include-commit-author) (new)
+    - [`--changelog-include-commit-author-fullname [msg]`](#--changelog-include-commit-author-fullname-msg) (new)
     - [`--changelog-header-message <msg>`](#--changelog-header-message-msg) (new)
     - [`--changelog-version-message <msg>`](#--changelog-version-message-msg) (new)
     - [`--create-release <type>`](#--create-release-type)
@@ -230,16 +230,34 @@ lerna version --conventional-commits --conventional-prerelease
 
 When run with this flag, `lerna version` will release with prerelease versions the specified packages (comma-separated) or all packages using `*`. Releases all unreleased changes as pre(patch/minor/major/release) by prefixing the version recommendation from `conventional-commits` with `pre`, eg. if present changes include a feature commit, the recommended bump will be `minor`, so this flag will result in a `preminor` release. If changes are present for packages that are not specified (if specifying packages), or for packages that are already in prerelease, those packages will be versioned as they normally would using `--conventional-commits`.
 
-### `--changelog-include-commit-author`
-Specify if we want to include the commit author's name, at the end of each commit entry, when using `--conventional-commits` with changelogs.
+### `--changelog-include-commit-author-fullname [msg]`
+Specify if we want to include the git commit author's name, at the end of each changelog commit entry, this is only available when using `--conventional-commits` with changelogs. The default format will append the author's name at the end of each commit entry and wrapped in `()`, for exampe "feat: commit message (Author Name)". We could also use a custom format by providing the `%a` token. Note that in every case, the author's name will always be appended as a suffix to each changelog commit entry.
+
+> **Note** that the author name is the name that was given in the user's Git config, refer to [Git Configuration](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration) for more info. In other words, this is **not** the same as a GitHub login username.
 
 ```sh
-lerna version --conventional-commits --changelog-include-commit-author
+lerna version --conventional-commits --changelog-include-commit-author-fullname
 ```
 
-See below for a sample of a changelog entry with author (note the url was shorten up for simplicity)
+See below for a sample of a changelog entry with the author's full name (note the url was shorten up for simplicity)
+#### Default Format
+The default format will append the author's name (wrapped in `()`) to the end of the commit message
+
 ```sh
-* **deps:** update dependency git-url-parse to v12 ([978bf36](https://github.com/ghiscoding/lerna-lite/commit/978bf36)) (@Renovate-Bot)
+* **deps:** update dependency git-url-parse to v12 ([978bf36](https://github.com/ghiscoding/lerna-lite/commit/978bf36)) (Renovate Bot)
+```
+
+#### Custom Format
+If we want to provide a default format, we can do so by using the `%a` token
+
+```sh
+lerna version --conventional-commits --changelog-include-commit-author-fullname " by _%a_"
+```
+
+will show the following (the use of `_` in this case would display the name in italic)
+
+```sh
+* **deps:** update dependency git-url-parse to v12 ([978bf36](https://github.com/ghiscoding/lerna-lite/commit/978bf36)) by _Renovate Bot_
 ```
 
 ### `--changelog-header-message <msg>`

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -601,7 +601,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
           changelogPreset,
           rootPath,
           tagPrefix: this.tagPrefix,
-          changelogIncludeCommitAuthor: this.options.changelogIncludeCommitAuthor,
+          changelogIncludeCommitAuthorFullname: this.options.changelogIncludeCommitAuthorFullname,
           changelogHeaderMessage: this.options.changelogHeaderMessage,
           changelogVersionMessage: this.options.changelogVersionMessage,
         }).then(({ logPath, newEntry }) => {
@@ -683,7 +683,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
             rootPath,
             tagPrefix: this.tagPrefix,
             version: this.globalVersion,
-            changelogIncludeCommitAuthor: this.options.changelogIncludeCommitAuthor,
+            changelogIncludeCommitAuthorFullname: this.options.changelogIncludeCommitAuthorFullname,
             changelogHeaderMessage: this.options.changelogHeaderMessage,
             changelogVersionMessage: this.options.changelogVersionMessage,
           }).then(({ logPath, newEntry }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new flag `--changelog-include-commit-author-fullname [msg]` to specify if we want to include the git commit author's name, at the end of each changelog commit entry, this is only available when using `--conventional-commits` with changelogs. The default format will append the author's name at the end of each commit entry and wrapped in `()`, for exampe "feat: commit message (Author Name)". We could also use a custom format by providing the `%a` token. Note that in every case, the author's name will always be appended as a suffix to each changelog commit entry.

## Motivation and Context

This improves the previous implementation done in PR #253, the previous implementation assumed wrongly that the author name was the same as the GitHub username while in fact it's totally different and is instead the name configured in git. This partially addresses issue #248

This PR adds the following flag 
`--changelog-include-commit-author-fullname [msg]` 
_it was previously implemented as a different flag name `--changelog-include-commit-author`_

A future PR is expected to add a second flag to add the GitHub username 
`--changelog-include-commit-author-username [msg]`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
