### PR TITLE
tests: add actual Profiler class in exec command unit tests

### DIFF
--- a/packages/exec/src/__tests__/exec-command.spec.ts
+++ b/packages/exec/src/__tests__/exec-command.spec.ts
@@ -6,6 +6,11 @@ jest.mock('@lerna-lite/core', () => ({
   spawnStreaming: jest.fn(() => Promise.resolve({ exitCode: 0 })),
 }));
 
+jest.mock('@lerna-lite/optional-cmd-common', () => ({
+  ...(jest.requireActual('@lerna-lite/optional-cmd-common') as any),
+  ...jest.requireActual('../../../optional-cmd-common/src/lib/profiler'), // test with the real Profiler for test coverage as well
+}));
+
 // also point to the local exec command so that all mocks are properly used even by the command-runner
 jest.mock('@lerna-lite/exec', () => jest.requireActual('../exec-command'));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add unit tests of `exec` command with the actual Profiler class implementation 

## Motivation and Context

increase unit test coverage by using the real Profiler class

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
