### PR TITLE
fix(run-lifecycle): lifecycle events should run to completion in series

### DIFF
--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -53,13 +53,19 @@ export interface ExecOpts {
 }
 
 export interface LifecycleConfig {
-  log?: typeof log;
+  access?: 'public' | 'restricted';
+  defaultTag?: string;
   ignorePrepublish?: boolean;
   ignoreScripts?: boolean;
+  log: log.Logger;
+  lernaCommand?: string;
   nodeOptions?: string;
+  projectScope?: string | null;
   scriptShell?: string;
   scriptsPrependNodePath?: boolean;
   snapshot?: any;
+  stdio?: string;
+  tag?: string;
   unsafePerm?: boolean;
 }
 
@@ -82,13 +88,13 @@ export interface UpdateChangelogOption {
 
 export interface FetchConfig {
   fetchRetries: number;
-  log: typeof log;
+  log: log.Logger;
   registry: string;
   username: string;
 }
 
 export interface PackConfig {
-  log: typeof log;
+  log: log.Logger;
 
   /* If "publish", run "prepublishOnly" lifecycle */
   lernaCommand?: string;

--- a/packages/publish/src/lib/npm-publish.ts
+++ b/packages/publish/src/lib/npm-publish.ts
@@ -6,7 +6,7 @@ import pify from 'pify';
 import { publish } from 'libnpmpublish';
 import readJSON from 'read-package-json';
 
-import { OneTimePasswordCache, otplease, Package, RawManifest, runLifecycle } from '@lerna-lite/core';
+import { LifecycleConfig, OneTimePasswordCache, otplease, Package, RawManifest, runLifecycle } from '@lerna-lite/core';
 import { LibNpmPublishOptions, PackagePublishConfig } from '../models';
 
 const readJSONAsync = pify(readJSON);
@@ -100,8 +100,8 @@ export function npmPublish(
     });
   }
 
-  chain = chain.then(() => runLifecycle(pkg, 'publish', opts));
-  chain = chain.then(() => runLifecycle(pkg, 'postpublish', opts));
+  chain = chain.then(() => runLifecycle(pkg, 'publish', opts as LifecycleConfig));
+  chain = chain.then(() => runLifecycle(pkg, 'postpublish', opts as LifecycleConfig));
 
   return chain;
 }

--- a/packages/publish/src/lib/pack-directory.ts
+++ b/packages/publish/src/lib/pack-directory.ts
@@ -3,7 +3,7 @@ import packlist from 'npm-packlist';
 import log from 'npmlog';
 import tar from 'tar';
 
-import { Package, PackConfig, runLifecycle, tempWrite } from '@lerna-lite/core';
+import { LifecycleConfig, Package, PackConfig, runLifecycle, tempWrite } from '@lerna-lite/core';
 import { getPacked } from './get-packed';
 import { Readable } from 'stream';
 import { Tarball } from '../models';
@@ -16,7 +16,7 @@ import { Tarball } from '../models';
  */
 export function packDirectory(_pkg: Package, dir: string, options: PackConfig) {
   const pkg = Package.lazy(_pkg, dir);
-  const opts = {
+  const opts: LifecycleConfig = {
     // @ts-ignore
     log,
     ...options,
@@ -33,6 +33,7 @@ export function packDirectory(_pkg: Package, dir: string, options: PackConfig) {
   chain = chain.then(() => runLifecycle(pkg, 'prepare', opts));
 
   if (opts.lernaCommand === 'publish') {
+    opts.stdio = 'inherit';
     chain = chain.then(() => pkg.refresh());
     chain = chain.then(() => runLifecycle(pkg, 'prepublishOnly', opts));
     chain = chain.then(() => pkg.refresh());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As per original Lerna PR 3262
> During the difficult migration from npm-lifecycle to @npmcli/run-script (because of lack of details from npm) we missed the fact (because it is undocumented) that npm-lifecycle actually maintains a queue for lifecycle processes and so even though they are eagerly invoked they will complete in series.

> This PR adds back some equivalent behavior to the new usage with @npmcli/run-script by utilizing the existing p-queue library that lerna depends upon.

> It also enables a streaming/process inheritance based approach for the "let lerna publish do all the things case".

## Motivation and Context
As per original Lerna PR 3262
> PS. This issue was discovered as a result of troubleshooting why it was that ionic needed to downgrade from v4 to v5 here: https://github.com/ionic-team/ionic-framework/pull/25497

> The reason this issue doesn't affect everyone in the same way as them is because ionic are running their whole build process via publish lifecycle scripts, instead of as a separate step before running publish (which is the more common pattern)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
