### PR TITLE
fix(version): ignore any scripts execution when updating pnpm lock file

### DIFF
--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -587,7 +587,7 @@ npm install --package-lock-only     # npm client >= 8.5.0
 npm shrinkwrap --package-lock-only  # npm client < 8.5.0 will execute a file rename of shrinkwrap file behind the scene
 
 # pnpm is assuming a "pnpm-lock.yaml" lock file and "npmClient": "pnpm"
-pnpm install --lockfile-only
+pnpm install --lockfile-only --ignore-scripts
 
 # yarn is assuming a "yarn.lock" lock file and "npmClient": "yarn"
 yarn install --mode update-lockfile

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -168,7 +168,7 @@ describe('run install lockfile-only', () => {
 
       const lockFileOutput = await runInstallLockFileOnly('pnpm', cwd);
 
-      expect(execSpy).toHaveBeenCalledWith('pnpm', ['install', '--lockfile-only'], { cwd });
+      expect(execSpy).toHaveBeenCalledWith('pnpm', ['install', '--lockfile-only', '--ignore-scripts'], { cwd });
       expect(lockFileOutput).toBe('pnpm-lock.yaml');
     });
   });

--- a/packages/version/src/__tests__/update-lockfile-version.spec.ts
+++ b/packages/version/src/__tests__/update-lockfile-version.spec.ts
@@ -153,7 +153,7 @@ describe('run install lockfile-only', () => {
       expect(logSpy).toHaveBeenCalledWith(
         'lock',
         expect.stringContaining(
-          `we could not sync or locate "pnpm-lock.yaml" by using "pnpm" client at location ${cwd}`
+          `we could not sync neither locate "pnpm-lock.yaml" by using "pnpm" client at location ${cwd}`
         )
       );
       expect(lockFileOutput).toBe(undefined);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

We should not run pnpm install lifecycle scripts when we simply want to update `pnpm-lock.yaml`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
