### PR TITLE
feat(publish): include all deps in package graph by default, allow no-sort

### DIFF
--- a/helpers/logging-output.ts
+++ b/helpers/logging-output.ts
@@ -1,6 +1,4 @@
-'use strict';
-
-const log = require('npmlog');
+import log from 'npmlog';
 import { multiLineTrimRight } from './index';
 
 // clear logs between tests

--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -1,0 +1,1 @@
+export * from './output';

--- a/packages/core/src/__mocks__/output.ts
+++ b/packages/core/src/__mocks__/output.ts
@@ -1,7 +1,5 @@
-'use strict';
-
-const chalk = require('chalk');
-const { multiLineTrimRight } = require('@lerna-test/helpers');
+import chalk from 'chalk';
+import { multiLineTrimRight } from '@lerna-test/helpers';
 
 // keep snapshots stable cross-platform
 chalk.level = 0;
@@ -9,7 +7,7 @@ chalk.level = 0;
 // @lerna/output is just a wrapper around console.log
 const mockOutput = jest.fn();
 
-function logged() {
+export function logged() {
   return mockOutput.mock.calls.map((args) => multiLineTrimRight(args[0])).join('\n');
 }
 

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -42,7 +42,7 @@ export class Command<T extends AvailableCommandOption> {
   concurrency!: number;
   envDefaults: any;
   sort: any;
-  toposort?: number;
+  toposort?: boolean;
 
   execOpts!: ExecOpts;
   commandName: CommandType = '';

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -187,7 +187,7 @@ export interface ProjectConfig extends LernaConfig, QueryGraphConfig {
   lernaVersion: string;
   progress?: boolean;
   since?: string;
-  sort?: any;
+  sort?: boolean;
   stream?: boolean;
   useNx?: boolean;
   onRejected?: (result: any) => void;

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -1,7 +1,6 @@
 import loadJsonFile from 'load-json-file';
 import npa from 'npm-package-arg';
 import npmlog from 'npmlog';
-import os from 'os';
 import path from 'path';
 import writePkg from 'write-pkg';
 

--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 // mocked modules of @lerna-lite/core
 jest.mock('@lerna-lite/core', () => ({
   ...jest.requireActual('@lerna-lite/core'), // return the other real methods, below we'll mock only 2 of the methods
@@ -29,7 +27,8 @@ import yargParser from 'yargs-parser';
 // mocked modules
 import writePkg from 'write-pkg';
 import { npmPublish } from '../lib/npm-publish';
-import { promptConfirmation, throwIfUncommitted } from '@lerna-lite/core';
+import { npmPublish as npmPublishMock } from '../lib/__mocks__/npm-publish';
+import { promptConfirmation, PublishCommandOption, throwIfUncommitted } from '@lerna-lite/core';
 
 // helpers
 import { gitAdd } from '@lerna-test/helpers';
@@ -57,7 +56,7 @@ const createArgv = (cwd, ...args) => {
   const parserArgs = args.join(' ');
   const argv = yargParser(parserArgs);
   argv['$0'] = cwd;
-  return argv;
+  return argv as unknown as PublishCommandOption;
 };
 
 async function initTaggedFixture(fixtureName, tagVersionPrefix = 'v') {
@@ -102,12 +101,12 @@ test('publish --canary', async () => {
   await new PublishCommand(createArgv(cwd, '--canary'));
 
   expect(promptConfirmation).toHaveBeenLastCalledWith('Are you sure you want to publish these packages?');
-  expect((npmPublish as any).registry).toMatchInlineSnapshot(`
+  expect((npmPublish as typeof npmPublishMock).registry).toMatchInlineSnapshot(`
   Map {
     "package-1" => "canary",
-    "package-3" => "canary",
     "package-4" => "canary",
     "package-2" => "canary",
+    "package-3" => "canary",
   }
   `);
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
@@ -131,12 +130,12 @@ test('publish --canary with auto-confirm --yes', async () => {
   await new PublishCommand(createArgv(cwd, '--canary', '--yes'));
 
   expect(promptConfirmation).not.toHaveBeenCalled();
-  expect((npmPublish as any).registry).toMatchInlineSnapshot(`
+  expect((npmPublish as typeof npmPublishMock).registry).toMatchInlineSnapshot(`
   Map {
     "package-1" => "canary",
-    "package-3" => "canary",
     "package-4" => "canary",
     "package-2" => "canary",
+    "package-3" => "canary",
   }
   `);
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`

--- a/packages/publish/src/lib/__mocks__/npm-publish.ts
+++ b/packages/publish/src/lib/__mocks__/npm-publish.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 const registry = new Map();
 
 // by default, act like a spy that populates registry
@@ -19,6 +17,9 @@ afterEach(() => {
   registry.clear();
 });
 
-module.exports.npmPublish = mockNpmPublish;
-module.exports.npmPublish.order = order;
-module.exports.npmPublish.registry = registry;
+export const npmPublish = mockNpmPublish as jest.Mock<Promise<void>, [pkg: any, tarData: any, opts: any]> & {
+  order: () => any[];
+  registry: Map<any, any>;
+};
+npmPublish.order = order;
+npmPublish.registry = registry;

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -65,6 +65,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
   runPackageLifecycle!: (pkg: Package, stage: string) => Promise<void>;
   runRootLifecycle!: (stage: string) => Promise<void> | void;
   verifyAccess?: boolean = false;
+  toposort = false;
   twoFactorAuthRequired = false;
   updates: PackageGraphNode[] = [];
   updatesVersions?: Map<string, any>;
@@ -85,6 +86,9 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
   configureProperties() {
     super.configureProperties();
+
+    // For publish we want to enable topological sorting by default, but allow users to override with --no-sort
+    this.toposort = this.options.sort !== false;
 
     // Defaults are necessary here because yargs defaults
     // override durable options provided by a config file
@@ -127,6 +131,13 @@ export class PublishCommand extends Command<PublishCommandOption> {
       this.logger.warn(
         'verify-access',
         '--verify-access=false and --no-verify-access are no longer needed, because the legacy preemptive access verification is now disabled by default. Requests will fail with appropriate errors when not authorized correctly.'
+      );
+    }
+
+    if (this.options.graphType === 'dependencies') {
+      this.logger.warn(
+        'graph-type',
+        '--graph-type=dependencies is deprecated and will be removed in the next major version of lerna-lite. If you have a use-case you feel requires it please open an issue to discuss: https://github.com/lerna/lerna/issues/new/choose'
       );
     }
 
@@ -701,15 +712,21 @@ export class PublishCommand extends Command<PublishCommandOption> {
   }
 
   topoMapPackages(mapper: (pkg: Package) => Promise<any>) {
-    // we don't respect --no-sort here, sorry
     return runTopologically(this.packagesToPublish, mapper, {
       concurrency: this.concurrency,
       rejectCycles: this.options.rejectCycles,
-      // By default, do not include devDependencies in the graph because it would
-      // increase the chance of dependency cycles, causing less-than-ideal order.
-      // If the user has opted-in to --graph-type=all (or 'graphType': 'all' in lerna.json),
-      // devDependencies _will_ be included in the graph construction.
-      graphType: this.options.graphType === 'all' ? 'allDependencies' : 'dependencies',
+      /**
+       * Previously `publish` had unique default behavior for graph creation vs other commands: it would only consider dependencies when finding
+       * edges by default (i.e. relationships between packages specified via devDependencies would be ignored). It was documented to be the case
+       * in order to try and reduce the chance of dependency cycles.
+       *
+       * We are removing this behavior altogether in v6 because we do not want to have different ways of constructing the graph,
+       * only different ways of utilizing it (e.g. --no-sort vs topological sort).
+       *
+       * Therefore until we remove graphType altogether in v6, we provide a way for users to opt into the old default behavior
+       * by setting the `graphType` option to `dependencies`.
+       */
+      graphType: this.options.graphType === 'dependencies' ? 'dependencies' : 'allDependencies',
     });
   }
 
@@ -752,7 +769,13 @@ export class PublishCommand extends Command<PublishCommandOption> {
       ).filter(Boolean)
     );
 
-    chain = chain.then(() => this.topoMapPackages(mapper));
+    chain = chain.then(() => {
+      if (this.toposort) {
+        return this.topoMapPackages(mapper);
+      }
+      return pMap(this.packagesToPublish, mapper, { concurrency: this.concurrency });
+    });
+
     chain = chain.then(() => removeTempLicenses(this.packagesToBeLicensed ?? []));
 
     // remove temporary license files if _any_ error occurs _anywhere_ in the promise chain
@@ -806,7 +829,12 @@ export class PublishCommand extends Command<PublishCommandOption> {
       ).filter(Boolean)
     );
 
-    chain = chain.then(() => this.topoMapPackages(mapper));
+    chain = chain.then(() => {
+      if (this.toposort) {
+        return this.topoMapPackages(mapper);
+      }
+      return pMap(this.packagesToPublish, mapper, { concurrency: this.concurrency });
+    });
 
     if (!this.hasRootedLeaf) {
       // cyclical 'publish' lifecycles are automatically skipped
@@ -848,7 +876,12 @@ export class PublishCommand extends Command<PublishCommandOption> {
         });
     };
 
-    chain = chain.then(() => this.topoMapPackages(mapper));
+    chain = chain.then(() => {
+      if (this.toposort) {
+        return this.topoMapPackages(mapper);
+      }
+      return pMap(this.packagesToPublish, mapper, { concurrency: this.concurrency });
+    });
 
     return chain.finally(() => tracker.finish());
   }

--- a/packages/tsconfig.bundle.json
+++ b/packages/tsconfig.bundle.json
@@ -23,5 +23,5 @@
     "sourceMap": true,
     "strict": true
   },
-  "exclude": ["**/*.spec.ts", "**/*.test.js", "**/*.test.ts"]
+  "exclude": ["**/*.spec.ts", "**/*.test.js", "**/*.test.ts", "**/__fixtures__/**/*.*", "**/__mocks__/**/*.*"]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -23,5 +23,12 @@
     "sourceMap": true,
     "strict": true
   },
-  "exclude": ["**/*.spec.js", "**/*.spec.ts", "**/*.test.js", "**/*.test.ts"]
+  "exclude": [
+    "**/*.spec.js",
+    "**/*.spec.ts",
+    "**/*.test.js",
+    "**/*.test.ts",
+    "**/__fixtures__/**/*.*",
+    "**/__mocks__/**/*.*"
+  ]
 }

--- a/packages/version/src/lib/__mocks__/write-pkg.ts
+++ b/packages/version/src/lib/__mocks__/write-pkg.ts
@@ -1,4 +1,4 @@
-import writePkg from 'write-pkg';
+const writePkg = jest.requireActual('write-pkg');
 const registry = new Map();
 
 // by default, act like a spy that populates registry

--- a/packages/version/src/lib/__mocks__/write-pkg.ts
+++ b/packages/version/src/lib/__mocks__/write-pkg.ts
@@ -1,6 +1,4 @@
-'use strict';
-
-const writePkg = jest.requireActual('write-pkg');
+import writePkg from 'write-pkg';
 const registry = new Map();
 
 // by default, act like a spy that populates registry


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
As per original Lerna [PR 3263](https://github.com/lerna/lerna/pull/3263)
> Users can still opt into the old behavior of ignoring `devDependencies` until v6 by passing `--graph-type=dependencies`, or setting it in their `lerna.json`.

> Note: For the unit test updates it's down to the fact that in the relevant fixture, `package-3` has a `devDependency` on `package-2`, so it now comes after it in the ordering.

## Motivation and Context

keep in sync with Lerna's codebase

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
