### PR TITLE
fix(core): use match pattern to get last tag date with independent mode

### DIFF
--- a/packages/core/src/conventional-commits/__tests__/get-commits-since-last-release.spec.ts
+++ b/packages/core/src/conventional-commits/__tests__/get-commits-since-last-release.spec.ts
@@ -31,15 +31,25 @@ describe('getCommitsSinceLastRelease', () => {
   });
 
   it('throws an error if used with a remote client other than "github"', async () => {
-    await expect(getCommitsSinceLastRelease('gitlab', 'durable', 'main', execOpts)).rejects.toThrow(
+    await expect(getCommitsSinceLastRelease('gitlab', 'durable', 'main', false, execOpts)).rejects.toThrow(
       'Invalid remote client type, "github" is currently the only supported client with the option --changelog-include-commits-client-login.'
     );
   });
 
   it('should expect commits returned when using "github" when a valid tag is returned', async () => {
     (getGithubCommits as jest.Mock).mockResolvedValue(commitsStub);
-    const result = await getCommitsSinceLastRelease('github', 'durable', 'main', execOpts);
+    const isIndependent = false;
+    const result = await getCommitsSinceLastRelease('github', 'durable', 'main', isIndependent, execOpts);
 
+    expect(result).toEqual(commitsStub);
+  });
+
+  it('should expect commits returned when using "github" when a valid tag in independent mode is returned', async () => {
+    (getGithubCommits as jest.Mock).mockResolvedValue(commitsStub);
+    const isIndependent = true;
+    const result = await getCommitsSinceLastRelease('github', 'durable', 'main', isIndependent, execOpts);
+
+    expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, false);
     expect(result).toEqual(commitsStub);
   });
 });
@@ -75,7 +85,7 @@ describe('getOldestCommitSinceLastTag', () => {
       (describeRefSync as jest.Mock).mockReturnValue(tagStub);
     });
 
-    it('should expect a result with a tag date, hash and ref count', async () => {
+    it('should return first commit date and hash when last tag is not found', async () => {
       const execSpy = (execSync as jest.Mock)
         .mockReturnValueOnce('')
         .mockReturnValueOnce('"deedbeaf 2022-07-01T00:01:02-04:00"');
@@ -87,11 +97,36 @@ describe('getOldestCommitSinceLastTag', () => {
       expect(result).toEqual({ commitDate: '2022-07-01T00:01:02-04:00', commitHash: 'deedbeaf' });
     });
 
-    it('should expect a result with a tag date, hash and ref count', async () => {
-      const result = await getOldestCommitSinceLastTag(execOpts);
+    it('should expect a result with a tag date, hash and ref count when last tag is found', async () => {
+      const result = await getOldestCommitSinceLastTag(execOpts, false, false);
       const execSpy = (execSync as jest.Mock).mockReturnValueOnce('"deadbeef 2022-07-01T00:01:02-04:00"');
 
+      expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test' }, false);
       expect(execSpy).toHaveBeenCalledWith('git', ['log', 'v1.0.0..HEAD', '--format="%h %aI"', '--reverse'], execOpts);
+      expect(result).toEqual({ commitDate: '2022-07-01T00:01:02-04:00', commitHash: 'deadbeef' });
+    });
+  });
+
+  describe('with existing tag in independent mode', () => {
+    beforeEach(() => {
+      (describeRefSync as jest.Mock).mockReturnValue({
+        ...tagStub,
+        lastTagName: '@my-workspace/pkg-a@2.0.3',
+        lastVersion: '2.0.3',
+      });
+    });
+
+    it('should expect a tag date & hash but queried with a particular tag match pattern when using independent mode', async () => {
+      const isIndependent = true;
+      const result = await getOldestCommitSinceLastTag(execOpts, isIndependent, false);
+      const execSpy = (execSync as jest.Mock).mockReturnValueOnce('"deadbeef 2022-07-01T00:01:02-04:00"');
+
+      expect(describeRefSync).toHaveBeenCalledWith({ cwd: '/test', match: '*@*' }, false);
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['log', '@my-workspace/pkg-a@2.0.3..HEAD', '--format="%h %aI"', '--reverse'],
+        execOpts
+      );
       expect(result).toEqual({ commitDate: '2022-07-01T00:01:02-04:00', commitHash: 'deadbeef' });
     });
   });

--- a/packages/core/src/conventional-commits/get-commits-since-last-release.ts
+++ b/packages/core/src/conventional-commits/get-commits-since-last-release.ts
@@ -20,7 +20,7 @@ export async function getCommitsSinceLastRelease(
   client: RemoteClientType,
   gitRemote: string,
   branchName: string,
-  isIndependent = false,
+  isIndependent?: boolean,
   execOpts?: ExecOpts
 ): Promise<RemoteCommit[]> {
   // get the last release tag date or the first commit date if no release tag found

--- a/packages/core/src/conventional-commits/get-commits-since-last-release.ts
+++ b/packages/core/src/conventional-commits/get-commits-since-last-release.ts
@@ -12,6 +12,7 @@ import { ValidationError } from '../validation-error';
  * @param {RemoteClientType} client
  * @param {String} gitRemote
  * @param {String} branchName
+ * @param {Boolean} [isIndependent]
  * @param {ExecOpts} [execOpts]
  * @returns {Promise<RemoteCommit[]>}
  */
@@ -19,10 +20,11 @@ export async function getCommitsSinceLastRelease(
   client: RemoteClientType,
   gitRemote: string,
   branchName: string,
+  isIndependent = false,
   execOpts?: ExecOpts
 ): Promise<RemoteCommit[]> {
   // get the last release tag date or the first commit date if no release tag found
-  const { commitDate } = getOldestCommitSinceLastTag(execOpts, false);
+  const { commitDate } = getOldestCommitSinceLastTag(execOpts, isIndependent, false);
 
   switch (client) {
     case 'github':
@@ -40,11 +42,15 @@ export async function getCommitsSinceLastRelease(
  * Find the oldest commit details since the last release tag or else if not tag exists then return first commit info
  * @param {ExecOpts} [execOpts]
  * @param {Boolean} [includeMergedTags]
+ * @param {Boolean} [isIndependent]
  * @returns {*} - oldest commit detail (hash, date)
  */
-export function getOldestCommitSinceLastTag(execOpts?: ExecOpts, includeMergedTags?: boolean) {
+export function getOldestCommitSinceLastTag(execOpts?: ExecOpts, isIndependent?: boolean, includeMergedTags?: boolean) {
   let commitResult = '';
   const describeOptions: DescribeRefOptions = { ...execOpts };
+  if (isIndependent) {
+    describeOptions.match = '*@*'; // independent tag pattern
+  }
   const { lastTagName } = describeRefSync(describeOptions, includeMergedTags);
 
   if (lastTagName) {

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -282,6 +282,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
         remoteClient,
         this.options.gitRemote,
         this.currentBranch,
+        isIndependent,
         this.execOpts
       );
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using the feature `--changelog-include-commits-client-login`, we need to find the last tag since the last release but when using `independent` mode, we need to add an extra argument to `describeRef` so that it returns the correct tag.  We should include a match pattern of `*@*` when calling `describeRef` (relates to a previously closed issue #220)

## Motivation and Context

This PR should fix issue #310

## How Has This Been Tested?

I'm not using `independent` mode myself, so this fix will need to be confirmed with the user who opened the issue once a new release is available

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
