### PR TITLE
fix(version): commit user login, oldest commit might be undefined

### DIFF
--- a/packages/core/src/conventional-commits/get-commits-since-last-release.ts
+++ b/packages/core/src/conventional-commits/get-commits-since-last-release.ts
@@ -49,7 +49,11 @@ export function getOldestCommitSinceLastTag(execOpts?: ExecOpts, includeMergedTa
 
   if (lastTagName) {
     log.silly('git', 'getCurrentBranchOldestCommitSinceLastTag');
-    const stdout = execSync('git', ['log', `${lastTagName}..HEAD`, '--format="%h %cI"', '--reverse'], execOpts);
+    let stdout = execSync('git', ['log', `${lastTagName}..HEAD`, '--format="%h %cI"', '--reverse'], execOpts);
+    if (!stdout) {
+      // in some occasion the previous git command might return nothing, in that case we'll return the tag detail instead
+      stdout = execSync('git', ['log', '-1', '--format="%h %cI"', lastTagName], execOpts);
+    }
     [commitResult] = stdout.split('\n');
   } else {
     log.silly('git', 'getCurrentBranchFirstCommit');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using option `--changelog-include-commits-client-login` we are executing a git command to identify the oldest commits since the last release, however in some cases it might return nothing, in that case we will return the tag info instead.

## Motivation and Context

Fix an issue identified after running a dry-run of a release on the same day and that returned nothing, when that happens we should return the tag info.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
