### PR TITLE
fix(publish): should only warn when using `--no-workspace-strict-match`

### DIFF
--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -242,7 +242,6 @@ describe('PublishCommand', () => {
       expect(logMessages).toMatchInlineSnapshot(`
         Array [
           "--graph-type=dependencies is deprecated and will be removed in the next major version of lerna-lite. If you have a use-case you feel requires it please open an issue to discuss: https://github.com/lerna/lerna/issues/new/choose",
-          "Providing --no-workspace-strict-match is deprecated and will be removed in future version, we will make \\"workspace:\\" protocol strict matching in every case.",
           "we recommend using --sync-workspace-lock which will sync your lock file via your favorite npm client instead of relying on Lerna-Lite itself to update it.",
         ]
       `);

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -141,7 +141,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
       );
     }
 
-    if (!this.options.workspaceStrictMatch) {
+    if (this.options.workspaceStrictMatch === false) {
       this.logger.warn(
         'deprecation',
         'Providing --no-workspace-strict-match is deprecated and will be removed in future version, we will make "workspace:" protocol strict matching in every case.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The warning about workspace strict match shouldn't be shown when the option is undefined

## Motivation and Context

The warning should really only be showing when directly using `--no-workspace-strict-match`, this fixes an issue identified in this [comment](https://github.com/ghiscoding/lerna-lite/pull/280#pullrequestreview-1056924413)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
