### PR TITLE
fix(version): properly update dependencies npm lockfile v2

### DIFF
--- a/__fixtures__/lockfile-leaf-v2/packages/package-1/package-lock.json
+++ b/__fixtures__/lockfile-leaf-v2/packages/package-1/package-lock.json
@@ -8,7 +8,11 @@
       "name": "package-1",
       "version": "1.0.0",
       "dependencies": {
-        "tiny-tarball": "^1.0.0"
+        "tiny-tarball": "^1.0.0",
+        "package-2": "^1.0.0"
+      },
+      "devDependencies": {
+        "package-3": "2.0.0"
       }
     },
     "node_modules/tiny-tarball": {

--- a/__fixtures__/lockfile-leaf-v2/packages/package-1/package.json
+++ b/__fixtures__/lockfile-leaf-v2/packages/package-1/package.json
@@ -2,6 +2,10 @@
   "name": "package-1",
   "version": "1.0.0",
   "dependencies": {
-    "tiny-tarball": "^1.0.0"
+    "tiny-tarball": "^1.0.0",
+    "package-2": "^1.0.0"
+  },
+  "devDependencies": {
+    "package-3": "2.0.0"
   }
 }

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -44,6 +44,8 @@ describe('npm classic lock file', () => {
     const [pkg] = await Project.getPackages(cwd);
 
     pkg.version = '2.0.0';
+    pkg.dependencies['package-1'] = '^2.0.0';
+    pkg.devDependencies['package-2'] = '3.0.0';
 
     const returnedLockfilePath = await updateClassicLockfileVersion(pkg as unknown as Package);
 
@@ -51,7 +53,9 @@ describe('npm classic lock file', () => {
     expect(Array.from((loadJsonFile as any).registry.keys())).toStrictEqual(['/packages/package-1']);
     const updatedLockfile = fs.readJSONSync(returnedLockfilePath as string);
     expect(updatedLockfile).toHaveProperty('version', '2.0.0');
-    expect(updatedLockfile).toHaveProperty(['packages', '', 'version'], '2.0.0');
+    expect(updatedLockfile).toHaveProperty(['packages', '', 'dependencies', 'package-1'], '^2.0.0');
+    expect(updatedLockfile).toHaveProperty(['packages', '', 'dependencies', 'tiny-tarball'], '^1.0.0');
+    expect(updatedLockfile).toHaveProperty(['packages', '', 'devDependencies', 'package-2'], '3.0.0');
   });
 
   test('updateClassicLockfileVersion without sibling lockfile', async () => {

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -45,6 +45,12 @@ export async function updateClassicLockfileVersion(pkg: Package): Promise<string
       // update version for a npm lockfile v2 format
       if (pkgLockFileObj.packages?.['']) {
         pkgLockFileObj.packages[''].version = pkg.version;
+        if (pkgLockFileObj.packages[''].dependencies) {
+          pkgLockFileObj.packages[''].dependencies = pkg.dependencies;
+        }
+        if (pkgLockFileObj.packages[''].devDependencies) {
+          pkgLockFileObj.packages[''].devDependencies = pkg.devDependencies;
+        }
       }
 
       await writeJsonFile(lockFilePath, pkgLockFileObj, {


### PR DESCRIPTION
npm lockfile v2 includes dependencies and devDependencies,
this commit updates those based on the updated package.

## Description

As per Lerna PR
> Follow up of PR https://github.com/lerna/lerna/pull/3091, also update lockfile v2 packages."".dependencies and packages."".devDependencies keys.

## Motivation and Context

As per Lerna [PR 3275](https://github.com/lerna/lerna/pull/3275)
> Solves an issue with npm lockfile v2, where dependencies/devDependencies are not properly updated.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
