### PR TITLE
feat(cli): add JSON Schema for `lerna.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,15 @@ Run the following commands to install Lerna-Lite in your project and/or install 
 If you are new to Lerna-Lite, you could also run the [lerna init](https://github.com/ghiscoding/lerna-lite/tree/main/packages/init#readme) command which will create the `lerna.json` for you with a minimal setup. If you are using a different client other than npm, then make sure to update the `npmClient` property in `lerna.json` (for example: `"npmClient": "yarn"`).
 
 ### JSON Schema
-You can add Lerna-Lite [JSON Schema](https://json-schema.org/) to your `lerna.json` with the `$schema` property (`lerna init` will automatically configure this for you). This will help with the developer experience, users can see what properties are valid with a brief description of what they do (taken from the lerna command options documentation). You can take a look at Lerna-Lite [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) config file for a demo.
+You can add the `$schema` property into your `lerna.json` to take advantage of Lerna-Lite [JSON Schema](https://json-schema.org/) (`lerna init` will automatically configure this for you). This will help with the developer experience, users can see what properties are valid with a brief description of what they do (taken from the lerna command options documentation).
+
+##### `lerna.json`
+```js
+{
+  "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
+  // ...
+}
+```
 
 ### CLI Installation
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ Mainly for the following reasons:
 1. original Lerna repo was unmaintained for nearly 2 years (dependencies were out of date)
     - this is no longer true since Nrwl took over stewardship of Lerna, but the next few points are still valid
     - keep PRs in sync with original Lerna
-2. certain desire to create a smaller and more modular lib that is lighter than the original all-in-one Lerna
+2. desire to create a smaller and more modular lib that is lighter than the original all-in-one Lerna
     - it's smaller since we only copied half of Lerna's commands and many of them are totally optional.
     - we don't need `bootstrap` anymore since Workspaces are supported by all package managers.
     - the main goal of this fork was to keep only `version` and `publish` commands in the core and make everything else optional (choose and install what you really need).
 3. rewrite the lib in TypeScript
 4. replicate a few opened PRs (fixes and features) from Lerna and also add extra features in Lerna-Lite
-    - for example we now support the `workspace:` protocol and some `dry-run` options
-5. Lerna v5+ is now installing **[Nx](https://nx.dev/)** as a required [dependency](https://github.com/lerna/lerna/blob/main/core/lerna/package.json#L57) while Lerna-Lite **does not**
-    - even if [Nx](https://nx.dev/) could be a nice addition with [`useNx`](https://github.com/ghiscoding/lerna-lite/tree/main/packages/run#usenx-experimental), it should and will always be optional in Lerna-Lite. You get to chose, we are not enforcing anything.
+    - for example we now support the `workspace:` protocol, changelog headers and some `dry-run` options
+5. Lerna v5+ is now installing **[Nx](https://nx.dev/)** as a required [dependency](https://github.com/lerna/lerna/blob/main/core/lerna/package.json#L57) while it remains optional in Lerna-Lite
+    - even if [Nx](https://nx.dev/) could be a nice addition with [`useNx`](https://github.com/ghiscoding/lerna-lite/tree/main/packages/run#usenx-experimental), it should and will always be optional in Lerna-Lite. You still get to choose.
 
 ### This lib will help you with
 
@@ -136,7 +136,7 @@ Run the following commands to install Lerna-Lite in your project and/or install 
 If you are new to Lerna-Lite, you could also run the [lerna init](https://github.com/ghiscoding/lerna-lite/tree/main/packages/init#readme) command which will create the `lerna.json` for you with a minimal setup. If you are using a different client other than npm, then make sure to update the `npmClient` property in `lerna.json` (for example: `"npmClient": "yarn"`).
 
 ### JSON Schema
-Lerna-Lite [JSON Schema](https://json-schema.org/) can be added to your `lerna.json` with the `$schema` property (this will be configured automatically when using `lerna init`). This will help the developer experience, users can see what properties are valid and a brief description of what they do (taken from the lerna command options documentation). You can consult [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) of Lerna-Lite for a demo.
+You can add Lerna-Lite [JSON Schema](https://json-schema.org/) to your `lerna.json` with the `$schema` property (this will be configured automatically when using `lerna init`). This will help with the developer experience, users can see what properties are valid with a brief description of what they do (taken from the lerna command options documentation). You can take a look at Lerna-Lite [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) config file for a demo.
 
 ### CLI Installation
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Run the following commands to install Lerna-Lite in your project and/or install 
 If you are new to Lerna-Lite, you could also run the [lerna init](https://github.com/ghiscoding/lerna-lite/tree/main/packages/init#readme) command which will create the `lerna.json` for you with a minimal setup. If you are using a different client other than npm, then make sure to update the `npmClient` property in `lerna.json` (for example: `"npmClient": "yarn"`).
 
 ### JSON Schema
-You can add a [JSON Schema](https://json-schema.org/) by adding the `$schema` property to your `lerna.json` config file (this will be configured automatically when using `lerna init`). This will help the developer experience, users can see what properties are valid and a brief description of what they do (taken from the lerna command options documentation). You can consult [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) of Lerna-Lite for a demo.
+Lerna-Lite [JSON Schema](https://json-schema.org/) can be added to your `lerna.json` with the `$schema` property (this will be configured automatically when using `lerna init`). This will help the developer experience, users can see what properties are valid and a brief description of what they do (taken from the lerna command options documentation). You can consult [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) of Lerna-Lite for a demo.
 
 ### CLI Installation
 

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ Mainly for the following reasons:
 
 1. original Lerna repo was unmaintained for nearly 2 years (dependencies were out of date)
     - this is no longer true since Nrwl took over stewardship of Lerna, but the next few points are still valid
-    - keep PRs in sync with original Lerna
-2. desire to create a smaller and more modular lib that is lighter than the original all-in-one Lerna
+    - we now keep PRs in sync with the original Lerna
+2. a desire to create a smaller and more modular lib that is lighter than the original all-in-one Lerna
     - it's smaller since we only copied half of Lerna's commands and many of them are totally optional.
     - we don't need `bootstrap` anymore since Workspaces are supported by all package managers.
     - the main goal of this fork was to keep only `version` and `publish` commands in the core and make everything else optional (choose and install what you really need).
-3. rewrite the lib in TypeScript
+3. rewrite the lib in TypeScript for type checking and to be compatible with ESM
 4. replicate a few opened PRs (fixes and features) from Lerna and also add extra features in Lerna-Lite
-    - for example we now support the `workspace:` protocol, changelog headers and some `dry-run` options
-5. Lerna v5+ is now installing **[Nx](https://nx.dev/)** as a required [dependency](https://github.com/lerna/lerna/blob/main/core/lerna/package.json#L57) while it remains optional in Lerna-Lite
-    - even if [Nx](https://nx.dev/) could be a nice addition with [`useNx`](https://github.com/ghiscoding/lerna-lite/tree/main/packages/run#usenx-experimental), it should and will always be optional in Lerna-Lite. You still get to choose.
+    - for example we now support the `workspace:` protocol, we added changelog headers and some `dry-run` options
+5. Lerna v5+ is now installing **[Nx](https://nx.dev/)** as a required [dependency](https://github.com/lerna/lerna/blob/main/core/lerna/package.json#L57) while it remains **optional** in Lerna-Lite
+    - even if [Nx](https://nx.dev/) could be a nice addition with [`useNx`](https://github.com/ghiscoding/lerna-lite/tree/main/packages/run#usenx-experimental) option, it should and will always be optional in Lerna-Lite. You still get to choose.
 
 ### This lib will help you with
 
@@ -136,7 +136,7 @@ Run the following commands to install Lerna-Lite in your project and/or install 
 If you are new to Lerna-Lite, you could also run the [lerna init](https://github.com/ghiscoding/lerna-lite/tree/main/packages/init#readme) command which will create the `lerna.json` for you with a minimal setup. If you are using a different client other than npm, then make sure to update the `npmClient` property in `lerna.json` (for example: `"npmClient": "yarn"`).
 
 ### JSON Schema
-You can add Lerna-Lite [JSON Schema](https://json-schema.org/) to your `lerna.json` with the `$schema` property (this will be configured automatically when using `lerna init`). This will help with the developer experience, users can see what properties are valid with a brief description of what they do (taken from the lerna command options documentation). You can take a look at Lerna-Lite [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) config file for a demo.
+You can add Lerna-Lite [JSON Schema](https://json-schema.org/) to your `lerna.json` with the `$schema` property (`lerna init` will automatically configure this for you). This will help with the developer experience, users can see what properties are valid with a brief description of what they do (taken from the lerna command options documentation). You can take a look at Lerna-Lite [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) config file for a demo.
 
 ### CLI Installation
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - [Why create this lib/fork?](#why-create-this-libfork)
 - [Getting Started](#getting-started)
   - [Installation](#installation)
+  - [JSON Schema](#json-schema)
   - [Migration for existing Lerna users](#migration-for-existing-lerna-users)
 - [Project Demo - See it in Action](https://github.com/ghiscoding/lerna-lite/wiki/Release-Demo)
 - [README Badge](#readme-badge)

--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ Mainly for the following reasons:
 1. original Lerna repo was unmaintained for nearly 2 years (dependencies were out of date)
     - this is no longer true since Nrwl took over stewardship of Lerna, but the next few points are still valid
     - keep PRs in sync with original Lerna
-2. desire to create a smaller lib that is more modular and lighter than the original all-in-one Lerna
-    - it's smaller since we only copied half of Lerna's commands and a few are totally optional.
-    - we don't need all of Lerna's packages anymore since Workspaces are supported by all package managers.
-    - the main starting goal of this fork was to keep only `version` and `publish` commands in the core and make everything else optional (install and use only what you really need).
+2. certain desire to create a smaller and more modular lib that is lighter than the original all-in-one Lerna
+    - it's smaller since we only copied half of Lerna's commands and many of them are totally optional.
+    - we don't need `bootstrap` anymore since Workspaces are supported by all package managers.
+    - the main goal of this fork was to keep only `version` and `publish` commands in the core and make everything else optional (choose and install what you really need).
 3. rewrite the lib in TypeScript
 4. replicate a few opened PRs (fixes and features) from Lerna and also add extra features in Lerna-Lite
     - for example we now support the `workspace:` protocol and some `dry-run` options
-5. Lerna v5+ is now installing **[Nx](https://nx.dev/)** as a required [dependency](https://github.com/lerna/lerna/blob/main/core/lerna/package.json#L57) while Lerna-Lite **does not**, it remains optional
-    - we did add the `useNx` option into Lerna-Lite, but even if [Nx](https://nx.dev/) is a nice lib, it should remain optional and it is in here.
+5. Lerna v5+ is now installing **[Nx](https://nx.dev/)** as a required [dependency](https://github.com/lerna/lerna/blob/main/core/lerna/package.json#L57) while Lerna-Lite **does not**
+    - even if [Nx](https://nx.dev/) could be a nice addition with [`useNx`](https://github.com/ghiscoding/lerna-lite/tree/main/packages/run#usenx-experimental), it should and will always be optional in Lerna-Lite. You get to chose, we are not enforcing anything.
 
 ### This lib will help you with
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ Note that `package-a` will not be created, it is only shown shown here to help c
 
 Run the following commands to install Lerna-Lite in your project and/or install it globally by adding the `-g` option.
 
-If you are new to Lerna-Lite, you could also run the [lerna init](https://github.com/ghiscoding/lerna-lite/tree/main/packages/init#readme) command which will create the `lerna.json` for you. If you are using a different client other than npm, then make sure to update the `npmClient` property in `lerna.json` (for example: `"npmClient": "yarn"`).
+If you are new to Lerna-Lite, you could also run the [lerna init](https://github.com/ghiscoding/lerna-lite/tree/main/packages/init#readme) command which will create the `lerna.json` for you with a minimal setup. If you are using a different client other than npm, then make sure to update the `npmClient` property in `lerna.json` (for example: `"npmClient": "yarn"`).
+
+### JSON Schema
+You can add a [JSON Schema](https://json-schema.org/) by adding the `$schema` property to your `lerna.json` config file (this will be configured automatically when using `lerna init`). This will help the developer experience, users can see what properties are valid and a brief description of what they do (taken from the lerna command options documentation). You can consult [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) of Lerna-Lite for a demo.
 
 ### CLI Installation
 
@@ -205,7 +208,7 @@ npm install @lerna-lite/run -D -W
 
 You want to see a project demo? Sure, you're looking at it 😉
 
-Yes indeed, this lib was originally created as an NPM Workspace and later changed to a [pnpm workspaces](https://pnpm.io/workspaces) for the sole purpose of demoing and testing its own code. All changelogs and published versions are created and published by the lib itself, how sweet is that? You will also find that Lerna-Lite project has its own [lerna.json](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) config file to run properly (take a look to see how it works).
+Yes indeed, this lib was originally created as an NPM Workspace and later changed to a [pnpm workspaces](https://pnpm.io/workspaces) for the sole purpose of demoing and testing its own code. All changelogs and published versions are created and published by the lib itself, how sweet is that? You will also find that Lerna-Lite project has its own [`lerna.json`](https://github.com/ghiscoding/lerna-lite/blob/main/lerna.json) config file to run properly (take a look to see how it works).
 
 ### See it in Action 🎦
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,18 +1,16 @@
 {
+  "$schema": "node_modules/@lerna-lite/cli/schemas/lerna-schema.json",
   "version": "1.10.0",
   "loglevel": "verbose",
   "npmClient": "pnpm",
   "command": {
-    "publish": {
-      "conventionalCommits": true
-    },
     "version": {
       "conventionalCommits": true,
       "createRelease": "github",
       "gitDryRun": false,
       "syncWorkspaceLock": true,
       "changelogIncludeCommitsClientLogin": " - by @%l",
-      "changelogHeaderMessage": "### Automate your Workspace Versioning, Publishing & Changelog updates with [Lerna-Lite](https://github.com/ghiscoding/lerna-lite) 🚀",
+      "changelogHeaderMessage": "### Automate your Workspace Versioning, Publishing & Changelog updates with [Lerna-Lite](https://github.com/ghiscoding/lerna-lite) 📦🚀",
       "message": "chore(release): publish new version %v"
     },
     "run": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,8 @@
     "lerna": "dist/cli.js"
   },
   "files": [
-    "/dist"
+    "/dist",
+    "schemas/lerna-schema.json"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1266,11 +1266,11 @@
           "description": "During `lerna version`, add a custom message at the top of your \"changelog.md\" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs."
         },
         "changelogIncludeCommitsGitAuthor": {
-          "type": "string",
+          "anyOf": [{ "type": "string" }, { "type": "boolean" }],
           "description": "During `lerna version`, specify if we want to include the commit author's name, this option is only available when using --conventional-commits with changelogs. We can also optionally provide a custom message or else a default format will be used."
         },
         "changelogIncludeCommitsClientLogin": {
-          "type": "string",
+          "anyOf": [{ "type": "string" }, { "type": "boolean" }],
           "description": "During `lerna version`, specify if we want to include the commit remote client login name (ie GitHub username), this option is only available when using --conventional-commits with changelogs. We can also optionally provide a custom message or else a default format will be used."
         },
         "changelogVersionMessage": {

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1,0 +1,1449 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://lerna.js.org/docs/getting-started#adding-lerna",
+  "title": "JSON schema for Lerna configuration",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "The version of the repository, or \"independent\" for a repository with independently versioned packages.",
+      "default": "0.0.0"
+    },
+    "packages": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "uniqueItems": true
+      },
+      "description": "An array of globs where packages can be located.",
+      "default": ["packages/*"]
+    },
+    "useNx": {
+      "type": "boolean",
+      "description": "When true, Lerna will delegate the implementation details of `lerna run` to the Nx task runner, instead of p-map or p-queue.",
+      "default": false
+    },
+    "command": {
+      "type": "object",
+      "description": "Options for individual Lerna commands.",
+      "properties": {
+        "changed": {
+          "type": "object",
+          "description": "Options for the `changed` command.",
+          "properties": {
+            "conventionalCommits": {
+              "$ref": "#/$defs/commandOptions/shared/conventionalCommits"
+            },
+            "conventionalGraduate": {
+              "$ref": "#/$defs/commandOptions/shared/conventionalGraduate"
+            },
+            "forcePublish": {
+              "$ref": "#/$defs/commandOptions/shared/forcePublish"
+            },
+            "ignoreChanges": {
+              "$ref": "#/$defs/commandOptions/shared/ignoreChanges"
+            },
+            "npmClient": {
+              "$ref": "#/$defs/globals/npmClient"
+            },
+            "loglevel": {
+              "$ref": "#/$defs/globals/loglevel"
+            },
+            "concurrency": {
+              "$ref": "#/$defs/globals/concurrency"
+            },
+            "rejectCycles": {
+              "$ref": "#/$defs/globals/rejectCycles"
+            },
+            "progress": {
+              "$ref": "#/$defs/globals/progress"
+            },
+            "sort": {
+              "$ref": "#/$defs/globals/sort"
+            },
+            "maxBuffer": {
+              "$ref": "#/$defs/globals/maxBuffer"
+            },
+            "yes": {
+              "$ref": "#/$defs/globals/yes"
+            },
+
+            "scope": {
+              "$ref": "#/$defs/filters/scope"
+            },
+            "ignore": {
+              "$ref": "#/$defs/filters/ignore"
+            },
+            "private": {
+              "$ref": "#/$defs/filters/private"
+            },
+            "since": {
+              "$ref": "#/$defs/filters/since"
+            },
+            "excludeDependents": {
+              "$ref": "#/$defs/filters/excludeDependents"
+            },
+            "includeDependents": {
+              "$ref": "#/$defs/filters/includeDependents"
+            },
+            "includeDependencies": {
+              "$ref": "#/$defs/filters/includeDependencies"
+            },
+            "includeMergedTags": {
+              "$ref": "#/$defs/filters/includeMergedTags"
+            },
+            "continueIfNoMatch": {
+              "$ref": "#/$defs/filters/continueIfNoMatch"
+            }
+          }
+        },
+        "diff": {
+          "type": "object",
+          "description": "Options for the `diff` command.",
+          "properties": {
+            "ignoreChanges": {
+              "$ref": "#/$defs/commandOptions/shared/ignoreChanges"
+            },
+
+            "npmClient": {
+              "$ref": "#/$defs/globals/npmClient"
+            },
+            "loglevel": {
+              "$ref": "#/$defs/globals/loglevel"
+            },
+            "concurrency": {
+              "$ref": "#/$defs/globals/concurrency"
+            },
+            "rejectCycles": {
+              "$ref": "#/$defs/globals/rejectCycles"
+            },
+            "progress": {
+              "$ref": "#/$defs/globals/progress"
+            },
+            "sort": {
+              "$ref": "#/$defs/globals/sort"
+            },
+            "maxBuffer": {
+              "$ref": "#/$defs/globals/maxBuffer"
+            },
+            "yes": {
+              "$ref": "#/$defs/globals/yes"
+            },
+
+            "scope": {
+              "$ref": "#/$defs/filters/scope"
+            },
+            "ignore": {
+              "$ref": "#/$defs/filters/ignore"
+            },
+            "private": {
+              "$ref": "#/$defs/filters/private"
+            },
+            "since": {
+              "$ref": "#/$defs/filters/since"
+            },
+            "excludeDependents": {
+              "$ref": "#/$defs/filters/excludeDependents"
+            },
+            "includeDependents": {
+              "$ref": "#/$defs/filters/includeDependents"
+            },
+            "includeDependencies": {
+              "$ref": "#/$defs/filters/includeDependencies"
+            },
+            "includeMergedTags": {
+              "$ref": "#/$defs/filters/includeMergedTags"
+            },
+            "continueIfNoMatch": {
+              "$ref": "#/$defs/filters/continueIfNoMatch"
+            }
+          }
+        },
+        "exec": {
+          "type": "object",
+          "description": "Options for the `exec` command.",
+          "properties": {
+            "cmdDryRun": {
+              "$ref": "#/$defs/commandOptions/exec/cmdDryRun"
+            },
+            "stream": {
+              "$ref": "#/$defs/commandOptions/shared/stream"
+            },
+            "parallel": {
+              "$ref": "#/$defs/commandOptions/shared/parallel"
+            },
+            "noBail": {
+              "$ref": "#/$defs/commandOptions/shared/noBail"
+            },
+            "bail": {
+              "$ref": "#/$defs/commandOptions/shared/bail"
+            },
+            "noPrefix": {
+              "$ref": "#/$defs/commandOptions/shared/noPrefix"
+            },
+            "prefix": {
+              "$ref": "#/$defs/commandOptions/shared/prefix"
+            },
+            "profile": {
+              "$ref": "#/$defs/commandOptions/shared/profile"
+            },
+            "profileLocation": {
+              "$ref": "#/$defs/commandOptions/shared/profileLocation"
+            },
+
+            "npmClient": {
+              "$ref": "#/$defs/globals/npmClient"
+            },
+            "loglevel": {
+              "$ref": "#/$defs/globals/loglevel"
+            },
+            "concurrency": {
+              "$ref": "#/$defs/globals/concurrency"
+            },
+            "rejectCycles": {
+              "$ref": "#/$defs/globals/rejectCycles"
+            },
+            "progress": {
+              "$ref": "#/$defs/globals/progress"
+            },
+            "sort": {
+              "$ref": "#/$defs/globals/sort"
+            },
+            "maxBuffer": {
+              "$ref": "#/$defs/globals/maxBuffer"
+            },
+            "yes": {
+              "$ref": "#/$defs/globals/yes"
+            },
+
+            "scope": {
+              "$ref": "#/$defs/filters/scope"
+            },
+            "ignore": {
+              "$ref": "#/$defs/filters/ignore"
+            },
+            "private": {
+              "$ref": "#/$defs/filters/private"
+            },
+            "since": {
+              "$ref": "#/$defs/filters/since"
+            },
+            "excludeDependents": {
+              "$ref": "#/$defs/filters/excludeDependents"
+            },
+            "includeDependents": {
+              "$ref": "#/$defs/filters/includeDependents"
+            },
+            "includeDependencies": {
+              "$ref": "#/$defs/filters/includeDependencies"
+            },
+            "includeMergedTags": {
+              "$ref": "#/$defs/filters/includeMergedTags"
+            },
+            "continueIfNoMatch": {
+              "$ref": "#/$defs/filters/continueIfNoMatch"
+            }
+          }
+        },
+        "init": {
+          "type": "object",
+          "description": "Options for the `init` command.",
+          "properties": {
+            "exact": {
+              "$ref": "#/$defs/commandOptions/shared/exact"
+            },
+            "independent": {
+              "$ref": "#/$defs/commandOptions/init/independent"
+            },
+            "useWorkspaces": {
+              "$ref": "#/$defs/commandOptions/init/useWorkspaces"
+            }
+          }
+        },
+        "list": {
+          "type": "object",
+          "description": "Options for the `list` command.",
+          "properties": {
+            "npmClient": {
+              "$ref": "#/$defs/globals/npmClient"
+            },
+            "loglevel": {
+              "$ref": "#/$defs/globals/loglevel"
+            },
+            "concurrency": {
+              "$ref": "#/$defs/globals/concurrency"
+            },
+            "rejectCycles": {
+              "$ref": "#/$defs/globals/rejectCycles"
+            },
+            "progress": {
+              "$ref": "#/$defs/globals/progress"
+            },
+            "sort": {
+              "$ref": "#/$defs/globals/sort"
+            },
+            "maxBuffer": {
+              "$ref": "#/$defs/globals/maxBuffer"
+            },
+            "yes": {
+              "$ref": "#/$defs/globals/yes"
+            },
+
+            "scope": {
+              "$ref": "#/$defs/filters/scope"
+            },
+            "ignore": {
+              "$ref": "#/$defs/filters/ignore"
+            },
+            "private": {
+              "$ref": "#/$defs/filters/private"
+            },
+            "since": {
+              "$ref": "#/$defs/filters/since"
+            },
+            "excludeDependents": {
+              "$ref": "#/$defs/filters/excludeDependents"
+            },
+            "includeDependents": {
+              "$ref": "#/$defs/filters/includeDependents"
+            },
+            "includeDependencies": {
+              "$ref": "#/$defs/filters/includeDependencies"
+            },
+            "includeMergedTags": {
+              "$ref": "#/$defs/filters/includeMergedTags"
+            },
+            "continueIfNoMatch": {
+              "$ref": "#/$defs/filters/continueIfNoMatch"
+            }
+          }
+        },
+        "publish": {
+          "type": "object",
+          "description": "Options for the `publish` command.",
+          "properties": {
+            "canary": {
+              "$ref": "#/$defs/commandOptions/publish/canary"
+            },
+            "preid": {
+              "$ref": "#/$defs/commandOptions/shared/preid"
+            },
+            "contents": {
+              "$ref": "#/$defs/commandOptions/shared/contents"
+            },
+            "distTag": {
+              "$ref": "#/$defs/commandOptions/publish/distTag"
+            },
+            "legacyAuth": {
+              "$ref": "#/$defs/commandOptions/publish/legacyAuth"
+            },
+            "preDistTag": {
+              "$ref": "#/$defs/commandOptions/publish/preDistTag"
+            },
+            "gitHead": {
+              "$ref": "#/$defs/commandOptions/publish/gitHead"
+            },
+            "graphType": {
+              "$ref": "#/$defs/commandOptions/publish/graphType"
+            },
+            "ignorePrepublish": {
+              "$ref": "#/$defs/commandOptions/shared/ignorePrepublish"
+            },
+            "ignoreScripts": {
+              "$ref": "#/$defs/commandOptions/shared/ignoreScripts"
+            },
+            "noGranularPathspec": {
+              "$ref": "#/$defs/commandOptions/shared/noGranularPathspec"
+            },
+            "granularPathspec": {
+              "$ref": "#/$defs/commandOptions/shared/granularPathspec"
+            },
+            "otp": {
+              "$ref": "#/$defs/commandOptions/publish/otp"
+            },
+            "registry": {
+              "$ref": "#/$defs/commandOptions/shared/registry"
+            },
+            "requireScripts": {
+              "$ref": "#/$defs/commandOptions/publish/requireScripts"
+            },
+            "noGitReset": {
+              "$ref": "#/$defs/commandOptions/publish/noGitReset"
+            },
+            "gitReset": {
+              "$ref": "#/$defs/commandOptions/publish/gitReset"
+            },
+            "tempTag": {
+              "$ref": "#/$defs/commandOptions/publish/tempTag"
+            },
+            "noVerifyAccess": {
+              "$ref": "#/$defs/commandOptions/publish/noVerifyAccess"
+            },
+            "verifyAccess": {
+              "$ref": "#/$defs/commandOptions/publish/verifyAccess"
+            },
+
+            "npmClient": {
+              "$ref": "#/$defs/globals/npmClient"
+            },
+            "loglevel": {
+              "$ref": "#/$defs/globals/loglevel"
+            },
+            "concurrency": {
+              "$ref": "#/$defs/globals/concurrency"
+            },
+            "rejectCycles": {
+              "$ref": "#/$defs/globals/rejectCycles"
+            },
+            "progress": {
+              "$ref": "#/$defs/globals/progress"
+            },
+            "sort": {
+              "$ref": "#/$defs/globals/sort"
+            },
+            "maxBuffer": {
+              "$ref": "#/$defs/globals/maxBuffer"
+            },
+            "yes": {
+              "$ref": "#/$defs/globals/yes"
+            },
+
+            "scope": {
+              "$ref": "#/$defs/filters/scope"
+            },
+            "ignore": {
+              "$ref": "#/$defs/filters/ignore"
+            },
+            "private": {
+              "$ref": "#/$defs/filters/private"
+            },
+            "since": {
+              "$ref": "#/$defs/filters/since"
+            },
+            "excludeDependents": {
+              "$ref": "#/$defs/filters/excludeDependents"
+            },
+            "includeDependents": {
+              "$ref": "#/$defs/filters/includeDependents"
+            },
+            "includeDependencies": {
+              "$ref": "#/$defs/filters/includeDependencies"
+            },
+            "includeMergedTags": {
+              "$ref": "#/$defs/filters/includeMergedTags"
+            },
+            "continueIfNoMatch": {
+              "$ref": "#/$defs/filters/continueIfNoMatch"
+            }
+          }
+        },
+        "run": {
+          "type": "object",
+          "description": "Options for the `run` command.",
+          "properties": {
+            "cmdDryRun": {
+              "$ref": "#/$defs/commandOptions/run/cmdDryRun"
+            },
+            "stream": {
+              "$ref": "#/$defs/commandOptions/shared/stream"
+            },
+            "parallel": {
+              "$ref": "#/$defs/commandOptions/shared/parallel"
+            },
+            "noBail": {
+              "$ref": "#/$defs/commandOptions/shared/noBail"
+            },
+            "bail": {
+              "$ref": "#/$defs/commandOptions/shared/bail"
+            },
+            "noPrefix": {
+              "$ref": "#/$defs/commandOptions/shared/noPrefix"
+            },
+            "prefix": {
+              "$ref": "#/$defs/commandOptions/shared/prefix"
+            },
+            "profile": {
+              "$ref": "#/$defs/commandOptions/shared/profile"
+            },
+            "profileLocation": {
+              "$ref": "#/$defs/commandOptions/shared/profileLocation"
+            },
+            "skipNxCache": {
+              "$ref": "#/$defs/commandOptions/run/skipNxCache"
+            },
+
+            "npmClient": {
+              "$ref": "#/$defs/globals/npmClient"
+            },
+            "loglevel": {
+              "$ref": "#/$defs/globals/loglevel"
+            },
+            "concurrency": {
+              "$ref": "#/$defs/globals/concurrency"
+            },
+            "rejectCycles": {
+              "$ref": "#/$defs/globals/rejectCycles"
+            },
+            "progress": {
+              "$ref": "#/$defs/globals/progress"
+            },
+            "sort": {
+              "$ref": "#/$defs/globals/sort"
+            },
+            "maxBuffer": {
+              "$ref": "#/$defs/globals/maxBuffer"
+            },
+            "yes": {
+              "$ref": "#/$defs/globals/yes"
+            },
+
+            "scope": {
+              "$ref": "#/$defs/filters/scope"
+            },
+            "ignore": {
+              "$ref": "#/$defs/filters/ignore"
+            },
+            "private": {
+              "$ref": "#/$defs/filters/private"
+            },
+            "since": {
+              "$ref": "#/$defs/filters/since"
+            },
+            "excludeDependents": {
+              "$ref": "#/$defs/filters/excludeDependents"
+            },
+            "includeDependents": {
+              "$ref": "#/$defs/filters/includeDependents"
+            },
+            "includeDependencies": {
+              "$ref": "#/$defs/filters/includeDependencies"
+            },
+            "includeMergedTags": {
+              "$ref": "#/$defs/filters/includeMergedTags"
+            },
+            "continueIfNoMatch": {
+              "$ref": "#/$defs/filters/continueIfNoMatch"
+            }
+          }
+        },
+        "version": {
+          "type": "object",
+          "description": "Options for the `version` command.",
+          "properties": {
+            "allowBranch": {
+              "$ref": "#/$defs/commandOptions/version/allowBranch"
+            },
+            "amend": {
+              "$ref": "#/$defs/commandOptions/version/amend"
+            },
+            "conventionalCommits": {
+              "$ref": "#/$defs/commandOptions/shared/conventionalCommits"
+            },
+            "conventionalGraduate": {
+              "$ref": "#/$defs/commandOptions/shared/conventionalGraduate"
+            },
+            "conventionalPrerelease": {
+              "$ref": "#/$defs/commandOptions/version/conventionalPrerelease"
+            },
+            "changelogPreset": {
+              "$ref": "#/$defs/commandOptions/version/changelogPreset"
+            },
+            "changelogIncludeCommitsGitAuthor": {
+              "$ref": "#/$defs/commandOptions/version/changelogIncludeCommitsGitAuthor"
+            },
+            "changelogIncludeCommitsClientLogin": {
+              "$ref": "#/$defs/commandOptions/version/changelogIncludeCommitsClientLogin"
+            },
+            "changelogHeaderMessage": {
+              "$ref": "#/$defs/commandOptions/version/changelogHeaderMessage"
+            },
+            "changelogVersionMessage": {
+              "$ref": "#/$defs/commandOptions/version/changelogVersionMessage"
+            },
+            "exact": {
+              "$ref": "#/$defs/commandOptions/shared/exact"
+            },
+            "forcePublish": {
+              "$ref": "#/$defs/commandOptions/shared/forcePublish"
+            },
+            "gitDryRun": {
+              "$ref": "#/$defs/commandOptions/version/gitDryRun"
+            },
+            "gitRemote": {
+              "$ref": "#/$defs/commandOptions/version/gitRemote"
+            },
+            "createRelease": {
+              "$ref": "#/$defs/commandOptions/version/createRelease"
+            },
+            "ignoreChanges": {
+              "$ref": "#/$defs/commandOptions/shared/ignoreChanges"
+            },
+            "ignoreScripts": {
+              "$ref": "#/$defs/commandOptions/shared/ignoreScripts"
+            },
+            "message": {
+              "$ref": "#/$defs/commandOptions/version/message"
+            },
+            "noChangelog": {
+              "$ref": "#/$defs/commandOptions/version/noChangelog"
+            },
+            "changelog": {
+              "$ref": "#/$defs/commandOptions/version/changelog"
+            },
+            "noCommitHooks": {
+              "$ref": "#/$defs/commandOptions/version/noCommitHooks"
+            },
+            "commitHooks": {
+              "$ref": "#/$defs/commandOptions/version/commitHooks"
+            },
+            "noGitTagVersion": {
+              "$ref": "#/$defs/commandOptions/version/noGitTagVersion"
+            },
+            "gitTagVersion": {
+              "$ref": "#/$defs/commandOptions/version/gitTagVersion"
+            },
+            "noGranularPathspec": {
+              "$ref": "#/$defs/commandOptions/shared/noGranularPathspec"
+            },
+            "granularPathspec": {
+              "$ref": "#/$defs/commandOptions/shared/granularPathspec"
+            },
+            "noPush": {
+              "$ref": "#/$defs/commandOptions/version/noPush"
+            },
+            "push": {
+              "$ref": "#/$defs/commandOptions/version/push"
+            },
+            "preid": {
+              "$ref": "#/$defs/commandOptions/shared/preid"
+            },
+            "signGitCommit": {
+              "$ref": "#/$defs/commandOptions/version/signGitCommit"
+            },
+            "signoffGitCommit": {
+              "$ref": "#/$defs/commandOptions/version/signoffGitCommit"
+            },
+            "signGitTag": {
+              "$ref": "#/$defs/commandOptions/version/signGitTag"
+            },
+            "forceGitTag": {
+              "$ref": "#/$defs/commandOptions/version/forceGitTag"
+            },
+            "syncWorkspaceLock": {
+              "$ref": "#/$defs/commandOptions/version/syncWorkspaceLock"
+            },
+            "tagVersionPrefix": {
+              "$ref": "#/$defs/commandOptions/version/tagVersionPrefix"
+            },
+
+            "npmClient": {
+              "$ref": "#/$defs/globals/npmClient"
+            },
+            "loglevel": {
+              "$ref": "#/$defs/globals/loglevel"
+            },
+            "concurrency": {
+              "$ref": "#/$defs/globals/concurrency"
+            },
+            "rejectCycles": {
+              "$ref": "#/$defs/globals/rejectCycles"
+            },
+            "progress": {
+              "$ref": "#/$defs/globals/progress"
+            },
+            "sort": {
+              "$ref": "#/$defs/globals/sort"
+            },
+            "maxBuffer": {
+              "$ref": "#/$defs/globals/maxBuffer"
+            },
+            "yes": {
+              "$ref": "#/$defs/globals/yes"
+            },
+
+            "scope": {
+              "$ref": "#/$defs/filters/scope"
+            },
+            "ignore": {
+              "$ref": "#/$defs/filters/ignore"
+            },
+            "private": {
+              "$ref": "#/$defs/filters/private"
+            },
+            "since": {
+              "$ref": "#/$defs/filters/since"
+            },
+            "excludeDependents": {
+              "$ref": "#/$defs/filters/excludeDependents"
+            },
+            "includeDependents": {
+              "$ref": "#/$defs/filters/includeDependents"
+            },
+            "includeDependencies": {
+              "$ref": "#/$defs/filters/includeDependencies"
+            },
+            "includeMergedTags": {
+              "$ref": "#/$defs/filters/includeMergedTags"
+            },
+            "continueIfNoMatch": {
+              "$ref": "#/$defs/filters/continueIfNoMatch"
+            }
+          }
+        }
+      }
+    },
+    "npmClient": {
+      "$ref": "#/$defs/globals/npmClient"
+    },
+    "loglevel": {
+      "$ref": "#/$defs/globals/loglevel"
+    },
+    "concurrency": {
+      "$ref": "#/$defs/globals/concurrency"
+    },
+    "rejectCycles": {
+      "$ref": "#/$defs/globals/rejectCycles"
+    },
+    "progress": {
+      "$ref": "#/$defs/globals/progress"
+    },
+    "sort": {
+      "$ref": "#/$defs/globals/sort"
+    },
+    "maxBuffer": {
+      "$ref": "#/$defs/globals/maxBuffer"
+    },
+    "yes": {
+      "$ref": "#/$defs/globals/yes"
+    },
+
+    "scope": {
+      "$ref": "#/$defs/filters/scope"
+    },
+    "ignore": {
+      "$ref": "#/$defs/filters/ignore"
+    },
+    "private": {
+      "$ref": "#/$defs/filters/private"
+    },
+    "since": {
+      "$ref": "#/$defs/filters/since"
+    },
+    "excludeDependents": {
+      "$ref": "#/$defs/filters/excludeDependents"
+    },
+    "includeDependents": {
+      "$ref": "#/$defs/filters/includeDependents"
+    },
+    "includeDependencies": {
+      "$ref": "#/$defs/filters/includeDependencies"
+    },
+    "includeMergedTags": {
+      "$ref": "#/$defs/filters/includeMergedTags"
+    },
+    "continueIfNoMatch": {
+      "$ref": "#/$defs/filters/continueIfNoMatch"
+    },
+
+    "dev": {
+      "$ref": "#/$defs/commandOptions/add/dev"
+    },
+    "peer": {
+      "$ref": "#/$defs/commandOptions/add/peer"
+    },
+    "noBootstrap": {
+      "$ref": "#/$defs/commandOptions/add/noBootstrap"
+    },
+    "bootstrap": {
+      "$ref": "#/$defs/commandOptions/add/bootstrap"
+    },
+    "hoist": {
+      "$ref": "#/$defs/commandOptions/bootstrap/hoist"
+    },
+    "nohoist": {
+      "$ref": "#/$defs/commandOptions/bootstrap/nohoist"
+    },
+    "mutex": {
+      "$ref": "#/$defs/commandOptions/bootstrap/mutex"
+    },
+    "strict": {
+      "$ref": "#/$defs/commandOptions/bootstrap/strict"
+    },
+    "useWorkspaces": {
+      "$ref": "#/$defs/commandOptions/bootstrap/useWorkspaces"
+    },
+
+    "access": {
+      "$ref": "#/$defs/commandOptions/create/access"
+    },
+    "bin": {
+      "$ref": "#/$defs/commandOptions/create/bin"
+    },
+    "description": {
+      "$ref": "#/$defs/commandOptions/create/description"
+    },
+    "dependencies": {
+      "$ref": "#/$defs/commandOptions/create/dependencies"
+    },
+    "esModule": {
+      "$ref": "#/$defs/commandOptions/create/esModule"
+    },
+    "homepage": {
+      "$ref": "#/$defs/commandOptions/create/homepage"
+    },
+    "keywords": {
+      "$ref": "#/$defs/commandOptions/create/keywords"
+    },
+    "license": {
+      "$ref": "#/$defs/commandOptions/create/license"
+    },
+    "tag": {
+      "$ref": "#/$defs/commandOptions/create/tag"
+    },
+
+    "flatten": {
+      "$ref": "#/$defs/commandOptions/import/flatten"
+    },
+    "dest": {
+      "$ref": "#/$defs/commandOptions/import/dest"
+    },
+    "preserveCommit": {
+      "$ref": "#/$defs/commandOptions/import/preserveCommit"
+    },
+
+    "independent": {
+      "$ref": "#/$defs/commandOptions/init/independent"
+    },
+
+    "canary": {
+      "$ref": "#/$defs/commandOptions/publish/canary"
+    },
+    "distTag": {
+      "$ref": "#/$defs/commandOptions/publish/distTag"
+    },
+    "preDistTag": {
+      "$ref": "#/$defs/commandOptions/publish/preDistTag"
+    },
+    "legacyAuth": {
+      "$ref": "#/$defs/commandOptions/publish/legacyAuth"
+    },
+    "gitHead": {
+      "$ref": "#/$defs/commandOptions/publish/gitHead"
+    },
+    "graphType": {
+      "$ref": "#/$defs/commandOptions/publish/graphType"
+    },
+    "otp": {
+      "$ref": "#/$defs/commandOptions/publish/otp"
+    },
+    "requireScripts": {
+      "$ref": "#/$defs/commandOptions/publish/requireScripts"
+    },
+    "noGitReset": {
+      "$ref": "#/$defs/commandOptions/publish/noGitReset"
+    },
+    "gitReset": {
+      "$ref": "#/$defs/commandOptions/publish/gitReset"
+    },
+    "tempTag": {
+      "$ref": "#/$defs/commandOptions/publish/tempTag"
+    },
+    "noVerifyAccess": {
+      "$ref": "#/$defs/commandOptions/publish/noVerifyAccess"
+    },
+    "verifyAccess": {
+      "$ref": "#/$defs/commandOptions/publish/verifyAccess"
+    },
+
+    "skipNxCache": {
+      "$ref": "#/$defs/commandOptions/run/skipNxCache"
+    },
+
+    "allowBranch": {
+      "$ref": "#/$defs/commandOptions/version/allowBranch"
+    },
+    "amend": {
+      "$ref": "#/$defs/commandOptions/version/amend"
+    },
+    "conventionalPrerelease": {
+      "$ref": "#/$defs/commandOptions/version/conventionalPrerelease"
+    },
+    "changelogPreset": {
+      "$ref": "#/$defs/commandOptions/version/changelogPreset"
+    },
+    "gitRemote": {
+      "$ref": "#/$defs/commandOptions/version/gitRemote"
+    },
+    "createRelease": {
+      "$ref": "#/$defs/commandOptions/version/createRelease"
+    },
+    "message": {
+      "$ref": "#/$defs/commandOptions/version/message"
+    },
+    "noChangelog": {
+      "$ref": "#/$defs/commandOptions/version/noChangelog"
+    },
+    "changelog": {
+      "$ref": "#/$defs/commandOptions/version/changelog"
+    },
+    "noCommitHooks": {
+      "$ref": "#/$defs/commandOptions/version/noCommitHooks"
+    },
+    "commitHooks": {
+      "$ref": "#/$defs/commandOptions/version/commitHooks"
+    },
+    "noGitTagVersion": {
+      "$ref": "#/$defs/commandOptions/version/noGitTagVersion"
+    },
+    "gitTagVersion": {
+      "$ref": "#/$defs/commandOptions/version/gitTagVersion"
+    },
+    "noPush": {
+      "$ref": "#/$defs/commandOptions/version/noPush"
+    },
+    "push": {
+      "$ref": "#/$defs/commandOptions/version/push"
+    },
+    "signGitCommit": {
+      "$ref": "#/$defs/commandOptions/version/signGitCommit"
+    },
+    "signGitTag": {
+      "$ref": "#/$defs/commandOptions/version/signGitTag"
+    },
+    "forceGitTag": {
+      "$ref": "#/$defs/commandOptions/version/forceGitTag"
+    },
+    "tagVersionPrefix": {
+      "$ref": "#/$defs/commandOptions/version/tagVersionPrefix"
+    },
+
+    "registry": {
+      "$ref": "#/$defs/commandOptions/shared/registry"
+    },
+    "conventionalCommits": {
+      "$ref": "#/$defs/commandOptions/shared/conventionalCommits"
+    },
+    "conventionalGraduate": {
+      "$ref": "#/$defs/commandOptions/shared/conventionalGraduate"
+    },
+    "forceLocal": {
+      "$ref": "#/$defs/commandOptions/shared/forceLocal"
+    },
+    "contents": {
+      "$ref": "#/$defs/commandOptions/shared/contents"
+    },
+    "ignoreChanges": {
+      "$ref": "#/$defs/commandOptions/shared/ignoreChanges"
+    },
+    "stream": {
+      "$ref": "#/$defs/commandOptions/shared/stream"
+    },
+    "parallel": {
+      "$ref": "#/$defs/commandOptions/shared/parallel"
+    },
+    "noBail": {
+      "$ref": "#/$defs/commandOptions/shared/noBail"
+    },
+    "bail": {
+      "$ref": "#/$defs/commandOptions/shared/bail"
+    },
+    "noPrefix": {
+      "$ref": "#/$defs/commandOptions/shared/noPrefix"
+    },
+    "prefix": {
+      "$ref": "#/$defs/commandOptions/shared/prefix"
+    },
+    "profile": {
+      "$ref": "#/$defs/commandOptions/shared/profile"
+    },
+    "profileLocation": {
+      "$ref": "#/$defs/commandOptions/shared/profileLocation"
+    },
+    "preid": {
+      "$ref": "#/$defs/commandOptions/shared/preid"
+    },
+    "ignoreScripts": {
+      "$ref": "#/$defs/commandOptions/shared/ignoreScripts"
+    },
+    "noGranularPathspec": {
+      "$ref": "#/$defs/commandOptions/shared/noGranularPathspec"
+    },
+    "granularPathspec": {
+      "$ref": "#/$defs/commandOptions/shared/granularPathspec"
+    },
+    "forcePublish": {
+      "$ref": "#/$defs/commandOptions/shared/forcePublish"
+    },
+    "exact": {
+      "$ref": "#/$defs/commandOptions/shared/exact"
+    },
+    "ignorePrepublish": {
+      "$ref": "#/$defs/commandOptions/shared/ignorePrepublish"
+    }
+  },
+  "$defs": {
+    "globals": {
+      "npmClient": {
+        "type": "string",
+        "description": "The npm client to use when running commands (either npm, pnpm or yarn). Defaults to npm if unspecified.",
+        "default": "npm",
+        "enum": ["npm", "pnpm", "yarn"]
+      },
+      "loglevel": {
+        "type": "string",
+        "description": "The level of logging to use when running commands. Defaults to info if unspecified.",
+        "default": "info",
+        "enum": ["error", "warn", "info", "verbose", "debug", "silly"]
+      },
+      "concurrency": {
+        "type": "integer",
+        "description": "The number of concurrent processes to use when running commands. Defaults to the number of CPUs if unspecified."
+      },
+      "rejectCycles": {
+        "type": "boolean",
+        "description": "When true, Lerna will fail if a cycle is detected among dependencies."
+      },
+      "progress": {
+        "type": "boolean",
+        "description": "When true, Lerna will display progress bars when running commands. Progress bars are always off in CI."
+      },
+      "sort": {
+        "type": "boolean",
+        "description": "When true, Lerna will sort the packages topologically (dependencies before dependents)."
+      },
+      "maxBuffer": {
+        "type": "integer",
+        "description": "The maximum number of bytes to allow a child process for subcommand execution."
+      },
+      "yes": {
+        "type": "boolean",
+        "description": "When true, Lerna will automatically answer yes to all confirmation prompts."
+      }
+    },
+    "filters": {
+      "scope": {
+        "type": "string",
+        "description": "Include only packages with names matching the given glob"
+      },
+      "ignore": {
+        "type": "string",
+        "description": "Exclude packages with names matching the given glob"
+      },
+      "private": {
+        "type": "boolean",
+        "description": "Include private packages in the command. During `lerna create`, specifies that the new package is private (never published to any external registry)."
+      },
+      "since": {
+        "type": "string",
+        "description": "Only include packages that have been changed since the specified [ref]."
+      },
+      "excludeDependents": {
+        "type": "boolean",
+        "description": "Exclude all transitive dependents when running a command with --since, overriding the default \"changed\" algorithm."
+      },
+      "includeDependents": {
+        "type": "boolean",
+        "description": "Include all transitive dependents when running a command regardless of --scope, --ignore, or --since."
+      },
+      "includeDependencies": {
+        "type": "boolean",
+        "description": "Include all transitive dependencies when running a command regardless of --scope, --ignore, or --since."
+      },
+      "includeMergedTags": {
+        "type": "boolean",
+        "description": "Include tags from merged branches when running a command with --since."
+      },
+      "continueIfNoMatch": {
+        "type": "boolean",
+        "description": "Don't fail if no package is matched."
+      }
+    },
+    "commandOptions": {
+      "add": {
+        "dev": {
+          "type": "boolean",
+          "description": "During `lerna add`, save the newly added package to devDependencies instead of dependencies."
+        },
+        "peer": {
+          "type": "boolean",
+          "description": "During `lerna add`, save the newly added package to peerDependencies instead of dependencies."
+        },
+        "noBootstrap": {
+          "type": "boolean",
+          "description": "Do not automatically chain `lerna bootstrap` after `lerna add`."
+        },
+        "bootstrap": {
+          "type": "boolean",
+          "description": "Automatically chain `lerna bootstrap` after `lerna add`."
+        }
+      },
+      "bootstrap": {
+        "hoist": {
+          "type": "string",
+          "description": "During `lerna bootstrap`, install external dependencies matching [glob] to the repo root."
+        },
+        "nohoist": {
+          "type": "string",
+          "description": "During `lerna bootstrap`, don't hoist external dependencies matching [glob] to the repo root."
+        },
+        "mutex": {},
+        "strict": {
+          "type": "boolean",
+          "description": "During `lerna bootstrap`, don't allow warnings when hoisting as it causes longer bootstrap times and other issues."
+        },
+        "useWorkspaces": {
+          "type": "boolean",
+          "description": "During `lerna bootstrap`, enable integration with Yarn workspaces."
+        }
+      },
+      "create": {
+        "access": {
+          "type": "string",
+          "enum": ["public", "restricted"],
+          "description": "During `lerna create` and when using a scope, set publishConfig.access value."
+        },
+        "bin": {
+          "type": "string",
+          "description": "During `lerna create`, specifies that the new package has an executable with the given name."
+        },
+        "description": {
+          "type": "string",
+          "description": "During `lerna create`, specifies the description of the new package."
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "During `lerna create`, specifies the list of dependencies of the new package."
+        },
+        "esModule": {
+          "type": "boolean",
+          "description": "During `lerna create`, when true, initializes a transpiled ES Module."
+        },
+        "homepage": {
+          "type": "string",
+          "description": "During `lerna create`, specifies the homepage of the new package. Defaults to a subpath of the root pkg.homepage."
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "During `lerna create`, specifies the list of keywords of the new package."
+        },
+        "license": {
+          "type": "string",
+          "description": "During `lerna create`, specifies the license of the new package (SPDX identifier). Defaults to ISC."
+        },
+        "tag": {
+          "type": "string",
+          "description": "During `lerna create`, specifies the publishConfig.tag for the new package."
+        }
+      },
+      "exec": {
+        "cmdDryRun": {
+          "type": "boolean",
+          "description": "During `lerna exec`, when true, displays the process command that would be performed without executing it."
+        }
+      },
+      "import": {
+        "flatten": {
+          "type": "boolean",
+          "description": "During `lerna import`, when true, import each merge commit as a single change the merge introduced."
+        },
+        "dest": {
+          "type": "string",
+          "description": "During `lerna import`, specifies the directory for the external git repository."
+        },
+        "preserveCommit": {
+          "type": "boolean",
+          "description": "During `lerna import`, when true, preserve the original committer in additional to original author."
+        }
+      },
+      "init": {
+        "independent": {
+          "type": "boolean",
+          "description": "During `lerna init`, when true, version packages independently."
+        },
+        "useWorkspaces": {
+          "type": "boolean",
+          "description": "During `lerna init`, enables integration with Yarn or other package manager that use `workspaces` property in `package.json`."
+        }
+      },
+      "publish": {
+        "canary": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, publish packages after every successful merge using the sha as part of the tag."
+        },
+        "distTag": {
+          "type": "string",
+          "description": "During `lerna publish`, publish packages with the specified npm dist-tag."
+        },
+        "preDistTag": {
+          "type": "string",
+          "description": "During `lerna publish`, publish prerelease packages with the specified npm dist-tag."
+        },
+        "legacyAuth": {
+          "type": "string",
+          "description": "For `lerna publish`, the Legacy Base64 Encoded username and password to use."
+        },
+        "gitHead": {
+          "type": "string",
+          "description": "For `lerna publish`, the explicit SHA to set as gitHead when packing tarballs, only allowed with 'from-package' positional."
+        },
+        "graphType": {
+          "type": "string",
+          "enum": ["all", "dependencies"],
+          "description": "DEPRECATED: For `lerna publish`, if you want to ignore devDependencies when considering the package graph you can set this property equal to 'dependencies'. This will be removed in v6 of lerna.",
+          "default": "all",
+          "deprecated": true
+        },
+        "otp": {
+          "type": "string",
+          "description": "During `lerna publish`, supply a one-time password for publishing with two-factor authentication."
+        },
+        "requireScripts": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, execute ./scripts/prepublish.js and ./scripts/postpublish.js, relative to package root."
+        },
+        "noGitReset": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, do not reset changes to working tree after publishing is complete."
+        },
+        "gitReset": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, reset changes to working tree after publishing is complete."
+        },
+        "tempTag": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, create a temporary tag while publishing."
+        },
+        "noVerifyAccess": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, do not verify package read-write access for current npm user."
+        },
+        "verifyAccess": {
+          "type": "boolean",
+          "description": "During `lerna publish`, when true, verify package read-write access for current npm user."
+        }
+      },
+      "run": {
+        "cmdDryRun": {
+          "type": "boolean",
+          "description": "During `lerna run`, when true, displays the process command that would be performed without executing it."
+        },
+        "skipNxCache": {
+          "type": "boolean",
+          "description": "During `lerna run`, when true, skip the nx cache."
+        }
+      },
+      "version": {
+        "allowBranch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "For `lerna version`, the branches to allow versioning from."
+        },
+        "amend": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, amend the existing commit instead of generating a new one."
+        },
+        "conventionalPrerelease": {
+          "anyOf": [{ "type": "string" }, { "type": "boolean" }, { "type": "array", "items": { "type": "string" } }],
+          "description": "During `lerna version`, version changed packages as prereleases when using --conventional-commits."
+        },
+        "changelogHeaderMessage": {
+          "type": "string",
+          "description": "During `lerna version`, add a custom message at the top of your \"changelog.md\" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs."
+        },
+        "changelogIncludeCommitsGitAuthor": {
+          "type": "string",
+          "description": "During `lerna version`, specify if we want to include the commit author's name, this option is only available when using --conventional-commits with changelogs. We can also optionally provide a custom message or else a default format will be used."
+        },
+        "changelogIncludeCommitsClientLogin": {
+          "type": "string",
+          "description": "During `lerna version`, specify if we want to include the commit remote client login name (ie GitHub username), this option is only available when using --conventional-commits with changelogs. We can also optionally provide a custom message or else a default format will be used."
+        },
+        "changelogVersionMessage": {
+          "type": "string",
+          "description": "During `lerna version`, add a custom message as a prefix to each new version in your \"changelog.md\" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs."
+        },
+        "changelogPreset": {
+          "type": "string",
+          "description": "For `lerna version`, the custom conventional-changelog preset."
+        },
+        "gitDryRun": {
+          "type": "boolean",
+          "description": "During `lerna version`, displays the process command that would be performed without executing it."
+        },
+        "gitRemote": {
+          "type": "string",
+          "description": "During `lerna version`, push git changes to the specified remote."
+        },
+        "createRelease": {
+          "type": "string",
+          "description": "During `lerna version`, an official GitHub or GitLab release for every version.",
+          "enum": ["github", "gitlab"]
+        },
+        "message": {
+          "type": "string",
+          "description": "For `lerna version`, the custom commit message to use when creating the version commit."
+        },
+        "noChangelog": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, do not generate CHANGELOG.md files when using --conventional-commits."
+        },
+        "changelog": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, generate CHANGELOG.md files when using --conventional-commits."
+        },
+        "noCommitHooks": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, do not run git commit hooks when committing version changes."
+        },
+        "commitHooks": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, run git commit hooks when committing version changes."
+        },
+        "noGitTagVersion": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, do not commit or tag version changes."
+        },
+        "gitTagVersion": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, commit and tag version changes."
+        },
+        "noPush": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, do not push tagged commit to git remote."
+        },
+        "push": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, push tagged commit to git remote."
+        },
+        "signGitCommit": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, pass the `--gpg-sign` flag to `git commit`."
+        },
+        "signoffGitCommit": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, pass the `--signoff` flag to `git commit`."
+        },
+        "signGitTag": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, pass the `--sign` flag to `git tag`."
+        },
+        "forceGitTag": {
+          "type": "boolean",
+          "description": "During `lerna version`, when true, pass the `--force` flag to `git tag`."
+        },
+        "syncWorkspaceLock": {
+          "type": "boolean",
+          "description": "During `lerna version`, runs `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`"
+        },
+        "tagVersionPrefix": {
+          "type": "string",
+          "description": "During `lerna version`, customize the tag prefix. To remove entirely, pass an empty string."
+        }
+      },
+      "shared": {
+        "registry": {
+          "type": "string",
+          "description": "The npm registry to use for all npm client operations. During `lerna create`, specifies the new package's publishConfig.registry."
+        },
+        "conventionalCommits": {
+          "type": "boolean",
+          "description": "During `lerna version`, `lerna changed`, and `lerna publish`, when true, use conventional commits specification to determine the version bump and generate CHANGELOG.md files."
+        },
+        "conventionalGraduate": {
+          "anyOf": [{ "type": "string" }, { "type": "boolean" }, { "type": "array", "items": { "type": "string" } }],
+          "description": "Detect currently prereleased packages that would change to a non-prerelease version. Relevant for `lerna changed` and `lerna version`."
+        },
+        "forceLocal": {
+          "type": "boolean",
+          "description": "During `lerna bootstrap` and `lerna link`, when true, force local sibling links regardless of version range match."
+        },
+        "contents": {
+          "type": "boolean",
+          "description": "For `lerna bootstrap`, `lerna link`, and `lerna publish`, the subdirectory to use as the source of any links. Must apply to ALL packages."
+        },
+        "ignoreChanges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Ignore changes in files matched by glob(s) when detecting changed packages. Relevant for `lerna changed`, `lerna publish`, `lerna version`, and `lerna diff`."
+        },
+        "stream": {
+          "type": "boolean",
+          "description": "During `lerna exec` and `lerna run`, stream output with lines prefixed by originating package name."
+        },
+        "parallel": {
+          "type": "boolean",
+          "description": "During `lerna exec` and `lerna run`, run commands with unlimited concurrency, streaming prefixed output."
+        },
+        "noBail": {
+          "type": "boolean",
+          "description": "During `lerna exec` and `lerna run`, when true, do not exit with non-zero status if a command fails."
+        },
+        "bail": {
+          "type": "boolean",
+          "description": "During `lerna exec` and `lerna run`, exit with non-zero status if any command fails."
+        },
+        "noPrefix": {
+          "type": "boolean",
+          "description": "During `lerna exec` and `lerna run`, when true, do not prefix output with originating package name."
+        },
+        "prefix": {
+          "type": "boolean",
+          "description": "During `lerna exec` and `lerna run`, prefix output with originating package name."
+        },
+        "profile": {
+          "type": "boolean",
+          "description": "During `lerna exec` and `lerna run`, profile command execution and output performance profile to default location."
+        },
+        "profileLocation": {
+          "type": "string",
+          "description": "During `lerna exec` and `lerna run`, profile command execution and output performance profile to the specified location instead of default project root."
+        },
+        "preid": {
+          "type": "string",
+          "description": "For `lerna publish` and `lerna version`, the prerelease identifier when versioning a prerelease."
+        },
+        "ignoreScripts": {
+          "type": "boolean",
+          "description": "During `lerna bootstrap`, `lerna publish`, and `lerna version`, don't run ANY lifecycle scripts in bootstrapped packages."
+        },
+        "noGranularPathspec": {
+          "type": "boolean",
+          "description": "During `lerna publish` and `lerna version`, when true, do not reset changes file-by-file, but globally."
+        },
+        "granularPathspec": {
+          "type": "boolean",
+          "description": "During `lerna publish` and `lerna version`, when true, reset changes file-by-file, not globally."
+        },
+        "forcePublish": {
+          "description": "During `lerna changed` and `lerna version`, always include targeted packages when detecting changed packages, skipping default logic.",
+          "anyOf": [{ "type": "string" }, { "type": "boolean" }, { "type": "array", "items": { "type": "string" } }]
+        },
+        "exact": {
+          "type": "boolean",
+          "description": "During `lerna add`, save the exact version of the newly added package. During `lerna version`, specify cross-dependency version numbers exactly rather than with a caret (^)."
+        },
+        "ignorePrepublish": {
+          "type": "boolean",
+          "description": "During `lerna publish` and `lerna bootstrap`, when true, disable deprecated 'prepublish' lifecycle script."
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -10,7 +10,7 @@ export interface ChangedCommandOption {
   /** always include targeted packages when detecting changed packages, skipping default logic. */
   forcePublish?: boolean | string | string[];
 
-  /** ignore changes in files matched by glob(s) when detecting changed packages. Pass --no-ignore-changes to completely disable. */
+  /** ignore changes in files matched by glob(s) when detecting changed packages. Pass `--no-ignore-changes` to completely disable. */
   ignoreChanges: string[];
 
   /** include tags from merged branches when detecting changed packages. */
@@ -18,7 +18,7 @@ export interface ChangedCommandOption {
 }
 
 export interface DiffCommandOption {
-  /** ignore changes in files matched by glob(s) when detecting changed packages. Pass --no-ignore-changes to completely disable. */
+  /** ignore changes in files matched by glob(s) when detecting changed packages. Pass `--no-ignore-changes` to completely disable. */
   ignoreChanges: string[];
 
   /** package name */
@@ -44,7 +44,7 @@ export interface ExecCommandOption {
   /** Continue executing command despite non-zero exit in a given package. */
   noBail?: boolean;
 
-  /** proxy for --no-bail */
+  /** proxy for `--no-bail` */
   bail?: boolean;
 
   // This option controls prefix for stream output so that it can be disabled to be friendly
@@ -52,7 +52,7 @@ export interface ExecCommandOption {
   /** Do not prefix streaming output. */
   noPrefix?: boolean;
 
-  /** proxy for --no-prefix */
+  /** proxy for `--no-prefix` */
   prefix?: boolean;
 
   /** Profile command executions and output performance profile to default location. */
@@ -97,7 +97,7 @@ export interface ListCommandOption {
 }
 
 export interface PublishCommandOption extends VersionCommandOption {
-  /** alias to '--canary' */
+  /** alias to `--canary` */
   c?: boolean;
 
   /** Publish packages after every successful merge using the sha as part of the tag. */
@@ -130,11 +130,11 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Disable all lifecycle scripts */
   ignoreScripts?: boolean;
 
-  // TODO: (major) make --no-granular-pathspec the default
+  // TODO: (major) make `--no-granular-pathspec` the default
   /** Do not reset changes file-by-file, but globally. */
   noGranularPathspec?: boolean;
 
-  /** proxy for --no-granular-pathspec */
+  /** proxy for `--no-granular-pathspec` */
   granularPathspec?: boolean;
 
   /** Supply a one-time password for publishing with two-factor authentication. */
@@ -149,7 +149,7 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Do not reset changes to working tree after publishing is complete. */
   noGitReset?: boolean;
 
-  // proxy for --no-git-reset
+  // proxy for `--no-git-reset`
   gitReset?: boolean;
 
   /** Create a temporary tag while publishing. */
@@ -158,10 +158,10 @@ export interface PublishCommandOption extends VersionCommandOption {
   /** Do not verify package read-write access for current npm user. */
   noVerifyAccess?: boolean;
 
-  /** proxy for --no-verify-access */
+  /** proxy for `--no-verify-access` */
   verifyAccess?: boolean;
 
-  /** alias to '--yes' */
+  /** alias to `--yes` */
   y?: boolean;
 
   /** Skip all confirmation prompts. */
@@ -185,14 +185,14 @@ export interface VersionCommandOption {
   /** Version currently prereleased packages to a non-prerelease version. */
   conventionalGraduate?: boolean | string;
 
-  /** Version changed packages as prereleases when using --conventional-commits. */
+  /** Version changed packages as prereleases when using `--conventional-commits`. */
   conventionalPrerelease?: boolean | string;
 
-  /** Add a custom message at the top of your "changelog.md" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs. */
+  /** Add a custom message at the top of your "changelog.md" which is located in the root of your project. This option is only available when using `--conventional-commits` with changelogs. */
   changelogHeaderMessage?: string;
 
   /**
-   * Specify if we want to include the commit author's name, this option is only available when using --conventional-commits with changelogs.
+   * Specify if we want to include the commit author's name, this option is only available when using `--conventional-commits` with changelogs.
    * We can also optionally provide a custom message or else a default format will be used.
    */
   changelogIncludeCommitsGitAuthor?: boolean | string;
@@ -201,14 +201,14 @@ export interface VersionCommandOption {
   changelogIncludeCommitAuthorFullname?: boolean | string;
 
   /**
-   * Specify if we want to include the commit remote client login name (ie GitHub username), this option is only available when using --conventional-commits with changelogs.
+   * Specify if we want to include the commit remote client login name (ie GitHub username), this option is only available when using `--conventional-commits` with changelogs.
    * We can also optionally provide a custom message or else a default format will be used.
    */
   changelogIncludeCommitsClientLogin?: boolean | string;
 
   /**
    * Add a custom message as a prefix to each new version in your "changelog.md" which is located in the root of your project.
-   * This option is only available when using --conventional-commits with changelogs.
+   * This option is only available when using `--conventional-commits` with changelogs.
    */
   changelogVersionMessage?: string;
 
@@ -232,62 +232,62 @@ export interface VersionCommandOption {
 
   /**
    * Ignore changes in files matched by glob(s) when detecting changed packages.
-   * Pass --no-ignore-changes to completely disable.
+   * Pass `--no-ignore-changes` to completely disable.
    */
   ignoreChanges?: string[];
 
-  /** Disable all lifecycle scripts */
+  /** Disable all lifecycle scripts. */
   ignoreScripts?: boolean;
 
   /** Include tags from merged branches when detecting changed packages. */
   includeMergedTags?: boolean;
 
-  /** alias to '--message' */
+  /** alias to `--message`. */
   m?: string;
 
   /** Use a custom commit message when creating the version commit. */
   message?: string;
 
-  /** Do not generate CHANGELOG.md files when using --conventional-commits. */
+  /** Do not generate CHANGELOG.md files when using `--conventional-commits`. */
   noChangelog?: boolean;
 
-  /** proxy for --no-changelog */
+  /** proxy for `--no-changelog`. */
   changelog?: boolean;
 
   /** Do not run git commit hooks when committing version changes. */
   noCommitHooks?: boolean;
 
-  /** proxy for --no-commit-hooks */
+  /** proxy for `--no-commit-hooks`. */
   commitHooks?: boolean;
 
   /** Do not commit or tag version changes. */
   noGitTagVersion?: boolean;
 
-  /** proxy for --no-git-tag-version */
+  /** proxy for `--no-git-tag-version`. */
   gitTagVersion?: boolean;
 
-  // TODO: (major) make --no-granular-pathspec the default
+  // TODO: (major) make `--no-granular-pathspec` the default
   /** Do not stage changes file-by-file, but globally. */
   noGranularPathspec?: boolean;
 
-  /** Stage changes file-by-file, not globally. Proxy for --no-granular-pathspec */
+  /** Stage changes file-by-file, not globally. Proxy for `--no-granular-pathspec`. */
   granularPathspec?: boolean;
 
-  // TODO: (major) make --no-private the default
+  // TODO: (major) make `--no-private` the default
   /** Do not version private packages. */
   noPrivate?: boolean;
 
-  /** proxy for --no-private */
+  /** proxy for `--no-private`. */
   private?: boolean;
 
   /** Do not push tagged commit to git remote. */
   noPush?: boolean;
 
-  /** proxy for --no-push */
+  /** proxy for `--no-push`. */
   push?: boolean;
 
   // preid is copied into ../publish/command because a whitelist for one option isn't worth it
-  /** Defaults to 'alpha', specify the prerelease identifier when versioning a prerelease */
+  /** Defaults to 'alpha', specify the prerelease identifier when versioning a prerelease. */
   preid?: string;
 
   /** Remote git client, which client is used when reading commits from remote which is useful when associating client login for each changelog entry. */
@@ -314,7 +314,7 @@ export interface VersionCommandOption {
   /** Defaults to true when found, update the project root lock file, the lib will internally read/write back to the lock file. */
   manuallyUpdateRootLockfile?: boolean;
 
-  /** Runs `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient` */
+  /** Runs `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`. */
   syncWorkspaceLock?: boolean;
 
   /**
@@ -323,7 +323,7 @@ export interface VersionCommandOption {
    */
   workspaceStrictMatch?: boolean;
 
-  /** alias to '--yes' */
+  /** alias to `--yes` */
   y?: boolean;
 
   /** Skip all confirmation prompts. */
@@ -346,7 +346,7 @@ export interface RunCommandOption {
   /** Continue running script despite non-zero exit in a given package. */
   noBail?: boolean;
 
-  /** proxy for --no-bail */
+  /** proxy for `--no-bail`. */
   bail?: boolean;
 
   // This option controls prefix for stream output so that it can be disabled to be friendly
@@ -355,7 +355,7 @@ export interface RunCommandOption {
   /** Do not prefix streaming output. */
   noPrefix?: boolean;
 
-  /** proxy for --no-prefix */
+  /** proxy for `--no-prefix`. */
   prefix?: boolean;
 
   /** Profile script executions and output performance profile to default location. */
@@ -364,10 +364,10 @@ export interface RunCommandOption {
   /** Output performance profile to custom location instead of default project root. */
   profileLocation?: string;
 
-  /** npm script to run by the command */
+  /** npm script to run by the command. */
   script: string;
 
-  /** Enables integration with [Nx](https://nx.dev) */
+  /** Enables integration with [Nx](https://nx.dev). */
   useNx?: boolean;
 
   /** when "useNx" is enabled, do we want to skip caching with Nx? */

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -204,6 +204,8 @@ export interface LernaConfig {
 }
 
 export interface ProjectConfig extends LernaConfig, QueryGraphConfig {
+  /** Lerna JSON Schema https://json-schema.org/ */
+  $schema: string;
   ci?: boolean;
   concurrency: number | string;
   cwd: string;

--- a/packages/init/src/__tests__/init-command.spec.ts
+++ b/packages/init/src/__tests__/init-command.spec.ts
@@ -159,6 +159,7 @@ describe('Init Command', () => {
         await lernaInit(testDir)('--exact');
 
         expect(await fs.readJSON(path.join(testDir, 'lerna.json'))).toMatchObject({
+          $schema: 'node_modules/@lerna-lite/cli/schemas/lerna-schema.json',
           command: {
             init: {
               exact: true,
@@ -176,6 +177,7 @@ describe('Init Command', () => {
 
         await fs.outputJSON(lernaJsonPath, {
           '@lerna-lite/cli': '0.1.100',
+          $schema: 'node_modules/@lerna-lite/cli/schemas/lerna-schema.json',
           command: {
             bootstrap: {
               hoist: true,
@@ -193,12 +195,12 @@ describe('Init Command', () => {
         await lernaInit(testDir)('--use-workspaces');
 
         expect(await fs.readJSON(lernaJsonPath)).toEqual({
+          $schema: 'node_modules/@lerna-lite/cli/schemas/lerna-schema.json',
           command: {
             bootstrap: {
               hoist: true,
             },
           },
-          useNx: false,
           version: '1.2.3',
         });
       });
@@ -319,8 +321,8 @@ describe('Init Command', () => {
       await lernaInit(testDir)();
 
       expect(await fs.readJSON(lernaJsonPath)).toEqual({
+        $schema: 'node_modules/@lerna-lite/cli/schemas/lerna-schema.json',
         packages: ['packages/*'],
-        useNx: false,
         version: '1.2.3',
       });
     });
@@ -347,6 +349,7 @@ describe('Init Command', () => {
 
       await fs.outputJSON(lernaJsonPath, {
         '@lerna-lite/cli': '0.1.100',
+        $schema: 'node_modules/@lerna-lite/cli/schemas/lerna-schema.json',
         command: {
           bootstrap: {
             hoist: true,
@@ -363,6 +366,7 @@ describe('Init Command', () => {
       await lernaInit(testDir)('--exact');
 
       expect(await fs.readJSON(lernaJsonPath)).toEqual({
+        $schema: 'node_modules/@lerna-lite/cli/schemas/lerna-schema.json',
         command: {
           bootstrap: {
             hoist: true,
@@ -372,7 +376,6 @@ describe('Init Command', () => {
           },
         },
         packages: ['packages/*'],
-        useNx: false,
         version: '1.2.3',
       });
     });

--- a/packages/init/src/init-command.ts
+++ b/packages/init/src/init-command.ts
@@ -115,7 +115,10 @@ export class InitCommand extends Command<InitCommandOption> {
       initConfig.exact = true;
     }
 
-    const lernaConfig: Partial<ProjectConfig> = { useNx: false, version };
+    const lernaConfig: Partial<ProjectConfig> = {
+      $schema: 'node_modules/@lerna-lite/cli/schemas/lerna-schema.json',
+      version,
+    };
     if (!this.options.useWorkspaces) {
       lernaConfig.packages = ['packages/*'];
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a [JSON Schema](https://json-schema.org/) to `lerna.json`

## Motivation and Context

As per Lerna [PR 3229](https://github.com/lerna/lerna/pull/3229)
> This change improves the developer experience of Lerna. Now, when modifying lerna.json, users can see what properties are valid and a brief description of what they do (taken from the lerna command options documentation).

> Note: All options for commands (as described in the command docs) are valid configuration options in lerna.json. They can be provided at three levels, in order of priority:

> Command line inline option
> 1. `lerna.json`, under a specific command
> 2. Top level of `lerna.json`
> 3. The JSON schema for `lerna.json` supports supplying options at both level 2 and 3 above.

## How Has This Been Tested?

> I tested the schema by changing lerna.json in this repo and observing (in my editor) the metadata from the schema. I did not manually test every configuration option for every command. I obtained the metadata from the configuration code for each of the Lerna commands (command.js), with some input from the docs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
