### PR TITLE
chore(deps): upgrade to Jest v29

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "pnpm": "7"
   },
   "devDependencies": {
-    "@jest/types": "^28.1.3",
+    "@jest/types": "^29.0.0",
     "@lerna-lite/changed": "workspace:*",
     "@lerna-lite/cli": "workspace:*",
     "@lerna-lite/core": "workspace:*",
@@ -63,7 +63,7 @@
     "@lerna-lite/version": "workspace:*",
     "@lerna-test/helpers": "link:helpers",
     "@types/jest": "^28.1.8",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.7.13",
     "@types/npmlog": "^4.1.4",
     "@types/yargs": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
@@ -80,8 +80,8 @@
     "find-up": "^5.0.0",
     "fs-extra": "^10.1.0",
     "globby": "^11.1.0",
-    "jest": "^28.1.3",
-    "jest-cli": "^28.1.3",
+    "jest": "^29.0.0",
+    "jest-cli": "^29.0.0",
     "jest-extended": "^3.0.2",
     "load-json-file": "^6.2.0",
     "normalize-newline": "^3.0.0",

--- a/packages/changed/src/__tests__/changed-command.spec.ts
+++ b/packages/changed/src/__tests__/changed-command.spec.ts
@@ -63,20 +63,20 @@ describe('Changed Command', () => {
     await factory(createArgv(cwd, ''));
 
     expect((logOutput as any).logged()).toMatchInlineSnapshot(`
-package-2
-package-3
-`);
+      package-2
+      package-3
+    `);
   });
 
   it('passes --force-publish to update collector', async () => {
     await new ChangedCommand(createArgv(cwd, '--force-publish'));
 
     expect((logOutput as any).logged()).toMatchInlineSnapshot(`
-package-1
-package-2
-package-3
-package-4
-`);
+      package-1
+      package-2
+      package-3
+      package-4
+    `);
     expect(collectUpdates).toHaveBeenLastCalledWith(
       expect.any(Array),
       expect.any(Object),
@@ -177,12 +177,12 @@ package-4
     await lernaChanged(cwd)('-alp');
 
     expect((logOutput as any).logged()).toMatchInlineSnapshot(`
-__TEST_ROOTDIR__/packages/package-1:package-1:1.0.0
-__TEST_ROOTDIR__/packages/package-2:package-2:1.0.0
-__TEST_ROOTDIR__/packages/package-3:package-3:1.0.0
-__TEST_ROOTDIR__/packages/package-4:package-4:1.0.0
-__TEST_ROOTDIR__/packages/package-5:package-5:1.0.0:PRIVATE
-`);
+      __TEST_ROOTDIR__/packages/package-1:package-1:1.0.0
+      __TEST_ROOTDIR__/packages/package-2:package-2:1.0.0
+      __TEST_ROOTDIR__/packages/package-3:package-3:1.0.0
+      __TEST_ROOTDIR__/packages/package-4:package-4:1.0.0
+      __TEST_ROOTDIR__/packages/package-5:package-5:1.0.0:PRIVATE
+    `);
   });
 
   it('outputs a stringified array of result objects with --json', async () => {
@@ -193,20 +193,20 @@ __TEST_ROOTDIR__/packages/package-5:package-5:1.0.0:PRIVATE
     // Output should be a parseable string
     const jsonOutput = JSON.parse((logOutput as any).logged());
     expect(jsonOutput).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "location": "__TEST_ROOTDIR__/packages/package-2",
-    "name": "package-2",
-    "private": false,
-    "version": "1.0.0",
-  },
-  Object {
-    "location": "__TEST_ROOTDIR__/packages/package-3",
-    "name": "package-3",
-    "private": false,
-    "version": "1.0.0",
-  },
-]
-`);
+      [
+        {
+          "location": "__TEST_ROOTDIR__/packages/package-2",
+          "name": "package-2",
+          "private": false,
+          "version": "1.0.0",
+        },
+        {
+          "location": "__TEST_ROOTDIR__/packages/package-3",
+          "name": "package-3",
+          "private": false,
+          "version": "1.0.0",
+        },
+      ]
+    `);
   });
 });

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -386,8 +386,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "workspace:2.0.0",
               "b": "workspace:>=1.0.0",
               "c": "workspace:./foo",
@@ -413,8 +413,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "devDependencies": Object {
+          {
+            "devDependencies": {
               "a": "workspace:*",
               "b": "workspace:^1.0.0",
             },
@@ -437,8 +437,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "optionalDependencies": Object {
+          {
+            "optionalDependencies": {
               "a": "workspace:^",
               "b": "workspace:^1.0.0",
             },
@@ -461,8 +461,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "workspace:~",
               "b": "workspace:^1.0.0",
             },
@@ -485,8 +485,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "workspace:2.0.0",
               "b": "workspace:^1.0.0",
             },
@@ -509,8 +509,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolved, '2.0.0', '^');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "workspace:>=2.0.0",
               "b": "workspace:^1.0.0",
             },
@@ -539,8 +539,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolvedB, '1.1.0', '^', true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "2.0.0",
               "b": "^1.1.0",
             },
@@ -567,8 +567,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolvedB, '1.1.0', '~', true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "^2.0.0",
               "b": "~1.1.0",
             },
@@ -595,8 +595,8 @@ describe('Package', () => {
         pkg.updateLocalDependency(resolvedB, '1.1.0', '^', true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "~2.0.0",
               "b": "^1.1.0",
             },
@@ -632,8 +632,8 @@ describe('Package', () => {
           ].join('')
         );
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "a": "latest",
               "b": "^2.2.4",
             },

--- a/packages/core/src/package-graph/__tests__/package-graph.spec.ts
+++ b/packages/core/src/package-graph/__tests__/package-graph.spec.ts
@@ -15,10 +15,10 @@ describe('PackageGraph', () => {
       ];
 
       expect(() => new PackageGraph(pkgs)).toThrowErrorMatchingInlineSnapshot(`
-"Package name \\"pkg-2\\" used in multiple packages:
-	/test/pkg-2
-	/test/pkg-3"
-`);
+        "Package name "pkg-2" used in multiple packages:
+        	/test/pkg-2
+        	/test/pkg-3"
+      `);
     });
 
     it('externalizes non-satisfied semver of local sibling', () => {
@@ -394,19 +394,19 @@ describe('PackageGraph', () => {
       expect(nodes.size).toBe(2);
       expect(Array.from(cycles).length).toBe(1);
       expect(paths).toMatchInlineSnapshot(`
-Set {
-  Array [
-    "pkg-1",
-    "pkg-2",
-    "pkg-1",
-  ],
-  Array [
-    "pkg-2",
-    "pkg-1",
-    "pkg-2",
-  ],
-}
-`);
+        Set {
+          [
+            "pkg-1",
+            "pkg-2",
+            "pkg-1",
+          ],
+          [
+            "pkg-2",
+            "pkg-1",
+            "pkg-2",
+          ],
+        }
+      `);
     });
 
     it('prunes all cycles from the graph, retaining non-cycles', () => {
@@ -416,41 +416,41 @@ Set {
       graph.pruneCycleNodes(nodes as any);
 
       expect(Array.from(graph.keys())).toMatchInlineSnapshot(`
-Array [
-  "dag-1",
-  "dag-2a",
-  "dag-2b",
-  "dag-3",
-  "standalone",
-]
-`);
+        [
+          "dag-1",
+          "dag-2a",
+          "dag-2b",
+          "dag-3",
+          "standalone",
+        ]
+      `);
       expect(Array.from(nodes.keys() as any).map((node: any) => node.name)).toMatchInlineSnapshot(`
-Array [
-  "cycle-1",
-  "cycle-2",
-  "cycle-tiebreaker",
-]
-`);
+        [
+          "cycle-1",
+          "cycle-2",
+          "cycle-tiebreaker",
+        ]
+      `);
       expect(paths).toMatchInlineSnapshot(`
-Set {
-  Array [
-    "cycle-1",
-    "cycle-2",
-    "cycle-1",
-  ],
-  Array [
-    "cycle-2",
-    "cycle-1",
-    "cycle-2",
-  ],
-  Array [
-    "cycle-tiebreaker",
-    "cycle-1",
-    "cycle-2",
-    "cycle-1",
-  ],
-}
-`);
+        Set {
+          [
+            "cycle-1",
+            "cycle-2",
+            "cycle-1",
+          ],
+          [
+            "cycle-2",
+            "cycle-1",
+            "cycle-2",
+          ],
+          [
+            "cycle-tiebreaker",
+            "cycle-1",
+            "cycle-2",
+            "cycle-1",
+          ],
+        }
+      `);
     });
   });
 });

--- a/packages/core/src/project/__tests__/project.spec.ts
+++ b/packages/core/src/project/__tests__/project.spec.ts
@@ -210,13 +210,13 @@ describe('Project', () => {
       const project = new Project(testDir);
       const result = await project.getPackages();
       expect(result).toMatchInlineSnapshot(`
-        Array [
-          Object {
+        [
+          {
             "name": "pkg-1",
             "version": "1.0.0",
           },
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "pkg-1": "^1.0.0",
             },
             "name": "pkg-2",
@@ -236,13 +236,13 @@ describe('Project', () => {
     it('returns a list of package instances synchronously', () => {
       const project = new Project(testDir);
       expect(project.getPackagesSync()).toMatchInlineSnapshot(`
-        Array [
-          Object {
+        [
+          {
             "name": "pkg-1",
             "version": "1.0.0",
           },
-          Object {
-            "dependencies": Object {
+          {
+            "dependencies": {
               "pkg-1": "^1.0.0",
             },
             "name": "pkg-2",

--- a/packages/core/src/utils/collect-updates/__tests__/lib-collect-packages.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/lib-collect-packages.spec.ts
@@ -15,18 +15,18 @@ test('returns all packages', () => {
   const result = collectPackages(graph);
 
   expect(toNamesList(result)).toMatchInlineSnapshot(`
-Array [
-  "package-cycle-1",
-  "package-cycle-2",
-  "package-cycle-extraneous-1",
-  "package-cycle-extraneous-2",
-  "package-dag-1",
-  "package-dag-2a",
-  "package-dag-2b",
-  "package-dag-3",
-  "package-standalone",
-]
-`);
+    [
+      "package-cycle-1",
+      "package-cycle-2",
+      "package-cycle-extraneous-1",
+      "package-cycle-extraneous-2",
+      "package-dag-1",
+      "package-dag-2a",
+      "package-dag-2b",
+      "package-dag-3",
+      "package-standalone",
+    ]
+  `);
 });
 
 test('filters packages through isCandidate, passing node and name', () => {
@@ -38,13 +38,13 @@ test('filters packages through isCandidate, passing node and name', () => {
   const result = collectPackages(graph, { isCandidate });
 
   expect(toNamesList(result)).toMatchInlineSnapshot(`
-Array [
-  "package-cycle-1",
-  "package-cycle-2",
-  "package-cycle-extraneous-1",
-  "package-cycle-extraneous-2",
-]
-`);
+    [
+      "package-cycle-1",
+      "package-cycle-2",
+      "package-cycle-extraneous-1",
+      "package-cycle-extraneous-2",
+    ]
+  `);
 });
 
 test('calls onInclude with included package name', () => {

--- a/packages/optional-cmd-common/package.json
+++ b/packages/optional-cmd-common/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/execa": "^2.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.7.13",
     "@types/p-map": "^2.0.0"
   }
 }

--- a/packages/publish/src/__tests__/get-unpublished-packages.spec.ts
+++ b/packages/publish/src/__tests__/get-unpublished-packages.spec.ts
@@ -41,33 +41,33 @@ test('getUnpublishedPackages', async () => {
 
   expect((pacote as any).packument).toHaveBeenCalledWith('package-1', opts);
   expect(pkgs).toMatchInlineSnapshot(`
-Array [
-  PackageGraphNode {
-    "externalDependencies": Map {},
-    "localDependencies": Map {},
-    "localDependents": Map {},
-    "name": "package-1",
-  },
-  PackageGraphNode {
-    "externalDependencies": Map {},
-    "localDependencies": Map {},
-    "localDependents": Map {},
-    "name": "package-3",
-  },
-  PackageGraphNode {
-    "externalDependencies": Map {},
-    "localDependencies": Map {},
-    "localDependents": Map {},
-    "name": "package-4",
-  },
-  PackageGraphNode {
-    "externalDependencies": Map {},
-    "localDependencies": Map {},
-    "localDependents": Map {},
-    "name": "package-5",
-  },
-]
-`);
+    [
+      PackageGraphNode {
+        "externalDependencies": Map {},
+        "localDependencies": Map {},
+        "localDependents": Map {},
+        "name": "package-1",
+      },
+      PackageGraphNode {
+        "externalDependencies": Map {},
+        "localDependencies": Map {},
+        "localDependents": Map {},
+        "name": "package-3",
+      },
+      PackageGraphNode {
+        "externalDependencies": Map {},
+        "localDependencies": Map {},
+        "localDependents": Map {},
+        "name": "package-4",
+      },
+      PackageGraphNode {
+        "externalDependencies": Map {},
+        "localDependencies": Map {},
+        "localDependents": Map {},
+        "name": "package-5",
+      },
+    ]
+  `);
 });
 
 test('getUnpublishedPackages with private package', async () => {
@@ -80,13 +80,13 @@ test('getUnpublishedPackages with private package', async () => {
 
   expect((pacote as any).packument).toHaveBeenCalledWith('package-1', opts);
   expect(pkgs).toMatchInlineSnapshot(`
-Array [
-  PackageGraphNode {
-    "externalDependencies": Map {},
-    "localDependencies": Map {},
-    "localDependents": Map {},
-    "name": "package-1",
-  },
-]
-`);
+    [
+      PackageGraphNode {
+        "externalDependencies": Map {},
+        "localDependencies": Map {},
+        "localDependents": Map {},
+        "name": "package-1",
+      },
+    ]
+  `);
 });

--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -99,20 +99,20 @@ test('publish --canary', async () => {
 
   expect(promptConfirmation).toHaveBeenLastCalledWith('Are you sure you want to publish these packages?');
   expect((npmPublish as typeof npmPublishMock).registry).toMatchInlineSnapshot(`
-  Map {
-    "package-1" => "canary",
-    "package-4" => "canary",
-    "package-2" => "canary",
-    "package-3" => "canary",
-  }
-  `);
+      Map {
+        "package-1" => "canary",
+        "package-4" => "canary",
+        "package-2" => "canary",
+        "package-3" => "canary",
+      }
+    `);
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-  Object {
-    "package-1": 1.0.1-alpha.0+SHA,
-    "package-2": 1.0.1-alpha.0+SHA,
-    "package-3": 1.0.1-alpha.0+SHA,
-    "package-4": 1.0.1-alpha.0+SHA,
-  }
+    {
+      "package-1": 1.0.1-alpha.0+SHA,
+      "package-2": 1.0.1-alpha.0+SHA,
+      "package-3": 1.0.1-alpha.0+SHA,
+      "package-4": 1.0.1-alpha.0+SHA,
+    }
   `);
 });
 
@@ -128,20 +128,20 @@ test('publish --canary with auto-confirm --yes', async () => {
 
   expect(promptConfirmation).not.toHaveBeenCalled();
   expect((npmPublish as typeof npmPublishMock).registry).toMatchInlineSnapshot(`
-  Map {
-    "package-1" => "canary",
-    "package-4" => "canary",
-    "package-2" => "canary",
-    "package-3" => "canary",
-  }
-  `);
+      Map {
+        "package-1" => "canary",
+        "package-4" => "canary",
+        "package-2" => "canary",
+        "package-3" => "canary",
+      }
+    `);
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-  Object {
-    "package-1": 1.0.1-alpha.0+SHA,
-    "package-2": 1.0.1-alpha.0+SHA,
-    "package-3": 1.0.1-alpha.0+SHA,
-    "package-4": 1.0.1-alpha.0+SHA,
-  }
+    {
+      "package-1": 1.0.1-alpha.0+SHA,
+      "package-2": 1.0.1-alpha.0+SHA,
+      "package-3": 1.0.1-alpha.0+SHA,
+      "package-4": 1.0.1-alpha.0+SHA,
+    }
   `);
 });
 
@@ -153,12 +153,12 @@ test('publish --canary --preid beta', async () => {
   await factory(createArgv(cwd, '--canary', '--preid', 'beta'));
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.0.1-beta.0+SHA,
-  "package-2": 1.0.1-beta.0+SHA,
-  "package-3": 1.0.1-beta.0+SHA,
-}
-`);
+    {
+      "package-1": 1.0.1-beta.0+SHA,
+      "package-2": 1.0.1-beta.0+SHA,
+      "package-3": 1.0.1-beta.0+SHA,
+    }
+  `);
 });
 
 test("publish --canary --tag-version-prefix='abc'", async () => {
@@ -168,12 +168,12 @@ test("publish --canary --tag-version-prefix='abc'", async () => {
   await new PublishCommand(createArgv(cwd, '--canary', '--tag-version-prefix', 'abc'));
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-}
-`);
+    {
+      "package-1": 1.0.1-alpha.0+SHA,
+      "package-2": 1.0.1-alpha.0+SHA,
+      "package-3": 1.0.1-alpha.0+SHA,
+    }
+  `);
 });
 
 test('publish --canary <semver>', async () => {
@@ -184,12 +184,12 @@ test('publish --canary <semver>', async () => {
   // prerelease === prepatch, which is the default
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-}
-`);
+    {
+      "package-1": 1.0.1-alpha.0+SHA,
+      "package-2": 1.0.1-alpha.0+SHA,
+      "package-3": 1.0.1-alpha.0+SHA,
+    }
+  `);
 });
 
 test('publish --canary --independent', async () => {
@@ -199,12 +199,12 @@ test('publish --canary --independent', async () => {
   await new PublishCommand(createArgv(cwd, '--canary', '--bump', 'preminor'));
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.1.0-alpha.0+SHA,
-  "package-2": 2.1.0-alpha.0+SHA,
-  "package-3": 3.1.0-alpha.0+SHA,
-}
-`);
+    {
+      "package-1": 1.1.0-alpha.0+SHA,
+      "package-2": 2.1.0-alpha.0+SHA,
+      "package-3": 3.1.0-alpha.0+SHA,
+    }
+  `);
 });
 
 test('publish --canary addresses unpublished package', async () => {
@@ -227,10 +227,10 @@ test('publish --canary addresses unpublished package', async () => {
 
   // there have been two commits since the beginning of the repo
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-6": 1.0.0-alpha.1+SHA,
-}
-`);
+    {
+      "package-6": 1.0.0-alpha.1+SHA,
+    }
+  `);
 });
 
 describe('publish --canary differential', () => {
@@ -241,14 +241,14 @@ describe('publish --canary differential', () => {
     await new PublishCommand(createArgv(cwd, '--canary', 'patch'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-  "package-4": 1.0.1-alpha.0+SHA,
-  "package-5": 1.0.1-alpha.0+SHA,
-}
-`);
+      {
+        "package-1": 1.0.1-alpha.0+SHA,
+        "package-2": 1.0.1-alpha.0+SHA,
+        "package-3": 1.0.1-alpha.0+SHA,
+        "package-4": 1.0.1-alpha.0+SHA,
+        "package-5": 1.0.1-alpha.0+SHA,
+      }
+    `);
   });
 
   test('internal', async () => {
@@ -258,12 +258,12 @@ Object {
     await new PublishCommand(createArgv(cwd, '--canary', '--bump', 'minor'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-3": 1.1.0-alpha.0+SHA,
-  "package-4": 1.1.0-alpha.0+SHA,
-  "package-5": 1.1.0-alpha.0+SHA,
-}
-`);
+      {
+        "package-3": 1.1.0-alpha.0+SHA,
+        "package-4": 1.1.0-alpha.0+SHA,
+        "package-5": 1.1.0-alpha.0+SHA,
+      }
+    `);
   });
 
   test('pendant', async () => {
@@ -273,10 +273,10 @@ Object {
     await new PublishCommand(createArgv(cwd, '--canary', '--bump', 'major'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-5": 2.0.0-alpha.0+SHA,
-}
-`);
+      {
+        "package-5": 2.0.0-alpha.0+SHA,
+      }
+    `);
   });
 });
 
@@ -292,10 +292,10 @@ describe('publish --canary sequential', () => {
     await new PublishCommand(createArgv(cwd, '--canary'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-5": 5.0.1-alpha.0+SHA,
-}
-`);
+      {
+        "package-5": 5.0.1-alpha.0+SHA,
+      }
+    `);
   });
 
   test('2. internal', async () => {
@@ -303,12 +303,12 @@ Object {
     await new PublishCommand(createArgv(cwd, '--canary'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-3": 3.0.1-alpha.1+SHA,
-  "package-4": 4.0.1-alpha.1+SHA,
-  "package-5": 5.0.1-alpha.1+SHA,
-}
-`);
+      {
+        "package-3": 3.0.1-alpha.1+SHA,
+        "package-4": 4.0.1-alpha.1+SHA,
+        "package-5": 5.0.1-alpha.1+SHA,
+      }
+    `);
   });
 
   test('3. source', async () => {
@@ -316,14 +316,14 @@ Object {
     await new PublishCommand(createArgv(cwd, '--canary'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.0.1-alpha.2+SHA,
-  "package-2": 2.0.1-alpha.2+SHA,
-  "package-3": 3.0.1-alpha.2+SHA,
-  "package-4": 4.0.1-alpha.2+SHA,
-  "package-5": 5.0.1-alpha.2+SHA,
-}
-`);
+      {
+        "package-1": 1.0.1-alpha.2+SHA,
+        "package-2": 2.0.1-alpha.2+SHA,
+        "package-3": 3.0.1-alpha.2+SHA,
+        "package-4": 4.0.1-alpha.2+SHA,
+        "package-5": 5.0.1-alpha.2+SHA,
+      }
+    `);
   });
 
   test('4. internal', async () => {
@@ -331,12 +331,12 @@ Object {
     await new PublishCommand(createArgv(cwd, '--canary'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-3": 3.0.1-alpha.3+SHA,
-  "package-4": 4.0.1-alpha.3+SHA,
-  "package-5": 5.0.1-alpha.3+SHA,
-}
-`);
+      {
+        "package-3": 3.0.1-alpha.3+SHA,
+        "package-4": 4.0.1-alpha.3+SHA,
+        "package-5": 5.0.1-alpha.3+SHA,
+      }
+    `);
   });
 
   test('5. pendant', async () => {
@@ -344,10 +344,10 @@ Object {
     await new PublishCommand(createArgv(cwd, '--canary'));
 
     expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-5": 5.0.1-alpha.4+SHA,
-}
-`);
+      {
+        "package-5": 5.0.1-alpha.4+SHA,
+      }
+    `);
   });
 });
 
@@ -371,13 +371,13 @@ test('publish --canary --force-publish on tagged release avoids early exit', asy
   // lerna WARN force-publish all packages
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-1": 1.0.1-alpha.0+SHA,
-  "package-2": 1.0.1-alpha.0+SHA,
-  "package-3": 1.0.1-alpha.0+SHA,
-  "package-4": 1.0.1-alpha.0+SHA,
-}
-`);
+    {
+      "package-1": 1.0.1-alpha.0+SHA,
+      "package-2": 1.0.1-alpha.0+SHA,
+      "package-3": 1.0.1-alpha.0+SHA,
+      "package-4": 1.0.1-alpha.0+SHA,
+    }
+  `);
 });
 
 test('publish --canary --force-publish <arg> on tagged release avoids early exit', async () => {
@@ -395,11 +395,11 @@ test('publish --canary --force-publish <arg> on tagged release avoids early exit
   // lerna WARN force-publish package-2
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-Object {
-  "package-2": 2.0.1-alpha.0+SHA,
-  "package-3": 3.0.1-alpha.0+SHA,
-}
-`);
+    {
+      "package-2": 2.0.1-alpha.0+SHA,
+      "package-3": 3.0.1-alpha.0+SHA,
+    }
+  `);
 });
 
 test('publish --canary with dirty tree throws error', async () => {
@@ -446,7 +446,7 @@ test('publish --canary without _any_ tags', async () => {
   await lernaPublish(cwd)('--canary');
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-    Object {
+    {
       "package-1": 1.0.1-alpha.0+SHA,
       "package-2": 1.0.1-alpha.0+SHA,
       "package-3": 1.0.1-alpha.0+SHA,
@@ -460,7 +460,7 @@ test('publish --canary without _any_ tags (independent)', async () => {
   await new PublishCommand(createArgv(cwd, '--canary'));
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-    Object {
+    {
       "package-1": 1.0.1-alpha.0+SHA,
       "package-2": 2.0.1-alpha.0+SHA,
       "package-3": 3.0.1-alpha.0+SHA,
@@ -489,7 +489,7 @@ test('publish --canary --no-private', async () => {
   await new PublishCommand(createArgv(cwd, '--canary', '--no-private'));
 
   expect((writePkg as any).updatedVersions()).toMatchInlineSnapshot(`
-    Object {
+    {
       "package-1": 1.0.1-alpha.0+SHA,
       "package-2": 2.0.1-alpha.0+SHA,
     }

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -243,7 +243,7 @@ describe('PublishCommand', () => {
 
       const logMessages = loggingOutput('warn');
       expect(logMessages).toMatchInlineSnapshot(`
-        Array [
+        [
           "--graph-type=dependencies is deprecated and will be removed in the next major version of lerna-lite. If you have a use-case you feel requires it please open an issue to discuss: https://github.com/lerna/lerna/issues/new/choose",
           "we recommend using --sync-workspace-lock which will sync your lock file via your favorite npm client instead of relying on Lerna-Lite itself to update it.",
         ]

--- a/packages/run/src/__tests__/__snapshots__/run-command.spec.ts.snap
+++ b/packages/run/src/__tests__/__snapshots__/run-command.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RunCommand in a basic repo omits package prefix with --parallel --no-prefix 1`] = `
-Array [
+[
   "packages/package-1 npm run env (prefixed: false)",
   "packages/package-2 npm run env (prefixed: false)",
   "packages/package-3 npm run env (prefixed: false)",
@@ -10,14 +10,14 @@ Array [
 `;
 
 exports[`RunCommand in a basic repo omits package prefix with --stream --no-prefix 1`] = `
-Array [
+[
   "packages/package-1 npm run my-script (prefixed: false)",
   "packages/package-3 npm run my-script (prefixed: false)",
 ]
 `;
 
 exports[`RunCommand in a basic repo runs a script in all packages with --parallel 1`] = `
-Array [
+[
   "packages/package-1 npm run env (prefixed: true)",
   "packages/package-2 npm run env (prefixed: true)",
   "packages/package-3 npm run env (prefixed: true)",
@@ -26,7 +26,7 @@ Array [
 `;
 
 exports[`RunCommand in a basic repo runs a script in packages with --stream 1`] = `
-Array [
+[
   "packages/package-1 npm run my-script (prefixed: true)",
   "packages/package-3 npm run my-script (prefixed: true)",
 ]

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -262,7 +262,7 @@ describe('RunCommand', () => {
       await new RunCommand(createArgv(testDir, 'env', '--concurrency', '1', '--no-sort', '--stream'));
 
       expect(ranInPackagesStreaming(testDir)).toMatchInlineSnapshot(`
-        Array [
+        [
           "packages/package-cycle-1 npm run env (prefixed: true)",
           "packages/package-cycle-2 npm run env (prefixed: true)",
           "packages/package-cycle-extraneous-1 npm run env (prefixed: true)",

--- a/packages/version/src/__tests__/__snapshots__/update-lockfile-version.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/update-lockfile-version.spec.ts.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`npm modern lock file updateModernLockfileVersion v2 in project root 1`] = `
-Object {
-  "dependencies": Object {
-    "@my-workspace/package-1": Object {
-      "requires": Object {
+{
+  "dependencies": {
+    "@my-workspace/package-1": {
+      "requires": {
         "tiny-tarball": "^1.0.0",
       },
       "version": "file:packages/package-1",
     },
-    "@my-workspace/package-2": Object {
-      "requires": Object {
+    "@my-workspace/package-2": {
+      "requires": {
         "@my-workspace/package-1": "^2.4.0",
       },
       "version": "file:packages/package-2",
@@ -18,35 +18,35 @@ Object {
   },
   "lockfileVersion": 2,
   "name": "my-workspace",
-  "packages": Object {
-    "": Object {
+  "packages": {
+    "": {
       "license": "MIT",
       "name": "my-workspace",
-      "workspaces": Array [
+      "workspaces": [
         "./packages/package-1",
         "./packages/package-2",
       ],
     },
-    "node_modules/package-1": Object {
+    "node_modules/package-1": {
       "link": true,
       "resolved": "packages/package-1",
     },
-    "node_modules/package-2": Object {
+    "node_modules/package-2": {
       "link": true,
       "resolved": "packages/package-2",
     },
-    "packages/package-1": Object {
+    "packages/package-1": {
       "license": "MIT",
       "name": "@my-workspace/package-1",
-      "tiny-tarball": Object {
+      "tiny-tarball": {
         "integrity": "sha1-u/EC1a5zr+LFUyleD7AiMCFvZbE=",
         "resolved": "https://registry.npmjs.org/tiny-tarball/-/tiny-tarball-1.0.0.tgz",
         "version": "1.0.0",
       },
       "version": "2.4.0",
     },
-    "packages/package-2": Object {
-      "dependencies": Object {
+    "packages/package-2": {
+      "dependencies": {
         "@my-workspace/package-1": "^2.4.0",
       },
       "license": "MIT",

--- a/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
+++ b/packages/version/src/__tests__/__snapshots__/version-command.spec.ts.snap
@@ -10,52 +10,52 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -5 +5 @@
--    \\"package-1\\": \\"1.0.0\\"
-+    \\"package-1\\": \\"1.0.1\\"
+-    "package-1": "1.0.0"
++    "package-1": "1.0.1"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -5 +5 @@
--    \\"package-2\\": \\"1.0.0\\"
-+    \\"package-2\\": \\"1.0.1\\"
+-    "package-2": "1.0.0"
++    "package-2": "1.0.1"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--    \\"package-1\\": \\"1.0.0\\"
-+    \\"package-1\\": \\"1.0.1\\"
+-    "package-1": "1.0.0"
++    "package-1": "1.0.1"
 @@ -7 +7 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\""
+-  "version": "1.0.0"
++  "version": "1.0.1""
 `;
 
 exports[`VersionCommand --exact updates matching local dependencies of published packages with exact versions 1`] = `
@@ -68,59 +68,59 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -5 +5 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "1.0.1"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -8 +8 @@
--    \\"package-2\\": \\"^1.0.0\\"
-+    \\"package-2\\": \\"1.0.1\\"
+-    "package-2": "^1.0.0"
++    "package-2": "1.0.1"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "1.0.1"
 @@ -7 +7 @@
--    \\"package-3\\": \\"^1.0.0\\"
-+    \\"package-3\\": \\"1.0.1\\"
+-    "package-3": "^1.0.0"
++    "package-3": "1.0.1"
 @@ -10 +10 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\""
+-  "version": "1.0.0"
++  "version": "1.0.1""
 `;
 
 exports[`VersionCommand --no-git-tag-version versions changed packages without git commit or push: gitHead 1`] = `
-Object {
+{
   "name": "package-1",
   "version": "1.0.1",
 }
@@ -136,55 +136,55 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -5 +5 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^1.0.1"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -8 +8 @@
--    \\"package-2\\": \\"^1.0.0\\"
-+    \\"package-2\\": \\"^1.0.1\\"
+-    "package-2": "^1.0.0"
++    "package-2": "^1.0.1"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^1.0.1"
 @@ -7 +7 @@
--    \\"package-3\\": \\"^1.0.0\\"
-+    \\"package-3\\": \\"^1.0.1\\"
+-    "package-3": "^1.0.0"
++    "package-3": "^1.0.1"
 @@ -10 +10 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\""
+-  "version": "1.0.0"
++  "version": "1.0.1""
 `;
 
 exports[`VersionCommand independent mode versions changed packages: commit 1`] = `
@@ -203,45 +203,45 @@ index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"2.0.0\\",
-+  \\"version\\": \\"2.1.0\\",
+-  "version": "2.0.0",
++  "version": "2.1.0",
 @@ -5 +5 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^1.0.1"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"3.0.0\\",
-+  \\"version\\": \\"4.0.0\\",
+-  "version": "3.0.0",
++  "version": "4.0.0",
 @@ -5 +5 @@
--    \\"package-2\\": \\"^2.0.0\\"
-+    \\"package-2\\": \\"^2.1.0\\"
+-    "package-2": "^2.0.0"
++    "package-2": "^2.1.0"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"4.0.0\\",
-+  \\"version\\": \\"4.1.0\\",
+-  "version": "4.0.0",
++  "version": "4.1.0",
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--    \\"package-3\\": \\"^3.0.0\\"
-+    \\"package-3\\": \\"^4.0.0\\"
+-    "package-3": "^3.0.0"
++    "package-3": "^4.0.0"
 @@ -7 +7 @@
--  \\"version\\": \\"5.0.0\\"
-+  \\"version\\": \\"5.0.1\\""
+-  "version": "5.0.0"
++  "version": "5.0.1""
 `;
 
 exports[`VersionCommand independent mode versions changed packages: console output 1`] = `
@@ -256,7 +256,7 @@ Changes (5 packages):
 `;
 
 exports[`VersionCommand independent mode versions changed packages: gitHead 1`] = `
-Object {
+{
   "name": "package-1",
   "version": "1.0.1",
 }
@@ -272,55 +272,55 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"2.0.0\\"
+-  "version": "1.0.0"
++  "version": "2.0.0"
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"2.0.0\\"
+-  "version": "1.0.0"
++  "version": "2.0.0"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"2.0.0\\",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 @@ -5 +5 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^2.0.0\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^2.0.0"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"2.0.0\\",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 @@ -8 +8 @@
--    \\"package-2\\": \\"^1.0.0\\"
-+    \\"package-2\\": \\"^2.0.0\\"
+-    "package-2": "^1.0.0"
++    "package-2": "^2.0.0"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"2.0.0\\",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^2.0.0\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^2.0.0"
 @@ -7 +7 @@
--    \\"package-3\\": \\"^1.0.0\\"
-+    \\"package-3\\": \\"^2.0.0\\"
+-    "package-3": "^1.0.0"
++    "package-3": "^2.0.0"
 @@ -10 +10 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"2.0.0\\""
+-  "version": "1.0.0"
++  "version": "2.0.0""
 `;
 
 exports[`VersionCommand normal mode only bumps changed packages when non-major version selected 1`] = `
@@ -333,15 +333,15 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.1.0\\"
+-  "version": "1.0.0"
++  "version": "1.1.0"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.1.0\\","
+-  "version": "1.0.0",
++  "version": "1.1.0","
 `;
 
 exports[`VersionCommand normal mode versions changed packages in dry-run mode: commit 1`] = `
@@ -356,7 +356,7 @@ index SHA..SHA
 +++ b/lerna.json
 @@ -0,0 +1,3 @@
 +{
-+  \\"version\\": \\"1.0.0\\"
++  "version": "1.0.0"
 +}
 diff --git a/package.json b/package.json
 new file mode 100644
@@ -365,7 +365,7 @@ index SHA..SHA
 +++ b/package.json
 @@ -0,0 +1,3 @@
 +{
-+  \\"name\\": \\"normal\\"
++  "name": "normal"
 +}
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 new file mode 100644
@@ -374,8 +374,8 @@ index SHA..SHA
 +++ b/packages/package-1/package.json
 @@ -0,0 +1,4 @@
 +{
-+  \\"name\\": \\"package-1\\",
-+  \\"version\\": \\"1.0.0\\"
++  "name": "package-1",
++  "version": "1.0.0"
 +}
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 new file mode 100644
@@ -384,10 +384,10 @@ index SHA..SHA
 +++ b/packages/package-2/package.json
 @@ -0,0 +1,7 @@
 +{
-+  \\"name\\": \\"package-2\\",
-+  \\"version\\": \\"1.0.0\\",
-+  \\"dependencies\\": {
-+    \\"package-1\\": \\"^1.0.0\\"
++  "name": "package-2",
++  "version": "1.0.0",
++  "dependencies": {
++    "package-1": "^1.0.0"
 +  }
 +}
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
@@ -397,13 +397,13 @@ index SHA..SHA
 +++ b/packages/package-3/package.json
 @@ -0,0 +1,10 @@
 +{
-+  \\"name\\": \\"package-3\\",
-+  \\"version\\": \\"1.0.0\\",
-+  \\"peerDependencies\\": {
-+    \\"package-2\\": \\"^1.0.0\\"
++  "name": "package-3",
++  "version": "1.0.0",
++  "peerDependencies": {
++    "package-2": "^1.0.0"
 +  },
-+  \\"devDependencies\\": {
-+    \\"package-2\\": \\"^1.0.0\\"
++  "devDependencies": {
++    "package-2": "^1.0.0"
 +  }
 +}
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
@@ -413,10 +413,10 @@ index SHA..SHA
 +++ b/packages/package-4/package.json
 @@ -0,0 +1,7 @@
 +{
-+  \\"name\\": \\"package-4\\",
-+  \\"version\\": \\"1.0.0\\",
-+  \\"dependencies\\": {
-+    \\"package-1\\": \\"^0.0.0\\"
++  "name": "package-4",
++  "version": "1.0.0",
++  "dependencies": {
++    "package-1": "^0.0.0"
 +  }
 +}
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
@@ -426,15 +426,15 @@ index SHA..SHA
 +++ b/packages/package-5/package.json
 @@ -0,0 +1,11 @@
 +{
-+  \\"name\\": \\"package-5\\",
-+  \\"dependencies\\": {
-+    \\"package-1\\": \\"^1.0.0\\"
++  "name": "package-5",
++  "dependencies": {
++    "package-1": "^1.0.0"
 +  },
-+  \\"optionalDependencies\\": {
-+    \\"package-3\\": \\"^1.0.0\\"
++  "optionalDependencies": {
++    "package-3": "^1.0.0"
 +  },
-+  \\"private\\": true,
-+  \\"version\\": \\"1.0.0\\"
++  "private": true,
++  "version": "1.0.0"
 +}"
 `;
 
@@ -450,47 +450,47 @@ Changes (5 packages):
 `;
 
 exports[`VersionCommand normal mode versions changed packages in dry-run mode: gitHead 1`] = `
-Object {
+{
   "name": "package-1",
   "version": "1.0.1",
 }
 `;
 
 exports[`VersionCommand normal mode versions changed packages in dry-run mode: prompt 1`] = `
-Array [
-  Array [
+[
+  [
     "Select a new version (currently 1.0.0)",
-    Object {
-      "choices": Array [
-        Object {
+    {
+      "choices": [
+        {
           "name": "Patch (1.0.1)",
           "value": "1.0.1",
         },
-        Object {
+        {
           "name": "Minor (1.1.0)",
           "value": "1.1.0",
         },
-        Object {
+        {
           "name": "Major (2.0.0)",
           "value": "2.0.0",
         },
-        Object {
+        {
           "name": "Prepatch (1.0.1-alpha.0)",
           "value": "1.0.1-alpha.0",
         },
-        Object {
+        {
           "name": "Preminor (1.1.0-alpha.0)",
           "value": "1.1.0-alpha.0",
         },
-        Object {
+        {
           "name": "Premajor (2.0.0-alpha.0)",
           "value": "2.0.0-alpha.0",
         },
-        Object {
+        {
           "name": "Custom Prerelease",
           "value": "PRERELEASE",
         },
-        Object {
+        {
           "name": "Custom Version",
           "value": "CUSTOM",
         },
@@ -512,7 +512,7 @@ index SHA..SHA
 +++ b/lerna.json
 @@ -0,0 +1,3 @@
 +{
-+  \\"version\\": \\"1.0.0\\"
++  "version": "1.0.0"
 +}
 diff --git a/package.json b/package.json
 new file mode 100644
@@ -521,7 +521,7 @@ index SHA..SHA
 +++ b/package.json
 @@ -0,0 +1,3 @@
 +{
-+  \\"name\\": \\"normal\\"
++  "name": "normal"
 +}
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 new file mode 100644
@@ -530,8 +530,8 @@ index SHA..SHA
 +++ b/packages/package-1/package.json
 @@ -0,0 +1,4 @@
 +{
-+  \\"name\\": \\"package-1\\",
-+  \\"version\\": \\"1.0.0\\"
++  "name": "package-1",
++  "version": "1.0.0"
 +}
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 new file mode 100644
@@ -540,10 +540,10 @@ index SHA..SHA
 +++ b/packages/package-2/package.json
 @@ -0,0 +1,7 @@
 +{
-+  \\"name\\": \\"package-2\\",
-+  \\"version\\": \\"1.0.0\\",
-+  \\"dependencies\\": {
-+    \\"package-1\\": \\"^1.0.0\\"
++  "name": "package-2",
++  "version": "1.0.0",
++  "dependencies": {
++    "package-1": "^1.0.0"
 +  }
 +}
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
@@ -553,13 +553,13 @@ index SHA..SHA
 +++ b/packages/package-3/package.json
 @@ -0,0 +1,10 @@
 +{
-+  \\"name\\": \\"package-3\\",
-+  \\"version\\": \\"1.0.0\\",
-+  \\"peerDependencies\\": {
-+    \\"package-2\\": \\"^1.0.0\\"
++  "name": "package-3",
++  "version": "1.0.0",
++  "peerDependencies": {
++    "package-2": "^1.0.0"
 +  },
-+  \\"devDependencies\\": {
-+    \\"package-2\\": \\"^1.0.0\\"
++  "devDependencies": {
++    "package-2": "^1.0.0"
 +  }
 +}
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
@@ -569,10 +569,10 @@ index SHA..SHA
 +++ b/packages/package-4/package.json
 @@ -0,0 +1,7 @@
 +{
-+  \\"name\\": \\"package-4\\",
-+  \\"version\\": \\"1.0.0\\",
-+  \\"dependencies\\": {
-+    \\"package-1\\": \\"^0.0.0\\"
++  "name": "package-4",
++  "version": "1.0.0",
++  "dependencies": {
++    "package-1": "^0.0.0"
 +  }
 +}
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
@@ -582,15 +582,15 @@ index SHA..SHA
 +++ b/packages/package-5/package.json
 @@ -0,0 +1,11 @@
 +{
-+  \\"name\\": \\"package-5\\",
-+  \\"dependencies\\": {
-+    \\"package-1\\": \\"^1.0.0\\"
++  "name": "package-5",
++  "dependencies": {
++    "package-1": "^1.0.0"
 +  },
-+  \\"optionalDependencies\\": {
-+    \\"package-3\\": \\"^1.0.0\\"
++  "optionalDependencies": {
++    "package-3": "^1.0.0"
 +  },
-+  \\"private\\": true,
-+  \\"version\\": \\"1.0.0\\"
++  "private": true,
++  "version": "1.0.0"
 +}"
 `;
 
@@ -606,47 +606,47 @@ Changes (5 packages):
 `;
 
 exports[`VersionCommand normal mode versions changed packages with publish prompt in dry-run mode: gitHead 1`] = `
-Object {
+{
   "name": "package-1",
   "version": "1.0.1",
 }
 `;
 
 exports[`VersionCommand normal mode versions changed packages with publish prompt in dry-run mode: prompt 1`] = `
-Array [
-  Array [
+[
+  [
     "Select a new version (currently 1.0.0)",
-    Object {
-      "choices": Array [
-        Object {
+    {
+      "choices": [
+        {
           "name": "Patch (1.0.1)",
           "value": "1.0.1",
         },
-        Object {
+        {
           "name": "Minor (1.1.0)",
           "value": "1.1.0",
         },
-        Object {
+        {
           "name": "Major (2.0.0)",
           "value": "2.0.0",
         },
-        Object {
+        {
           "name": "Prepatch (1.0.1-alpha.0)",
           "value": "1.0.1-alpha.0",
         },
-        Object {
+        {
           "name": "Preminor (1.1.0-alpha.0)",
           "value": "1.1.0-alpha.0",
         },
-        Object {
+        {
           "name": "Premajor (2.0.0-alpha.0)",
           "value": "2.0.0-alpha.0",
         },
-        Object {
+        {
           "name": "Custom Prerelease",
           "value": "PRERELEASE",
         },
-        Object {
+        {
           "name": "Custom Version",
           "value": "CUSTOM",
         },
@@ -666,55 +666,55 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -5 +5 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^1.0.1"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -8 +8 @@
--    \\"package-2\\": \\"^1.0.0\\"
-+    \\"package-2\\": \\"^1.0.1\\"
+-    "package-2": "^1.0.0"
++    "package-2": "^1.0.1"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^1.0.1"
 @@ -7 +7 @@
--    \\"package-3\\": \\"^1.0.0\\"
-+    \\"package-3\\": \\"^1.0.1\\"
+-    "package-3": "^1.0.0"
++    "package-3": "^1.0.1"
 @@ -10 +10 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\""
+-  "version": "1.0.0"
++  "version": "1.0.1""
 `;
 
 exports[`VersionCommand normal mode versions changed packages with publish prompt: console output 1`] = `
@@ -729,47 +729,47 @@ Changes (5 packages):
 `;
 
 exports[`VersionCommand normal mode versions changed packages with publish prompt: gitHead 1`] = `
-Object {
+{
   "name": "package-1",
   "version": "1.0.1",
 }
 `;
 
 exports[`VersionCommand normal mode versions changed packages with publish prompt: prompt 1`] = `
-Array [
-  Array [
+[
+  [
     "Select a new version (currently 1.0.0)",
-    Object {
-      "choices": Array [
-        Object {
+    {
+      "choices": [
+        {
           "name": "Patch (1.0.1)",
           "value": "1.0.1",
         },
-        Object {
+        {
           "name": "Minor (1.1.0)",
           "value": "1.1.0",
         },
-        Object {
+        {
           "name": "Major (2.0.0)",
           "value": "2.0.0",
         },
-        Object {
+        {
           "name": "Prepatch (1.0.1-alpha.0)",
           "value": "1.0.1-alpha.0",
         },
-        Object {
+        {
           "name": "Preminor (1.1.0-alpha.0)",
           "value": "1.1.0-alpha.0",
         },
-        Object {
+        {
           "name": "Premajor (2.0.0-alpha.0)",
           "value": "2.0.0-alpha.0",
         },
-        Object {
+        {
           "name": "Custom Prerelease",
           "value": "PRERELEASE",
         },
-        Object {
+        {
           "name": "Custom Version",
           "value": "CUSTOM",
         },
@@ -789,55 +789,55 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\"
+-  "version": "1.0.0"
++  "version": "1.0.1"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -5 +5 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^1.0.1"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 @@ -8 +8 @@
--    \\"package-2\\": \\"^1.0.0\\"
-+    \\"package-2\\": \\"^1.0.1\\"
+-    "package-2": "^1.0.0"
++    "package-2": "^1.0.1"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -3 +3 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"1.0.1\\",
+-  "version": "1.0.0",
++  "version": "1.0.1",
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^1.0.1\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^1.0.1"
 @@ -7 +7 @@
--    \\"package-3\\": \\"^1.0.0\\"
-+    \\"package-3\\": \\"^1.0.1\\"
+-    "package-3": "^1.0.0"
++    "package-3": "^1.0.1"
 @@ -10 +10 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"1.0.1\\""
+-  "version": "1.0.0"
++  "version": "1.0.1""
 `;
 
 exports[`VersionCommand normal mode versions changed packages: console output 1`] = `
@@ -852,47 +852,47 @@ Changes (5 packages):
 `;
 
 exports[`VersionCommand normal mode versions changed packages: gitHead 1`] = `
-Object {
+{
   "name": "package-1",
   "version": "1.0.1",
 }
 `;
 
 exports[`VersionCommand normal mode versions changed packages: prompt 1`] = `
-Array [
-  Array [
+[
+  [
     "Select a new version (currently 1.0.0)",
-    Object {
-      "choices": Array [
-        Object {
+    {
+      "choices": [
+        {
           "name": "Patch (1.0.1)",
           "value": "1.0.1",
         },
-        Object {
+        {
           "name": "Minor (1.1.0)",
           "value": "1.1.0",
         },
-        Object {
+        {
           "name": "Major (2.0.0)",
           "value": "2.0.0",
         },
-        Object {
+        {
           "name": "Prepatch (1.0.1-alpha.0)",
           "value": "1.0.1-alpha.0",
         },
-        Object {
+        {
           "name": "Preminor (1.1.0-alpha.0)",
           "value": "1.1.0-alpha.0",
         },
-        Object {
+        {
           "name": "Premajor (2.0.0-alpha.0)",
           "value": "2.0.0-alpha.0",
         },
-        Object {
+        {
           "name": "Custom Prerelease",
           "value": "PRERELEASE",
         },
-        Object {
+        {
           "name": "Custom Version",
           "value": "CUSTOM",
         },
@@ -912,68 +912,68 @@ index SHA..SHA 100644
 --- a/lerna.json
 +++ b/lerna.json
 @@ -2 +2 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"2.0.0\\"
+-  "version": "1.0.0"
++  "version": "2.0.0"
 diff --git a/packages/package-1/package.json b/packages/package-1/package.json
 index SHA..SHA 100644
 --- a/packages/package-1/package.json
 +++ b/packages/package-1/package.json
 @@ -4 +4 @@
--  \\"version\\": \\"1.0.0\\"
-+  \\"version\\": \\"2.0.0\\"
+-  "version": "1.0.0"
++  "version": "2.0.0"
 diff --git a/packages/package-2/package.json b/packages/package-2/package.json
 index SHA..SHA 100644
 --- a/packages/package-2/package.json
 +++ b/packages/package-2/package.json
 @@ -4 +4 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"2.0.0\\",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 @@ -6 +6 @@
--    \\"package-1\\": \\"^1.0.0\\"
-+    \\"package-1\\": \\"^2.0.0\\"
+-    "package-1": "^1.0.0"
++    "package-1": "^2.0.0"
 diff --git a/packages/package-3/package.json b/packages/package-3/package.json
 index SHA..SHA 100644
 --- a/packages/package-3/package.json
 +++ b/packages/package-3/package.json
 @@ -4 +4 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"2.0.0\\",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 @@ -6 +6 @@
--    \\"package-2\\": \\"^1.0.0\\"
-+    \\"package-2\\": \\"^2.0.0\\"
+-    "package-2": "^1.0.0"
++    "package-2": "^2.0.0"
 diff --git a/packages/package-4/package.json b/packages/package-4/package.json
 index SHA..SHA 100644
 --- a/packages/package-4/package.json
 +++ b/packages/package-4/package.json
 @@ -4 +4 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"2.0.0\\",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 @@ -6 +6 @@
--    \\"package-3\\": \\"^1.0.0\\"
-+    \\"package-3\\": \\"^2.0.0\\"
+-    "package-3": "^1.0.0"
++    "package-3": "^2.0.0"
 diff --git a/packages/package-5/package.json b/packages/package-5/package.json
 index SHA..SHA 100644
 --- a/packages/package-5/package.json
 +++ b/packages/package-5/package.json
 @@ -4 +4 @@
--  \\"version\\": \\"1.0.0\\",
-+  \\"version\\": \\"2.0.0\\",
+-  "version": "1.0.0",
++  "version": "2.0.0",
 @@ -6 +6 @@
--    \\"package-4\\": \\"^1.0.0\\"
-+    \\"package-4\\": \\"^2.0.0\\""
+-    "package-4": "^1.0.0"
++    "package-4": "^2.0.0""
 `;
 
 exports[`VersionCommand with root lockfile on npm lockfile version >=2 should update project root lockfile version 2 for every necessary properties by writing directly to the file 1`] = `
-Object {
-  "dependencies": Object {
-    "@my-workspace/package-1": Object {
-      "requires": Object {
+{
+  "dependencies": {
+    "@my-workspace/package-1": {
+      "requires": {
         "tiny-tarball": "^1.0.0",
       },
       "version": "file:packages/package-1",
     },
-    "@my-workspace/package-2": Object {
-      "requires": Object {
+    "@my-workspace/package-2": {
+      "requires": {
         "@my-workspace/package-1": "^3.0.0",
       },
       "version": "file:packages/package-2",
@@ -981,35 +981,35 @@ Object {
   },
   "lockfileVersion": 2,
   "name": "my-workspace",
-  "packages": Object {
-    "": Object {
+  "packages": {
+    "": {
       "license": "MIT",
       "name": "my-workspace",
-      "workspaces": Array [
+      "workspaces": [
         "./packages/package-1",
         "./packages/package-2",
       ],
     },
-    "node_modules/package-1": Object {
+    "node_modules/package-1": {
       "link": true,
       "resolved": "packages/package-1",
     },
-    "node_modules/package-2": Object {
+    "node_modules/package-2": {
       "link": true,
       "resolved": "packages/package-2",
     },
-    "packages/package-1": Object {
+    "packages/package-1": {
       "license": "MIT",
       "name": "@my-workspace/package-1",
-      "tiny-tarball": Object {
+      "tiny-tarball": {
         "integrity": "sha1-u/EC1a5zr+LFUyleD7AiMCFvZbE=",
         "resolved": "https://registry.npmjs.org/tiny-tarball/-/tiny-tarball-1.0.0.tgz",
         "version": "1.0.0",
       },
       "version": "3.0.0",
     },
-    "packages/package-2": Object {
-      "dependencies": Object {
+    "packages/package-2": {
+      "dependencies": {
         "@my-workspace/package-1": "^3.0.0",
       },
       "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@jest/types': ^28.1.3
+      '@jest/types': ^29.0.0
       '@lerna-lite/changed': workspace:*
       '@lerna-lite/cli': workspace:*
       '@lerna-lite/core': workspace:*
@@ -19,7 +19,7 @@ importers:
       '@lerna-lite/version': workspace:*
       '@lerna-test/helpers': link:helpers
       '@types/jest': ^28.1.8
-      '@types/node': ^18.0.0
+      '@types/node': ^18.7.13
       '@types/npmlog': ^4.1.4
       '@types/yargs': ^17.0.11
       '@typescript-eslint/eslint-plugin': ^5.35.1
@@ -36,8 +36,8 @@ importers:
       find-up: ^5.0.0
       fs-extra: ^10.1.0
       globby: ^11.1.0
-      jest: ^28.1.3
-      jest-cli: ^28.1.3
+      jest: ^29.0.0
+      jest-cli: ^29.0.0
       jest-extended: ^3.0.2
       load-json-file: ^6.2.0
       normalize-newline: ^3.0.0
@@ -54,7 +54,7 @@ importers:
       typescript: ^4.7.4
       write-json-file: ^4.3.0
     devDependencies:
-      '@jest/types': 28.1.3
+      '@jest/types': 29.0.0
       '@lerna-lite/changed': link:packages/changed
       '@lerna-lite/cli': link:packages/cli
       '@lerna-lite/core': link:packages/core
@@ -69,7 +69,7 @@ importers:
       '@lerna-lite/version': link:packages/version
       '@lerna-test/helpers': link:helpers
       '@types/jest': 28.1.8
-      '@types/node': 18.0.0
+      '@types/node': 18.7.13
       '@types/npmlog': 4.1.4
       '@types/yargs': 17.0.11
       '@typescript-eslint/eslint-plugin': 5.35.1_ktjxjibzrfqejavile4bhmzhjq
@@ -78,7 +78,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0_2iahngt3u2tkbdlu6s4gkur3pu
       eslint-config-prettier: 8.5.0_eslint@8.22.0
       eslint-plugin-import: 2.26.0_lewfh47l4outvz5ytnjtm3tbm4
-      eslint-plugin-jest: 26.8.7_mwa3amaxosy2l465c2swgvcqq4
+      eslint-plugin-jest: 26.8.7_zxhiafmftvfe4puksvvg6n62ya
       eslint-plugin-node: 11.1.0_eslint@8.22.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@8.22.0
       execa: 5.1.1
@@ -86,9 +86,9 @@ importers:
       find-up: 5.0.0
       fs-extra: 10.1.0
       globby: 11.1.0
-      jest: 28.1.3_@types+node@18.0.0
-      jest-cli: 28.1.3_@types+node@18.0.0
-      jest-extended: 3.0.2_jest@28.1.3
+      jest: 29.0.0_@types+node@18.7.13
+      jest-cli: 29.0.0_@types+node@18.7.13
+      jest-extended: 3.0.2_jest@29.0.0
       load-json-file: 6.2.0
       normalize-newline: 3.0.0
       normalize-path: 3.0.0
@@ -99,7 +99,7 @@ importers:
       semver: 7.3.7
       tacks: 1.3.0
       tempy: 1.0.1
-      ts-jest: 28.0.8_lhw3xkmzugq5tscs3x2ndm4sby
+      ts-jest: 28.0.8_jyww2gcrjpzyjpnm54ewaesugm
       tsm: 2.2.2
       typescript: 4.7.4
       write-json-file: 4.3.0
@@ -418,7 +418,7 @@ importers:
     specifiers:
       '@lerna-lite/core': workspace:*
       '@types/execa': ^2.0.0
-      '@types/node': ^18.0.0
+      '@types/node': ^18.7.13
       '@types/p-map': ^2.0.0
       fs-extra: ^10.1.0
       multimatch: ^5.0.0
@@ -436,7 +436,7 @@ importers:
       yargs: 17.5.1
     devDependencies:
       '@types/execa': 2.0.0
-      '@types/node': 18.0.0
+      '@types/node': 18.7.13
       '@types/p-map': 2.0.0
 
   packages/publish:
@@ -633,7 +633,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.15
     dev: true
 
   /@babel/code-frame/7.16.7:
@@ -740,6 +740,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-plugin-utils/7.18.9:
+    resolution: {integrity: sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-simple-access/7.18.2:
     resolution: {integrity: sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==}
     engines: {node: '>=6.9.0'}
@@ -796,7 +801,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.18.2:
@@ -805,7 +810,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.18.2:
@@ -814,7 +819,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.18.2:
@@ -823,7 +828,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.2:
@@ -832,7 +837,17 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
+    dev: true
+
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.2:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.2
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.2:
@@ -841,7 +856,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.2:
@@ -850,7 +865,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.2:
@@ -859,7 +874,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.2:
@@ -868,7 +883,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.2:
@@ -877,7 +892,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.2:
@@ -886,7 +901,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.18.2:
@@ -896,7 +911,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
+      '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
   /@babel/plugin-syntax-typescript/7.17.12_@babel+core@7.18.2:
@@ -1021,42 +1036,53 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/28.1.3:
-    resolution: {integrity: sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /@jest/console/29.0.0:
+    resolution: {integrity: sha512-rHsKEqT2Kx73PqO9qIOdwg0Grd6Y3COyqNpi5SKRI0qXgmlqXkOczQMfIb8I0Gdnc9/kaMj6cTnBGLyBA03Xrg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
+      chalk: 4.1.2
+      jest-message-util: 29.0.0
+      jest-util: 29.0.0
+      slash: 3.0.0
+    dev: true
+
+  /@jest/core/29.0.0:
+    resolution: {integrity: sha512-9qljprspjQwbmnq3Wv9d/M6/ejMdWs1uAAljQAX9QsjJ1SlSByXw1mRA9UpR2BP9TxLLwEembbm0ykrT//2STg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/console': 28.1.3
-      '@jest/reporters': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/transform': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.0.0
+      '@jest/console': 29.0.0
+      '@jest/reporters': 29.0.0
+      '@jest/test-result': 29.0.0
+      '@jest/transform': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.3.1
       exit: 0.1.2
       graceful-fs: 4.2.10
-      jest-changed-files: 28.1.3
-      jest-config: 28.1.3_@types+node@18.0.0
-      jest-haste-map: 28.1.3
-      jest-message-util: 28.1.3
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-resolve-dependencies: 28.1.3
-      jest-runner: 28.1.3
-      jest-runtime: 28.1.3
-      jest-snapshot: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      jest-watcher: 28.1.3
+      jest-changed-files: 29.0.0
+      jest-config: 29.0.0_@types+node@18.7.13
+      jest-haste-map: 29.0.0
+      jest-message-util: 29.0.0
+      jest-regex-util: 29.0.0
+      jest-resolve: 29.0.0
+      jest-resolve-dependencies: 29.0.0
+      jest-runner: 29.0.0
+      jest-runtime: 29.0.0
+      jest-snapshot: 29.0.0
+      jest-util: 29.0.0
+      jest-validate: 29.0.0
+      jest-watcher: 29.0.0
       micromatch: 4.0.5
-      pretty-format: 28.1.3
-      rimraf: 3.0.2
+      pretty-format: 29.0.0
       slash: 3.0.0
       strip-ansi: 6.0.1
     transitivePeerDependencies:
@@ -1074,11 +1100,28 @@ packages:
       jest-mock: 28.1.3
     dev: true
 
+  /@jest/environment/29.0.0:
+    resolution: {integrity: sha512-ZHLvUENMAnwXowtyhmPRS0QLCXM4TS0ZfuiSR4QfRsJVN5lG4KdBDvI9kHJe/21vrgzPVOkvI7IBnkyPFCbV7g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/fake-timers': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
+      jest-mock: 29.0.0
+    dev: true
+
   /@jest/expect-utils/28.1.3:
     resolution: {integrity: sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       jest-get-type: 28.0.2
+    dev: true
+
+  /@jest/expect-utils/29.0.0:
+    resolution: {integrity: sha512-odQ+cjUpui6++a9Ua/oWn7CG0Af+EZe9weWZbfUQHTg7C3K9PCb0AnD4X7nyAe4WjfeZmVVyG5SJELMQaUbCtg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.0.0
     dev: true
 
   /@jest/expect/28.1.3:
@@ -1087,6 +1130,16 @@ packages:
     dependencies:
       expect: 28.1.3
       jest-snapshot: 28.1.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/expect/29.0.0:
+    resolution: {integrity: sha512-X2S5NpZOeXXDGBLvU/4K1nAD5iIz6/9Gs041wToI0FiX3glh/aEGGsVv3+SxKddYIb6Ei+ZbqzJmfRzQ7nwPlQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      expect: 29.0.0
+      jest-snapshot: 29.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1103,6 +1156,18 @@ packages:
       jest-util: 28.1.3
     dev: true
 
+  /@jest/fake-timers/29.0.0:
+    resolution: {integrity: sha512-4tqH5fT9H0+Ms3Z1HLZ/JfpzJluep2Zo3uuj0KPyu6IIyYSHCDfkXuiBQNWUGvumZDLQ2Si03cC7Gq0r73VgVg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.0.0
+      '@sinonjs/fake-timers': 9.1.2
+      '@types/node': 18.7.13
+      jest-message-util: 29.0.0
+      jest-mock: 29.0.0
+      jest-util: 29.0.0
+    dev: true
+
   /@jest/globals/28.1.3:
     resolution: {integrity: sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -1114,9 +1179,21 @@ packages:
       - supports-color
     dev: true
 
-  /@jest/reporters/28.1.3:
-    resolution: {integrity: sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /@jest/globals/29.0.0:
+    resolution: {integrity: sha512-ZHQMh6BZtabbikh9wkuPpVQmPHEpc4EgOaY/UJNM6hHHA5HRmiP5rH54M8267nkGscuqM5KpWP+zAZ4XEOXZag==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.0.0
+      '@jest/expect': 29.0.0
+      '@jest/types': 29.0.0
+      jest-mock: 29.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/reporters/29.0.0:
+    resolution: {integrity: sha512-6ZFLlHQwncULTucAKWeGJLGPvzjgC/0gFmxJi/LgU9G1v498r/RcWQiZBPqhJcSvpWGTCaqjvUGmPCLtrUpubw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
@@ -1124,12 +1201,12 @@ packages:
         optional: true
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/transform': 28.1.3
-      '@jest/types': 28.1.3
-      '@jridgewell/trace-mapping': 0.3.13
-      '@types/node': 18.0.0
+      '@jest/console': 29.0.0
+      '@jest/test-result': 29.0.0
+      '@jest/transform': 29.0.0
+      '@jest/types': 29.0.0
+      '@jridgewell/trace-mapping': 0.3.15
+      '@types/node': 18.7.13
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -1140,9 +1217,9 @@ packages:
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.4
-      jest-message-util: 28.1.3
-      jest-util: 28.1.3
-      jest-worker: 28.1.3
+      jest-message-util: 29.0.0
+      jest-util: 29.0.0
+      jest-worker: 29.0.0
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -1159,11 +1236,27 @@ packages:
       '@sinclair/typebox': 0.24.19
     dev: true
 
+  /@jest/schemas/29.0.0:
+    resolution: {integrity: sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.24.19
+    dev: true
+
   /@jest/source-map/28.1.2:
     resolution: {integrity: sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.13
+      callsites: 3.1.0
+      graceful-fs: 4.2.10
+    dev: true
+
+  /@jest/source-map/29.0.0:
+    resolution: {integrity: sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.15
       callsites: 3.1.0
       graceful-fs: 4.2.10
     dev: true
@@ -1178,13 +1271,23 @@ packages:
       collect-v8-coverage: 1.0.1
     dev: true
 
-  /@jest/test-sequencer/28.1.3:
-    resolution: {integrity: sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /@jest/test-result/29.0.0:
+    resolution: {integrity: sha512-mv76j8ILaqOuZAWBGR1/ZSRinN5Q/eEji7kMcvADjd+gQGfn/Py+91nUrVakJT69idC66bvQ7yF24frQpzFKUg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/test-result': 28.1.3
+      '@jest/console': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/istanbul-lib-coverage': 2.0.4
+      collect-v8-coverage: 1.0.1
+    dev: true
+
+  /@jest/test-sequencer/29.0.0:
+    resolution: {integrity: sha512-uL6yX//SUME1c/ucbY365obdsrPjvSoNBwB80WTe+drYL4jf7A87vA2+w4hYwXJEIGQspv5skg3iB/sJSys7ew==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/test-result': 29.0.0
       graceful-fs: 4.2.10
-      jest-haste-map: 28.1.3
+      jest-haste-map: 29.0.0
       slash: 3.0.0
     dev: true
 
@@ -1211,6 +1314,29 @@ packages:
       - supports-color
     dev: true
 
+  /@jest/transform/29.0.0:
+    resolution: {integrity: sha512-hwyBt8UR5o8GGaphmRqNQwVCctiOR8ncugCp/RlInEZvQ+ysKkS5TFfe5RgeQ0KtKdWByQqn5yA574LLOp3OWw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.18.2
+      '@jest/types': 29.0.0
+      '@jridgewell/trace-mapping': 0.3.15
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 1.8.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.10
+      jest-haste-map: 29.0.0
+      jest-regex-util: 29.0.0
+      jest-util: 29.0.0
+      micromatch: 4.0.5
+      pirates: 4.0.5
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@jest/types/28.1.3:
     resolution: {integrity: sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -1219,6 +1345,18 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.0.0
+      '@types/yargs': 17.0.11
+      chalk: 4.1.2
+    dev: true
+
+  /@jest/types/29.0.0:
+    resolution: {integrity: sha512-ErShruvByUF7vphEtPugMAphCtDIDdfWh3DxpBLxPEtHhL/H5MaidHsOutnOUhKpPL7QA6/7GitjFgLOLeGa1A==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.0.0
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.7.13
       '@types/yargs': 17.0.11
       chalk: 4.1.2
     dev: true
@@ -1237,7 +1375,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.13
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.15
     dev: true
 
   /@jridgewell/resolve-uri/3.0.7:
@@ -1256,6 +1394,13 @@ packages:
 
   /@jridgewell/trace-mapping/0.3.13:
     resolution: {integrity: sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.0.7
+      '@jridgewell/sourcemap-codec': 1.4.13
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.15:
+    resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
     dependencies:
       '@jridgewell/resolve-uri': 3.0.7
       '@jridgewell/sourcemap-codec': 1.4.13
@@ -1637,7 +1782,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 18.0.0
+      '@types/node': 18.7.13
     dev: true
 
   /@types/inquirer/9.0.1:
@@ -1707,6 +1852,10 @@ packages:
 
   /@types/node/18.0.0:
     resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
+    dev: true
+
+  /@types/node/18.7.13:
+    resolution: {integrity: sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -2145,17 +2294,17 @@ packages:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
     dev: false
 
-  /babel-jest/28.1.3_@babel+core@7.18.2:
-    resolution: {integrity: sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /babel-jest/29.0.0_@babel+core@7.18.2:
+    resolution: {integrity: sha512-EJM2dqxz9+uWJLLucZLPYAmRsHHt1IMkitAHGqjDlIP2IQXzkIMO3ATbBWk0lU6VwX4rNeVN04t/DDB8U5C2rg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
       '@babel/core': 7.18.2
-      '@jest/transform': 28.1.3
+      '@jest/transform': 29.0.0
       '@types/babel__core': 7.1.19
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 28.1.3_@babel+core@7.18.2
+      babel-preset-jest: 29.0.0_@babel+core@7.18.2
       chalk: 4.1.2
       graceful-fs: 4.2.10
       slash: 3.0.0
@@ -2176,9 +2325,9 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-jest-hoist/28.1.3:
-    resolution: {integrity: sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /babel-plugin-jest-hoist/29.0.0:
+    resolution: {integrity: sha512-B9oaXrlxXHFWeWqhDPg03iqQd2UN/mg/VdZOsLaqAVBkztru3ctTryAI4zisxLEEgmcUnLTKewqx0gGifoXD3A==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.16.7
       '@babel/types': 7.18.4
@@ -2206,14 +2355,14 @@ packages:
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.2
     dev: true
 
-  /babel-preset-jest/28.1.3_@babel+core@7.18.2:
-    resolution: {integrity: sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /babel-preset-jest/29.0.0_@babel+core@7.18.2:
+    resolution: {integrity: sha512-B5Ke47Xcs8rDF3p1korT3LoilpADCwbG93ALqtvqu6Xpf4d8alKkrCBTExbNzdHJcIuEPpfYvEaFFRGee2kUgQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.18.2
-      babel-plugin-jest-hoist: 28.1.3
+      babel-plugin-jest-hoist: 29.0.0
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.2
     dev: true
 
@@ -2506,7 +2655,7 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   /concat-stream/2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -2594,8 +2743,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      JSONStream: 1.3.5
       is-text-path: 1.0.1
+      JSONStream: 1.3.5
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -2779,6 +2928,11 @@ packages:
   /diff-sequences/28.1.1:
     resolution: {integrity: sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dev: true
+
+  /diff-sequences/29.0.0:
+    resolution: {integrity: sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /dir-glob/3.0.1:
@@ -3246,7 +3400,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest/26.8.7_mwa3amaxosy2l465c2swgvcqq4:
+  /eslint-plugin-jest/26.8.7_zxhiafmftvfe4puksvvg6n62ya:
     resolution: {integrity: sha512-nJJVv3VY6ZZvJGDMC8h1jN/TIGT4We1JkNn1lvstPURicr/eZPVnlFULQ4W2qL9ByCuCr1hPmlBOc2aZ1ktw4Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3262,7 +3416,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.35.1_ktjxjibzrfqejavile4bhmzhjq
       '@typescript-eslint/utils': 5.33.1_4rv7y5c6xz3vfxwhbrcxxi73bq
       eslint: 8.22.0
-      jest: 28.1.3_@types+node@18.0.0
+      jest: 29.0.0_@types+node@18.7.13
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3463,6 +3617,17 @@ packages:
       jest-matcher-utils: 28.1.3
       jest-message-util: 28.1.3
       jest-util: 28.1.3
+    dev: true
+
+  /expect/29.0.0:
+    resolution: {integrity: sha512-OKAHGwaBqZ6I7bas0cnrrvomEL2d0yp2XXYQhhnVHfaqDaKStUBxjWtlGu/uI2tBqwb9sBMvaS41DSJFsRRJHQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/expect-utils': 29.0.0
+      jest-get-type: 29.0.0
+      jest-matcher-utils: 29.0.0
+      jest-message-util: 29.0.0
+      jest-util: 29.0.0
     dev: true
 
   /external-editor/3.1.0:
@@ -4289,9 +4454,9 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: true
 
-  /jest-changed-files/28.1.3:
-    resolution: {integrity: sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-changed-files/29.0.0:
+    resolution: {integrity: sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       execa: 5.1.1
       p-limit: 3.1.0
@@ -4324,9 +4489,36 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/28.1.3_@types+node@18.0.0:
-    resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-circus/29.0.0:
+    resolution: {integrity: sha512-6EX70/+ZdzPLShBeokMVIpUaq5cQpOsO4OCDiV1drKUHht0hmUOWvY6LE4pBSFdepB0Sukw4Y0ajRqtvLBO9/A==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.0.0
+      '@jest/expect': 29.0.0
+      '@jest/test-result': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 0.7.0
+      is-generator-fn: 2.1.0
+      jest-each: 29.0.0
+      jest-matcher-utils: 29.0.0
+      jest-message-util: 29.0.0
+      jest-runtime: 29.0.0
+      jest-snapshot: 29.0.0
+      jest-util: 29.0.0
+      p-limit: 3.1.0
+      pretty-format: 29.0.0
+      slash: 3.0.0
+      stack-utils: 2.0.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-cli/29.0.0_@types+node@18.7.13:
+    resolution: {integrity: sha512-VZUPQjWJKL8QABFiBk1tHeJ3czBodjU9r22ceQmeL7X8/M73FYxTte0RkYPHI2SiLPWy99GZNWA+oOu9x0xKOA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -4334,16 +4526,16 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/types': 28.1.3
+      '@jest/core': 29.0.0
+      '@jest/test-result': 29.0.0
+      '@jest/types': 29.0.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.3_@types+node@18.0.0
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
+      jest-config: 29.0.0_@types+node@18.7.13
+      jest-util: 29.0.0
+      jest-validate: 29.0.0
       prompts: 2.4.2
       yargs: 17.5.1
     transitivePeerDependencies:
@@ -4352,9 +4544,9 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/28.1.3_@types+node@18.0.0:
-    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-config/29.0.0_@types+node@18.7.13:
+    resolution: {integrity: sha512-RbcUgQBJDS0O8OThWUwm5UCfzo0zOymUX/cJzUNlYB1ZWqe3M8MFEcgwqgZSifYuYTi46xWu5cmkMiyRQAdnMw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@types/node': '*'
       ts-node: '>=9.0.0'
@@ -4365,26 +4557,26 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.18.2
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.0.0
-      babel-jest: 28.1.3_@babel+core@7.18.2
+      '@jest/test-sequencer': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
+      babel-jest: 29.0.0_@babel+core@7.18.2
       chalk: 4.1.2
       ci-info: 3.3.1
       deepmerge: 4.2.2
       glob: 7.2.3
       graceful-fs: 4.2.10
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
+      jest-circus: 29.0.0
+      jest-environment-node: 29.0.0
+      jest-get-type: 29.0.0
+      jest-regex-util: 29.0.0
+      jest-resolve: 29.0.0
+      jest-runner: 29.0.0
+      jest-util: 29.0.0
+      jest-validate: 29.0.0
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 28.1.3
+      pretty-format: 29.0.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4401,9 +4593,19 @@ packages:
       pretty-format: 28.1.3
     dev: true
 
-  /jest-docblock/28.1.1:
-    resolution: {integrity: sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-diff/29.0.0:
+    resolution: {integrity: sha512-erkuYf1dQBHow3XJmS+bH6t9TZ0GwrSdQGauN8sTqyZlFByOjRadmHgTTcAHINeeSwxzGHN2ob3PXVvZphD7XQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.0.0
+      jest-get-type: 29.0.0
+      pretty-format: 29.0.0
+    dev: true
+
+  /jest-docblock/29.0.0:
+    resolution: {integrity: sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       detect-newline: 3.1.0
     dev: true
@@ -4419,25 +4621,36 @@ packages:
       pretty-format: 28.1.3
     dev: true
 
-  /jest-environment-node/28.1.3:
-    resolution: {integrity: sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-each/29.0.0:
+    resolution: {integrity: sha512-ACKRvqdo7Bc0YrjQbrQtokpQ2NZxdXA63OklJht7a9UarCJXlZeWh51wEUe0ORqbnu15nAnX1YFQHmVpS1+ZXA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 28.1.3
-      '@jest/fake-timers': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.0.0
-      jest-mock: 28.1.3
-      jest-util: 28.1.3
+      '@jest/types': 29.0.0
+      chalk: 4.1.2
+      jest-get-type: 29.0.0
+      jest-util: 29.0.0
+      pretty-format: 29.0.0
     dev: true
 
-  /jest-extended/3.0.2_jest@28.1.3:
+  /jest-environment-node/29.0.0:
+    resolution: {integrity: sha512-Cns21Vgu0z7LjtssL0SWkxmjclHdwXeECFAP3ONit5NPnGCbv+0Rqby8w9vK7NpFlUaFgMmLYYBsUjSmIhwpvg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.0.0
+      '@jest/fake-timers': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
+      jest-mock: 29.0.0
+      jest-util: 29.0.0
+    dev: true
+
+  /jest-extended/3.0.2_jest@29.0.0:
     resolution: {integrity: sha512-LnVZvwWLRV9AL8J7f4frKu0KHuTrbIFK15IqrvSwbFCYxalkuC5l7HfcofsksePrvlEJ2WAcfYNnu1+bEGvInA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       jest: '>=27.2.5'
     dependencies:
-      jest: 28.1.3_@types+node@18.0.0
+      jest: 29.0.0_@types+node@18.7.13
       jest-diff: 28.1.3
       jest-get-type: 28.0.2
     dev: true
@@ -4445,6 +4658,11 @@ packages:
   /jest-get-type/28.0.2:
     resolution: {integrity: sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dev: true
+
+  /jest-get-type/29.0.0:
+    resolution: {integrity: sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /jest-haste-map/28.1.3:
@@ -4466,12 +4684,31 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /jest-leak-detector/28.1.3:
-    resolution: {integrity: sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-haste-map/29.0.0:
+    resolution: {integrity: sha512-mLyDt2WyNU0DZ64s7kRFkFJzrHEuXIxG+OKOs9/P5s1W7NzXE+P7SvLbxjz2Cg63cJjuglYRrD6fZcYf19T8Lw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      jest-get-type: 28.0.2
-      pretty-format: 28.1.3
+      '@jest/types': 29.0.0
+      '@types/graceful-fs': 4.1.5
+      '@types/node': 18.7.13
+      anymatch: 3.1.2
+      fb-watchman: 2.0.1
+      graceful-fs: 4.2.10
+      jest-regex-util: 29.0.0
+      jest-util: 29.0.0
+      jest-worker: 29.0.0
+      micromatch: 4.0.5
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /jest-leak-detector/29.0.0:
+    resolution: {integrity: sha512-kBjNS0/z2+ZV/3N7R+ot5fKD2W1fHkoxC3kH/fkb2z24YSPfR9RGwiNX+YLRG9r0gWsxQx16boxzHT23G6rFBw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.0.0
+      pretty-format: 29.0.0
     dev: true
 
   /jest-matcher-utils/28.1.3:
@@ -4482,6 +4719,16 @@ packages:
       jest-diff: 28.1.3
       jest-get-type: 28.0.2
       pretty-format: 28.1.3
+    dev: true
+
+  /jest-matcher-utils/29.0.0:
+    resolution: {integrity: sha512-HtCxFHI8lQSbN1RppFjtl6DIrS+x4d3lOhpJljVxFEXob4lxlKon3FunW0XoGxNSvIoD00AfTFspnufpOqszrg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.0.0
+      jest-get-type: 29.0.0
+      pretty-format: 29.0.0
     dev: true
 
   /jest-message-util/28.1.3:
@@ -4499,12 +4746,35 @@ packages:
       stack-utils: 2.0.5
     dev: true
 
+  /jest-message-util/29.0.0:
+    resolution: {integrity: sha512-4U0RdNV0TBTgVGzEchjryEpq4sqLO3gUQT7TEIbO5+q0K5MuiofOPcXk4GLpWviWByMRJjliQNMuzJ4YGT+oGQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@jest/types': 29.0.0
+      '@types/stack-utils': 2.0.1
+      chalk: 4.1.2
+      graceful-fs: 4.2.10
+      micromatch: 4.0.5
+      pretty-format: 29.0.0
+      slash: 3.0.0
+      stack-utils: 2.0.5
+    dev: true
+
   /jest-mock/28.1.3:
     resolution: {integrity: sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
       '@types/node': 18.0.0
+    dev: true
+
+  /jest-mock/29.0.0:
+    resolution: {integrity: sha512-0AWznVt415KMCxcJPaE2+tWaruw0w8aRrKH1Y/NZUx3+Pd9f20jQjUR82iHqGSuYS4EOHL9uI8SjAhJk+ET91g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
     dev: true
 
   /jest-pnp-resolver/1.2.2_jest-resolve@28.1.3:
@@ -4519,17 +4789,34 @@ packages:
       jest-resolve: 28.1.3
     dev: true
 
+  /jest-pnp-resolver/1.2.2_jest-resolve@29.0.0:
+    resolution: {integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+    dependencies:
+      jest-resolve: 29.0.0
+    dev: true
+
   /jest-regex-util/28.0.2:
     resolution: {integrity: sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dev: true
 
-  /jest-resolve-dependencies/28.1.3:
-    resolution: {integrity: sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-regex-util/29.0.0:
+    resolution: {integrity: sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jest-resolve-dependencies/29.0.0:
+    resolution: {integrity: sha512-1TYUMcLZcUqa2fdUQ3leYtiXWXfNmimPvnJ34YDLLf0nyJ/aEeqlHJM9Ji2jw9Qxdh7nUypanjUlUV87yRHBFQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      jest-regex-util: 28.0.2
-      jest-snapshot: 28.1.3
+      jest-regex-util: 29.0.0
+      jest-snapshot: 29.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4549,29 +4836,44 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /jest-runner/28.1.3:
-    resolution: {integrity: sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-resolve/29.0.0:
+    resolution: {integrity: sha512-MN19maPUXzibBshYg/cSrDWqiJwEBur6gbQb2lwOL4+6k14wdNW8Xh0uNPPxUntb7cpTi07uql/bUO5TVwiJbA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/console': 28.1.3
-      '@jest/environment': 28.1.3
-      '@jest/test-result': 28.1.3
-      '@jest/transform': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.0.0
+      chalk: 4.1.2
+      graceful-fs: 4.2.10
+      jest-haste-map: 29.0.0
+      jest-pnp-resolver: 1.2.2_jest-resolve@29.0.0
+      jest-util: 29.0.0
+      jest-validate: 29.0.0
+      resolve: 1.22.0
+      resolve.exports: 1.1.0
+      slash: 3.0.0
+    dev: true
+
+  /jest-runner/29.0.0:
+    resolution: {integrity: sha512-OpTpRIBOIn9RXuMMrpS+h9ZoK+nZHaOuNOceUiDbDoOJ6pmeGu0zst7VR22xXT3fOCwWqg5qe0fZ23G+ve5P0Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/console': 29.0.0
+      '@jest/environment': 29.0.0
+      '@jest/test-result': 29.0.0
+      '@jest/transform': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.10
-      jest-docblock: 28.1.1
-      jest-environment-node: 28.1.3
-      jest-haste-map: 28.1.3
-      jest-leak-detector: 28.1.3
-      jest-message-util: 28.1.3
-      jest-resolve: 28.1.3
-      jest-runtime: 28.1.3
-      jest-util: 28.1.3
-      jest-watcher: 28.1.3
-      jest-worker: 28.1.3
+      jest-docblock: 29.0.0
+      jest-environment-node: 29.0.0
+      jest-haste-map: 29.0.0
+      jest-leak-detector: 29.0.0
+      jest-message-util: 29.0.0
+      jest-resolve: 29.0.0
+      jest-runtime: 29.0.0
+      jest-util: 29.0.0
+      jest-watcher: 29.0.0
+      jest-worker: 29.0.0
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
@@ -4602,6 +4904,36 @@ packages:
       jest-resolve: 28.1.3
       jest-snapshot: 28.1.3
       jest-util: 28.1.3
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-runtime/29.0.0:
+    resolution: {integrity: sha512-dU0qFpTRWZY7Rur7yBgpz4g67mITSozBZ1jlhoG4ER/P/NiTFyZ/W8nMd5floeAMafmbrOc/5A9SlCu7SQCoBA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.0.0
+      '@jest/fake-timers': 29.0.0
+      '@jest/globals': 29.0.0
+      '@jest/source-map': 29.0.0
+      '@jest/test-result': 29.0.0
+      '@jest/transform': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
+      chalk: 4.1.2
+      cjs-module-lexer: 1.2.2
+      collect-v8-coverage: 1.0.1
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-haste-map: 29.0.0
+      jest-message-util: 29.0.0
+      jest-mock: 29.0.0
+      jest-regex-util: 29.0.0
+      jest-resolve: 29.0.0
+      jest-snapshot: 29.0.0
+      jest-util: 29.0.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -4639,12 +4971,56 @@ packages:
       - supports-color
     dev: true
 
+  /jest-snapshot/29.0.0:
+    resolution: {integrity: sha512-rR3B8GInk/IibF0M/sQCukSM8xX8bPI3Q0kjoAw4HT9Mx0Q3bS0MmF74rsreBOnVJgzN0Iwrc7YY56Yp8KQ7kA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.18.2
+      '@babel/generator': 7.18.2
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.2
+      '@babel/plugin-syntax-typescript': 7.17.12_@babel+core@7.18.2
+      '@babel/traverse': 7.18.2
+      '@babel/types': 7.18.4
+      '@jest/expect-utils': 29.0.0
+      '@jest/transform': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/babel__traverse': 7.17.1
+      '@types/prettier': 2.6.3
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.2
+      chalk: 4.1.2
+      expect: 29.0.0
+      graceful-fs: 4.2.10
+      jest-diff: 29.0.0
+      jest-get-type: 29.0.0
+      jest-haste-map: 29.0.0
+      jest-matcher-utils: 29.0.0
+      jest-message-util: 29.0.0
+      jest-util: 29.0.0
+      natural-compare: 1.4.0
+      pretty-format: 29.0.0
+      semver: 7.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /jest-util/28.1.3:
     resolution: {integrity: sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
       '@types/node': 18.0.0
+      chalk: 4.1.2
+      ci-info: 3.3.1
+      graceful-fs: 4.2.10
+      picomatch: 2.3.1
+    dev: true
+
+  /jest-util/29.0.0:
+    resolution: {integrity: sha512-HMjW/pkFgi34LGKumjNDK03DYonV+nPMNUZ63rZX8PFdBkdIWUtOCEiaa7sAJkWrw5MyMVzSpa22NcOJjoQ3JQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
       chalk: 4.1.2
       ci-info: 3.3.1
       graceful-fs: 4.2.10
@@ -4663,17 +5039,29 @@ packages:
       pretty-format: 28.1.3
     dev: true
 
-  /jest-watcher/28.1.3:
-    resolution: {integrity: sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-validate/29.0.0:
+    resolution: {integrity: sha512-UhgDKmahJnv5s5MK6a8kQ397YNS9euvL7gWTvUf7y0OO7vZeafUItlq3tguvfFVazQJ+kBGUm/XCJes7V61l8g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/test-result': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.0.0
+      '@jest/types': 29.0.0
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.0.0
+      leven: 3.1.0
+      pretty-format: 29.0.0
+    dev: true
+
+  /jest-watcher/29.0.0:
+    resolution: {integrity: sha512-GoRq5QJt5/dv3keK7rIzg9R0e/HpTnjyMNYtCTTDZgGIj6QUDMpiJqt7Mwfyyaxwg5PS8gVyQvRQn6Lril4cuQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/test-result': 29.0.0
+      '@jest/types': 29.0.0
+      '@types/node': 18.7.13
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
-      jest-util: 28.1.3
+      jest-util: 29.0.0
       string-length: 4.0.2
     dev: true
 
@@ -4686,9 +5074,18 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/28.1.3_@types+node@18.0.0:
-    resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /jest-worker/29.0.0:
+    resolution: {integrity: sha512-2t9Panx3F9N1wAvRuZT7xLEptRFc1C5G90DOHniIGz1JIgF9uhd5u8jNBsc7wN63lhnaiLeVLnNx21wT7OVFEQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@types/node': 18.7.13
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+    dev: true
+
+  /jest/29.0.0_@types+node@18.7.13:
+    resolution: {integrity: sha512-9uz4Tclskb8WrfRXqu66FsFCFoyYctwWXpruKwnD95FZqkyoEAA1oGH53HUn7nQx7uEgZTKdNl/Yo6DqqU+XMg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -4696,10 +5093,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 28.1.3
-      '@jest/types': 28.1.3
+      '@jest/core': 29.0.0
+      '@jest/types': 29.0.0
       import-local: 3.1.0
-      jest-cli: 28.1.3_@types+node@18.0.0
+      jest-cli: 29.0.0_@types+node@18.7.13
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -5717,6 +6114,15 @@ packages:
       react-is: 18.1.0
     dev: true
 
+  /pretty-format/29.0.0:
+    resolution: {integrity: sha512-tMkFRn1vxRwZdiDETcveuNeonRKDg4doOvI+iyb1sOAtxYioGzRicqnsr+d3C/lLv9hBiM/2lDBi5ilR81h2bQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.0.0
+      ansi-styles: 5.2.0
+      react-is: 18.1.0
+    dev: true
+
   /proc-log/2.0.1:
     resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -6386,7 +6792,7 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /ts-jest/28.0.8_lhw3xkmzugq5tscs3x2ndm4sby:
+  /ts-jest/28.0.8_jyww2gcrjpzyjpnm54ewaesugm:
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -6407,10 +6813,10 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@jest/types': 28.1.3
+      '@jest/types': 29.0.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.3_@types+node@18.0.0
+      jest: 29.0.0_@types+node@18.7.13
       jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2
@@ -6590,7 +6996,7 @@ packages:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.15
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.8.0
     dev: true
@@ -6703,7 +7109,6 @@ packages:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-    dev: false
 
   /write-json-file/3.2.0:
     resolution: {integrity: sha512-3xZqT7Byc2uORAatYiP3DHUUAVEkNOswEWNs9H5KXiicRTvzYzYqKjYc4G7p+8pltvAw641lVByKVtMpf+4sYQ==}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

Renovate failed on upgrading to Jest v29 because ts-jest has a hard dependency on v28, so let's upgrade manually. However I had to update all Jest snapshots to the new format which was the main breaking change of v29, the new format is a lot better since it is now a 1 to 1 input/output which is really nice to see

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
