### PR TITLE
fix(version): get oldest commit data for changelog include commit login

### DIFF
--- a/packages/core/src/conventional-commits/get-commits-since-last-release.ts
+++ b/packages/core/src/conventional-commits/get-commits-since-last-release.ts
@@ -12,21 +12,21 @@ import { ValidationError } from '../validation-error';
  * @param {RemoteClientType} client
  * @param {String} gitRemote
  * @param {String} branchName
- * @param {ExecOpts} execOpts
+ * @param {ExecOpts} [execOpts]
  * @returns {Promise<RemoteCommit[]>}
  */
 export async function getCommitsSinceLastRelease(
   client: RemoteClientType,
   gitRemote: string,
   branchName: string,
-  execOpts: ExecOpts
+  execOpts?: ExecOpts
 ): Promise<RemoteCommit[]> {
   // get the last release tag date or the first commit date if no release tag found
-  const { tagDate } = getLastTagDetails(execOpts, false);
+  const { commitDate } = getOldestCommitSinceLastTag(execOpts, false);
 
   switch (client) {
     case 'github':
-      return getGithubCommits(gitRemote, branchName, tagDate, execOpts);
+      return getGithubCommits(gitRemote, branchName, commitDate, execOpts);
     case 'gitlab':
     default:
       throw new ValidationError(
@@ -37,26 +37,29 @@ export async function getCommitsSinceLastRelease(
 }
 
 /**
- * From the current branch, we will return the last tag date, sha and ref count
- * or else return it from the first commit of the current branch
+ * Find the oldest commit details since the last release tag or else if not tag exists then return first commit info
+ * @param {ExecOpts} [execOpts]
+ * @param {Boolean} [includeMergedTags]
+ * @returns {*} - oldest commit detail (hash, date)
  */
-export function getLastTagDetails(execOpts: ExecOpts, includeMergedTags?: boolean) {
-  let execResult = '';
+export function getOldestCommitSinceLastTag(execOpts?: ExecOpts, includeMergedTags?: boolean) {
+  let commitResult = '';
   const describeOptions: DescribeRefOptions = { ...execOpts };
-  const { refCount, lastTagName } = describeRefSync(describeOptions, includeMergedTags);
+  const { lastTagName } = describeRefSync(describeOptions, includeMergedTags);
 
   if (lastTagName) {
-    log.silly('git', 'getCurrentBranchLastTagDateSha');
-    execResult = execSync('git', ['log', '-1', '--format="%h %cI"', lastTagName], execOpts);
+    log.silly('git', 'getCurrentBranchOldestCommitSinceLastTag');
+    const stdout = execSync('git', ['log', `${lastTagName}..HEAD`, '--format="%h %cI"', '--reverse'], execOpts);
+    [commitResult] = stdout.split('\n');
   } else {
-    log.silly('git', 'getCurrentBranchFirstCommitDateSha');
-    execResult = execSync(
+    log.silly('git', 'getCurrentBranchFirstCommit');
+    commitResult = execSync(
       'git',
       ['log', '--oneline', '--format="%h %cI"', '--reverse', '--max-parents=0', 'HEAD'],
       execOpts
     );
   }
 
-  const [_, tagHash, tagDate] = /^"?([0-9a-f]+)\s([0-9\-T\:]*)"?$/.exec(execResult) || [];
-  return { tagHash, tagDate, tagRefCount: refCount };
+  const [, commitHash, commitDate] = /^"?([0-9a-f]+)\s([0-9\-T\:]*)"?$/.exec(commitResult) || [];
+  return { commitHash, commitDate };
 }

--- a/packages/core/src/conventional-commits/get-github-commits.ts
+++ b/packages/core/src/conventional-commits/get-github-commits.ts
@@ -19,7 +19,7 @@ export async function getGithubCommits(
   gitRemote: string,
   branchName: string,
   sinceDate: string,
-  execOpts: ExecOpts
+  execOpts?: ExecOpts
 ): Promise<RemoteCommit[]> {
   const repo = parseGitRepo(gitRemote, execOpts);
   const octokit = createGitHubClient();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using `lerna version --changelog-include-commits-client-login`, it wasn't always including all commits info and the reason is simply because I could have Pull Request that only get merged after a new release/tag and so these commits become older than the tag date so I cannot rely solely on the tag date.

## Motivation and Context

In some cases where a Pull Request might be created in between 2 tags but only released after the last tag, the commits details were not included because the commit timestamp was older than the tag timestamp and so client login were not found for these in between PRs. This PR fixes this issue by finding the oldest commit since the last tag instead of looking solely on the tag timestamp which was not always correct.

Note

The new code to find oldest commit might not be the most efficient way of pulling the oldest commit and for that reason I asked a question in that regard on Stack Overflow [Get date of oldest git commit since last git tag](https://stackoverflow.com/questions/73245203/get-date-of-oldest-git-commit-since-last-git-tag) and there were no good solution posted yet so I might have to keep what I have. I'll wait couple days before merging to see if any good solution comes up (for a more efficient single git command).

## How Has This Been Tested?

adjusted previous unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
