### PR TITLE
chore: remove unnecessary `whatwg-url` dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,7 +81,6 @@
     "tar": "^6.1.11",
     "temp-dir": "^1.0.0",
     "uuid": "^8.3.2",
-    "whatwg-url": "^11.0.0",
     "write-file-atomic": "^4.0.2",
     "write-json-file": "^4.3.0",
     "write-pkg": "^4.0.0",

--- a/packages/core/src/git-clients/GitLabClient.ts
+++ b/packages/core/src/git-clients/GitLabClient.ts
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch';
 import log from 'npmlog';
 import path from 'path';
-import { URL } from 'whatwg-url';
 
 import { GitClient, GitClientRelease } from '../models';
 
@@ -9,7 +8,7 @@ export class GitLabClient implements GitClient {
   baseUrl: string;
   token: string;
 
-  constructor(baseUrl = 'https://gitlab.com/api/v4', token: string) {
+  constructor(token: string, baseUrl = 'https://gitlab.com/api/v4') {
     this.baseUrl = baseUrl;
     this.token = token;
   }

--- a/packages/core/src/git-clients/__tests__/GitLabClient.spec.ts
+++ b/packages/core/src/git-clients/__tests__/GitLabClient.spec.ts
@@ -8,7 +8,7 @@ import { GitLabClient } from '../GitLabClient';
 describe('GitLabClient', () => {
   describe('constructor', () => {
     it('sets `baseUrl` and `token`', () => {
-      const client = new GitLabClient('http://some/host', 'TOKEN');
+      const client = new GitLabClient('TOKEN', 'http://some/host');
 
       expect(client.baseUrl).toEqual('http://some/host');
       expect(client.token).toEqual('TOKEN');
@@ -17,7 +17,7 @@ describe('GitLabClient', () => {
 
   describe('releasesUrl', () => {
     it('returns a GitLab releases API URL', () => {
-      const client = new GitLabClient('http://some/host', 'TOKEN');
+      const client = new GitLabClient('TOKEN', 'http://some/host');
       const url = client.releasesUrl('the-namespace', 'the-project');
 
       expect(url).toEqual('http://some/host/projects/the-namespace%2Fthe-project/releases');
@@ -26,7 +26,7 @@ describe('GitLabClient', () => {
 
   describe('createRelease', () => {
     it('requests releases api with release', () => {
-      const client = new GitLabClient('http://some/host', 'TOKEN');
+      const client = new GitLabClient('TOKEN', 'http://some/host');
       (fetch as jest.Mock).mockResolvedValue({ ok: true });
       const release = {
         owner: 'the-owner',

--- a/packages/core/src/git-clients/__tests__/gitlab-client.spec.ts
+++ b/packages/core/src/git-clients/__tests__/gitlab-client.spec.ts
@@ -33,7 +33,7 @@ describe('createGitLabClient', () => {
 
     createGitLabClient();
 
-    expect(GitLabClient).toHaveBeenCalledWith('http://some/host', 'TOKEN');
+    expect(GitLabClient).toHaveBeenCalledWith('TOKEN', 'http://some/host');
   });
 
   it('has a createRelease method like ocktokit', () => {

--- a/packages/core/src/git-clients/gitlab-client.ts
+++ b/packages/core/src/git-clients/gitlab-client.ts
@@ -14,7 +14,7 @@ function createGitLabClient() {
     throw new Error('A GL_TOKEN environment variable is required.');
   }
 
-  const client = new GitLabClient(GL_API_URL, GL_TOKEN);
+  const client = new GitLabClient(GL_TOKEN, GL_API_URL);
 
   return OcktokitAdapter(client);
 }

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -56,7 +56,6 @@
     "ssri": "^9.0.1",
     "strong-log-transformer": "^2.1.0",
     "tar": "^6.1.11",
-    "whatwg-url": "^11.0.0",
     "write-file-atomic": "^4.0.2",
     "write-json-file": "^4.3.0",
     "write-pkg": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,7 +225,6 @@ importers:
       tar: ^6.1.11
       temp-dir: ^1.0.0
       uuid: ^8.3.2
-      whatwg-url: ^11.0.0
       write-file-atomic: ^4.0.2
       write-json-file: ^4.3.0
       write-pkg: ^4.0.0
@@ -282,7 +281,6 @@ importers:
       tar: 6.1.11
       temp-dir: 1.0.0
       uuid: 8.3.2
-      whatwg-url: 11.0.0
       write-file-atomic: 4.0.2
       write-json-file: 4.3.0
       write-pkg: 4.0.0
@@ -479,7 +477,6 @@ importers:
       ssri: ^9.0.1
       strong-log-transformer: ^2.1.0
       tar: ^6.1.11
-      whatwg-url: ^11.0.0
       write-file-atomic: ^4.0.2
       write-json-file: ^4.3.0
       write-pkg: ^4.0.0
@@ -511,7 +508,6 @@ importers:
       ssri: 9.0.1
       strong-log-transformer: 2.1.0
       tar: 6.1.11
-      whatwg-url: 11.0.0
       write-file-atomic: 4.0.2
       write-json-file: 4.3.0
       write-pkg: 4.0.0
@@ -2593,8 +2589,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -5761,6 +5757,7 @@ packages:
   /punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
+    dev: true
 
   /q/1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
@@ -6364,13 +6361,6 @@ packages:
     resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
     dev: false
 
-  /tr46/3.0.0:
-    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
-    engines: {node: '>=12'}
-    dependencies:
-      punycode: 2.1.1
-    dev: false
-
   /trim-newlines/3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
@@ -6613,19 +6603,6 @@ packages:
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
-    dev: false
-
-  /webidl-conversions/7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /whatwg-url/11.0.0:
-    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      tr46: 3.0.0
-      webidl-conversions: 7.0.0
     dev: false
 
   /whatwg-url/5.0.0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follows Lerna [PR 3297](https://github.com/lerna/lerna/pull/3297)

> Remove the `whatwg-url` dependency that is no longer needed. Also fixes a lint error with the GitLabClient constructor.

## Motivation and Context

as per Lerna PR

> Node v10 and above has native support for the WHATWG url specification via the global "URL" class, so a dedicated package for it is no longer needed.

## How Has This Been Tested?

as per Lerna PR
> Unit tests cover the creation of all URLs that were affected by this change (`GitLabClient.test.js` and `create-command.test.js`). Unit tests also cover the creation of the `GitLabClient`, whose arguments were rearranged for the lint fix. `GitLabClient` itself is not exported from the utility library, so it has no public consumers to worry about.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
