### PR TITLE
fix(version): use `%aI` to pull oldest commit author date

### DIFF
--- a/packages/core/src/conventional-commits/__tests__/get-commits-since-last-release.spec.ts
+++ b/packages/core/src/conventional-commits/__tests__/get-commits-since-last-release.spec.ts
@@ -63,7 +63,7 @@ describe('getOldestCommitSinceLastTag', () => {
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
-        ['log', '--oneline', '--format="%h %cI"', '--reverse', '--max-parents=0', 'HEAD'],
+        ['log', '--oneline', '--format="%h %aI"', '--reverse', '--max-parents=0', 'HEAD'],
         execOpts
       );
       expect(result).toEqual({ commitDate: '2022-07-01T00:01:02-04:00', commitHash: 'abcbeef' });
@@ -82,8 +82,8 @@ describe('getOldestCommitSinceLastTag', () => {
 
       const result = await getOldestCommitSinceLastTag(execOpts);
 
-      expect(execSpy).toHaveBeenCalledWith('git', ['log', 'v1.0.0..HEAD', '--format="%h %cI"', '--reverse'], execOpts);
-      expect(execSpy).toHaveBeenCalledWith('git', ['log', '-1', '--format="%h %cI"', 'v1.0.0'], execOpts);
+      expect(execSpy).toHaveBeenCalledWith('git', ['log', 'v1.0.0..HEAD', '--format="%h %aI"', '--reverse'], execOpts);
+      expect(execSpy).toHaveBeenCalledWith('git', ['log', '-1', '--format="%h %aI"', 'v1.0.0'], execOpts);
       expect(result).toEqual({ commitDate: '2022-07-01T00:01:02-04:00', commitHash: 'deedbeaf' });
     });
 
@@ -91,7 +91,7 @@ describe('getOldestCommitSinceLastTag', () => {
       const result = await getOldestCommitSinceLastTag(execOpts);
       const execSpy = (execSync as jest.Mock).mockReturnValueOnce('"deadbeef 2022-07-01T00:01:02-04:00"');
 
-      expect(execSpy).toHaveBeenCalledWith('git', ['log', 'v1.0.0..HEAD', '--format="%h %cI"', '--reverse'], execOpts);
+      expect(execSpy).toHaveBeenCalledWith('git', ['log', 'v1.0.0..HEAD', '--format="%h %aI"', '--reverse'], execOpts);
       expect(result).toEqual({ commitDate: '2022-07-01T00:01:02-04:00', commitHash: 'deadbeef' });
     });
   });

--- a/packages/core/src/conventional-commits/get-commits-since-last-release.ts
+++ b/packages/core/src/conventional-commits/get-commits-since-last-release.ts
@@ -49,17 +49,17 @@ export function getOldestCommitSinceLastTag(execOpts?: ExecOpts, includeMergedTa
 
   if (lastTagName) {
     log.silly('git', 'getCurrentBranchOldestCommitSinceLastTag');
-    let stdout = execSync('git', ['log', `${lastTagName}..HEAD`, '--format="%h %cI"', '--reverse'], execOpts);
+    let stdout = execSync('git', ['log', `${lastTagName}..HEAD`, '--format="%h %aI"', '--reverse'], execOpts);
     if (!stdout) {
       // in some occasion the previous git command might return nothing, in that case we'll return the tag detail instead
-      stdout = execSync('git', ['log', '-1', '--format="%h %cI"', lastTagName], execOpts);
+      stdout = execSync('git', ['log', '-1', '--format="%h %aI"', lastTagName], execOpts);
     }
     [commitResult] = stdout.split('\n');
   } else {
     log.silly('git', 'getCurrentBranchFirstCommit');
     commitResult = execSync(
       'git',
-      ['log', '--oneline', '--format="%h %cI"', '--reverse', '--max-parents=0', 'HEAD'],
+      ['log', '--oneline', '--format="%h %aI"', '--reverse', '--max-parents=0', 'HEAD'],
       execOpts
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We should use `%aI` commit author date which is not the one we're interested in.

## Motivation and Context

We should use `%aI` (commit author date) instead of `%cI` because the author commit is really the person who created the commit while the `%c` is the committer which is not the one we're interested in.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
