### PR TITLE
chore: add dry-run prefix to version/publish prompt for easier dry-run

### DIFF
--- a/packages/publish/src/__tests__/publish-from-git.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-git.spec.ts
@@ -79,6 +79,26 @@ describe('publish from-git', () => {
     ]);
   });
 
+  it('publishes tagged packages in dry-run mode', async () => {
+    const cwd = await initFixture('normal');
+
+    await gitTag(cwd, 'v1.0.0');
+    await new PublishCommand(createArgv(cwd, '--bump', 'from-git', '--git-dry-run'));
+
+    // called from chained describeRef()
+    expect(throwIfUncommitted).toHaveBeenCalled();
+
+    expect(promptConfirmation).toHaveBeenLastCalledWith('dry-run> Are you sure you want to publish these packages?');
+    expect((logOutput as any).logged()).toMatch('Found 4 packages to publish:');
+    expect((npmPublish as typeof npmPublishMock).order()).toEqual([
+      'package-1',
+      'package-4',
+      'package-2',
+      'package-3',
+      // package-5 is private
+    ]);
+  });
+
   it('publishes tagged packages, lexically sorted when --no-sort is present', async () => {
     const cwd = await initFixture('normal');
 

--- a/packages/publish/src/__tests__/publish-from-package.spec.ts
+++ b/packages/publish/src/__tests__/publish-from-package.spec.ts
@@ -79,6 +79,21 @@ describe('publish from-package', () => {
     expect((npmPublish as typeof npmPublishMock).order()).toEqual(['package-2', 'package-3']);
   });
 
+  it('publishes unpublished packages in dry-run mode', async () => {
+    const cwd = await initFixture('normal');
+
+    (getUnpublishedPackages as jest.Mock).mockImplementationOnce((packageGraph) => {
+      const pkgs = packageGraph.rawPackageList.slice(1, 3);
+      return pkgs.map((pkg) => packageGraph.get(pkg.name));
+    });
+
+    await new PublishCommand(createArgv(cwd, '--bump', 'from-package', '--git-dry-run'));
+
+    expect(promptConfirmation).toHaveBeenLastCalledWith('dry-run> Are you sure you want to publish these packages?');
+    expect((logOutput as any).logged()).toMatch('Found 2 packages to publish:');
+    expect((npmPublish as typeof npmPublishMock).order()).toEqual(['package-2', 'package-3']);
+  });
+
   it('publishes unpublished independent packages', async () => {
     const cwd = await initFixture('independent');
 

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -486,7 +486,9 @@ export class PublishCommand extends Command<PublishCommandOption> {
       return true;
     }
 
-    return promptConfirmation('Are you sure you want to publish these packages?');
+    let confirmMessage = this.options.gitDryRun ? 'dry-run> ' : '';
+    confirmMessage += 'Are you sure you want to publish these packages?';
+    return promptConfirmation(confirmMessage);
   }
 
   prepareLicenseActions() {

--- a/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
@@ -344,6 +344,318 @@ index SHA..SHA 100644
 +  \\"version\\": \\"1.1.0\\","
 `;
 
+exports[`VersionCommand normal mode versions changed packages in dry-run mode: commit 1`] = `
+"Init commit
+
+HEAD -> main
+
+diff --git a/lerna.json b/lerna.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/lerna.json
+@@ -0,0 +1,3 @@
++{
++  \\"version\\": \\"1.0.0\\"
++}
+diff --git a/package.json b/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/package.json
+@@ -0,0 +1,3 @@
++{
++  \\"name\\": \\"normal\\"
++}
+diff --git a/packages/package-1/package.json b/packages/package-1/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-1/package.json
+@@ -0,0 +1,4 @@
++{
++  \\"name\\": \\"package-1\\",
++  \\"version\\": \\"1.0.0\\"
++}
+diff --git a/packages/package-2/package.json b/packages/package-2/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-2/package.json
+@@ -0,0 +1,7 @@
++{
++  \\"name\\": \\"package-2\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^1.0.0\\"
++  }
++}
+diff --git a/packages/package-3/package.json b/packages/package-3/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-3/package.json
+@@ -0,0 +1,10 @@
++{
++  \\"name\\": \\"package-3\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"peerDependencies\\": {
++    \\"package-2\\": \\"^1.0.0\\"
++  },
++  \\"devDependencies\\": {
++    \\"package-2\\": \\"^1.0.0\\"
++  }
++}
+diff --git a/packages/package-4/package.json b/packages/package-4/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-4/package.json
+@@ -0,0 +1,7 @@
++{
++  \\"name\\": \\"package-4\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^0.0.0\\"
++  }
++}
+diff --git a/packages/package-5/package.json b/packages/package-5/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-5/package.json
+@@ -0,0 +1,11 @@
++{
++  \\"name\\": \\"package-5\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^1.0.0\\"
++  },
++  \\"optionalDependencies\\": {
++    \\"package-3\\": \\"^1.0.0\\"
++  },
++  \\"private\\": true,
++  \\"version\\": \\"1.0.0\\"
++}"
+`;
+
+exports[`VersionCommand normal mode versions changed packages in dry-run mode: console output 1`] = `
+"
+Changes (5 packages):
+ - package-1: 1.0.0 => 1.0.1
+ - package-2: 1.0.0 => 1.0.1
+ - package-3: 1.0.0 => 1.0.1
+ - package-4: 1.0.0 => 1.0.1
+ - package-5: 1.0.0 => 1.0.1 (private)
+"
+`;
+
+exports[`VersionCommand normal mode versions changed packages in dry-run mode: gitHead 1`] = `
+Object {
+  "name": "package-1",
+  "version": "1.0.1",
+}
+`;
+
+exports[`VersionCommand normal mode versions changed packages in dry-run mode: prompt 1`] = `
+Array [
+  Array [
+    "Select a new version (currently 1.0.0)",
+    Object {
+      "choices": Array [
+        Object {
+          "name": "Patch (1.0.1)",
+          "value": "1.0.1",
+        },
+        Object {
+          "name": "Minor (1.1.0)",
+          "value": "1.1.0",
+        },
+        Object {
+          "name": "Major (2.0.0)",
+          "value": "2.0.0",
+        },
+        Object {
+          "name": "Prepatch (1.0.1-alpha.0)",
+          "value": "1.0.1-alpha.0",
+        },
+        Object {
+          "name": "Preminor (1.1.0-alpha.0)",
+          "value": "1.1.0-alpha.0",
+        },
+        Object {
+          "name": "Premajor (2.0.0-alpha.0)",
+          "value": "2.0.0-alpha.0",
+        },
+        Object {
+          "name": "Custom Prerelease",
+          "value": "PRERELEASE",
+        },
+        Object {
+          "name": "Custom Version",
+          "value": "CUSTOM",
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`VersionCommand normal mode versions changed packages with publish prompt in dry-run mode: commit 1`] = `
+"Init commit
+
+HEAD -> main
+
+diff --git a/lerna.json b/lerna.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/lerna.json
+@@ -0,0 +1,3 @@
++{
++  \\"version\\": \\"1.0.0\\"
++}
+diff --git a/package.json b/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/package.json
+@@ -0,0 +1,3 @@
++{
++  \\"name\\": \\"normal\\"
++}
+diff --git a/packages/package-1/package.json b/packages/package-1/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-1/package.json
+@@ -0,0 +1,4 @@
++{
++  \\"name\\": \\"package-1\\",
++  \\"version\\": \\"1.0.0\\"
++}
+diff --git a/packages/package-2/package.json b/packages/package-2/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-2/package.json
+@@ -0,0 +1,7 @@
++{
++  \\"name\\": \\"package-2\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^1.0.0\\"
++  }
++}
+diff --git a/packages/package-3/package.json b/packages/package-3/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-3/package.json
+@@ -0,0 +1,10 @@
++{
++  \\"name\\": \\"package-3\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"peerDependencies\\": {
++    \\"package-2\\": \\"^1.0.0\\"
++  },
++  \\"devDependencies\\": {
++    \\"package-2\\": \\"^1.0.0\\"
++  }
++}
+diff --git a/packages/package-4/package.json b/packages/package-4/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-4/package.json
+@@ -0,0 +1,7 @@
++{
++  \\"name\\": \\"package-4\\",
++  \\"version\\": \\"1.0.0\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^0.0.0\\"
++  }
++}
+diff --git a/packages/package-5/package.json b/packages/package-5/package.json
+new file mode 100644
+index SHA..SHA
+--- /dev/null
++++ b/packages/package-5/package.json
+@@ -0,0 +1,11 @@
++{
++  \\"name\\": \\"package-5\\",
++  \\"dependencies\\": {
++    \\"package-1\\": \\"^1.0.0\\"
++  },
++  \\"optionalDependencies\\": {
++    \\"package-3\\": \\"^1.0.0\\"
++  },
++  \\"private\\": true,
++  \\"version\\": \\"1.0.0\\"
++}"
+`;
+
+exports[`VersionCommand normal mode versions changed packages with publish prompt in dry-run mode: console output 1`] = `
+"
+Changes (5 packages):
+ - package-1: 1.0.0 => 1.0.1
+ - package-2: 1.0.0 => 1.0.1
+ - package-3: 1.0.0 => 1.0.1
+ - package-4: 1.0.0 => 1.0.1
+ - package-5: 1.0.0 => 1.0.1 (private)
+"
+`;
+
+exports[`VersionCommand normal mode versions changed packages with publish prompt in dry-run mode: gitHead 1`] = `
+Object {
+  "name": "package-1",
+  "version": "1.0.1",
+}
+`;
+
+exports[`VersionCommand normal mode versions changed packages with publish prompt in dry-run mode: prompt 1`] = `
+Array [
+  Array [
+    "Select a new version (currently 1.0.0)",
+    Object {
+      "choices": Array [
+        Object {
+          "name": "Patch (1.0.1)",
+          "value": "1.0.1",
+        },
+        Object {
+          "name": "Minor (1.1.0)",
+          "value": "1.1.0",
+        },
+        Object {
+          "name": "Major (2.0.0)",
+          "value": "2.0.0",
+        },
+        Object {
+          "name": "Prepatch (1.0.1-alpha.0)",
+          "value": "1.0.1-alpha.0",
+        },
+        Object {
+          "name": "Preminor (1.1.0-alpha.0)",
+          "value": "1.1.0-alpha.0",
+        },
+        Object {
+          "name": "Premajor (2.0.0-alpha.0)",
+          "value": "2.0.0-alpha.0",
+        },
+        Object {
+          "name": "Custom Prerelease",
+          "value": "PRERELEASE",
+        },
+        Object {
+          "name": "Custom Version",
+          "value": "CUSTOM",
+        },
+      ],
+    },
+  ],
+]
+`;
+
 exports[`VersionCommand normal mode versions changed packages with publish prompt: commit 1`] = `
 "v1.0.1
 

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -132,6 +132,33 @@ describe('VersionCommand', () => {
       expect((logOutput as any).logged()).toMatchSnapshot('console output');
     });
 
+    it('versions changed packages in dry-run mode', async () => {
+      const testDir = await initFixture('normal');
+      // when --conventional-commits is absent,
+      // --no-changelog should have _no_ effect
+      await new VersionCommand(createArgv(testDir, '--no-changelog', '--git-dry-run'));
+
+      expect(checkWorkingTree).toHaveBeenCalled();
+
+      expect((promptSelectOne as jest.Mock).mock.calls).toMatchSnapshot('prompt');
+      expect(promptConfirmation).toHaveBeenLastCalledWith('dry-run> Are you sure you want to create these versions?');
+
+      expect((writePkg as any).updatedManifest('package-1')).toMatchSnapshot('gitHead');
+
+      const patch = await showCommit(testDir);
+      expect(patch).toMatchSnapshot('commit');
+
+      expect(libPush).toHaveBeenLastCalledWith(
+        'origin',
+        'main',
+        expect.objectContaining({
+          cwd: testDir,
+        }),
+        true
+      );
+      expect((logOutput as any).logged()).toMatchSnapshot('console output');
+    });
+
     it('versions changed packages with publish prompt', async () => {
       const testDir = await initFixture('normal');
       // when --conventional-commits is absent,
@@ -155,6 +182,33 @@ describe('VersionCommand', () => {
           cwd: testDir,
         }),
         undefined
+      );
+      expect((logOutput as any).logged()).toMatchSnapshot('console output');
+    });
+
+    it('versions changed packages with publish prompt in dry-run mode', async () => {
+      const testDir = await initFixture('normal');
+      // when --conventional-commits is absent,
+      // --no-changelog should have _no_ effect
+      await new VersionCommand({ ...createArgv(testDir, '--no-changelog', '--git-dry-run'), composed: 'composed' });
+
+      expect(checkWorkingTree).toHaveBeenCalled();
+
+      expect((promptSelectOne as jest.Mock).mock.calls).toMatchSnapshot('prompt');
+      expect(promptConfirmation).toHaveBeenLastCalledWith('dry-run> Are you sure you want to publish these packages?');
+
+      expect((writePkg as any).updatedManifest('package-1')).toMatchSnapshot('gitHead');
+
+      const patch = await showCommit(testDir);
+      expect(patch).toMatchSnapshot('commit');
+
+      expect(libPush).toHaveBeenLastCalledWith(
+        'origin',
+        'main',
+        expect.objectContaining({
+          cwd: testDir,
+        }),
+        true
       );
       expect((logOutput as any).logged()).toMatchSnapshot('console output');
     });

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -567,11 +567,12 @@ export class VersionCommand extends Command<VersionCommandOption> {
     }
 
     // When composed from `lerna publish`, use this opportunity to confirm publishing
-    const message = this.composed
+    let confirmMessage = this.options.gitDryRun ? 'dry-run> ' : '';
+    confirmMessage += this.composed
       ? 'Are you sure you want to publish these packages?'
       : 'Are you sure you want to create these versions?';
 
-    return promptConfirmation(message);
+    return promptConfirmation(confirmMessage);
   }
 
   updatePackageVersions() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

simply add "dry-run> " prefix on version/publish prompt

## Motivation and Context

to clearly identify that the user is in dry-run mode

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
