### PR TITLE
fix(version): --changelog-include-commits-[x] in cli should be truthy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,13 @@
       "request": "launch",
       "runtimeExecutable": "node",
       "runtimeArgs": ["--nolazy", "-r", "tsm"],
-      "args": ["packages/cli/src/cli.ts", "version", "--git-dry-run"],
+      "args": [
+        "packages/cli/src/cli.ts",
+        "version",
+        "--git-dry-run",
+        "--changelog-include-commits-client-login",
+        "--conventional-commits"
+      ],
       "cwd": "${workspaceRoot}",
       "console": "integratedTerminal",
       "internalConsoleOptions": "openOnSessionStart",

--- a/packages/core/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/core/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -437,7 +437,7 @@ describe('conventional-commits', () => {
           tagPrefix: 'dragons-are-awesome',
         }),
         updateChangelog({ location: cwd } as Package, 'root', {
-          changelogIncludeCommitsGitAuthor: true,
+          changelogIncludeCommitsGitAuthor: '', // empty string would be treated the same as being true but without a format
           tagPrefix: 'dragons-are-awesome',
           version: '1.0.1',
         }),
@@ -776,7 +776,7 @@ describe('conventional-commits', () => {
 
       const opt1s = {
         changelogPreset: 'conventional-changelog-angular',
-        changelogIncludeCommitsClientLogin: true,
+        changelogIncludeCommitsClientLogin: '', // empty string would be treated the same as being true but without a format
         commitsSinceLastRelease: [
           {
             authorName: 'Tester McPerson',

--- a/packages/core/src/conventional-commits/update-changelog.ts
+++ b/packages/core/src/conventional-commits/update-changelog.ts
@@ -51,9 +51,12 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
   const gitRawCommitsOpts = Object.assign({}, options.config.gitRawCommitsOpts);
 
   // are we including commit author name/email or remote client login name
-  if (changelogIncludeCommitsGitAuthor) {
+  if (changelogIncludeCommitsGitAuthor || changelogIncludeCommitsGitAuthor === '') {
     setConfigChangelogCommitGitAuthor(config, gitRawCommitsOpts, writerOpts, changelogIncludeCommitsGitAuthor);
-  } else if (changelogIncludeCommitsClientLogin && commitsSinceLastRelease) {
+  } else if (
+    (changelogIncludeCommitsClientLogin || changelogIncludeCommitsClientLogin === '') &&
+    commitsSinceLastRelease
+  ) {
     // prettier-ignore
     setConfigChangelogCommitClientLogin(config, gitRawCommitsOpts, writerOpts, commitsSinceLastRelease, changelogIncludeCommitsClientLogin);
   }

--- a/packages/core/src/conventional-commits/writer-opts-transform.ts
+++ b/packages/core/src/conventional-commits/writer-opts-transform.ts
@@ -26,7 +26,7 @@ export function setConfigChangelogCommitGitAuthor(
 ) {
   gitRawCommitsOpts.format = GIT_COMMIT_WITH_AUTHOR_FORMAT;
   const extraCommitMsg =
-    typeof commitCustomFormat === 'string'
+    typeof commitCustomFormat === 'string' && commitCustomFormat !== ''
       ? commitCustomFormat.replace(/%a/g, '{{authorName}}' || '').replace(/%e/g, '{{authorEmail}}' || '')
       : `({{authorName}})`;
   writerOpts.commitPartial =
@@ -53,7 +53,7 @@ export function setConfigChangelogCommitClientLogin(
 ) {
   gitRawCommitsOpts.format = GIT_COMMIT_WITH_AUTHOR_FORMAT;
   const extraCommitMsg =
-    typeof commitCustomFormat === 'string'
+    typeof commitCustomFormat === 'string' && commitCustomFormat !== ''
       ? commitCustomFormat
           .replace(/%a/g, '{{authorName}}' || '')
           .replace(/%e/g, '{{authorEmail}}' || '')

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -357,7 +357,7 @@ describe('VersionCommand', () => {
 
     it('call getCommitsSinceLastRelease() when --changelog-include-commits-client-login is provided', async () => {
       const testDir = await initFixture('normal');
-      await new VersionCommand(
+      const command = new VersionCommand(
         createArgv(
           testDir,
           '--changelog-include-commits-client-login',
@@ -366,7 +366,9 @@ describe('VersionCommand', () => {
           'github'
         )
       );
+      await command;
 
+      expect(command.changelogIncludeCommitsClientLogin).toBe(true);
       expect(getCommitsSinceLastRelease).toHaveBeenCalled();
     });
   });

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -60,6 +60,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
   name = 'version' as CommandType;
 
   globalVersion = '';
+  changelogIncludeCommitsClientLogin?: boolean | string;
+  changelogIncludeCommitsGitAuthor?: boolean | string;
   commitsSinceLastRelease?: RemoteCommit[];
   packagesToVersion: Package[] = [];
   updatesVersions?: Map<string, string>;
@@ -104,6 +106,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
     // override durable options provided by a config file
     const {
       amend,
+      changelogIncludeCommitsClientLogin,
+      changelogIncludeCommitsGitAuthor,
       commitHooks = true,
       gitRemote = 'origin',
       gitTagVersion = true,
@@ -120,6 +124,10 @@ export class VersionCommand extends Command<VersionCommandOption> {
     this.tagPrefix = tagVersionPrefix;
     this.commitAndTag = gitTagVersion;
     this.pushToRemote = gitTagVersion && amend !== true && push;
+    this.changelogIncludeCommitsClientLogin =
+      changelogIncludeCommitsClientLogin === '' ? true : changelogIncludeCommitsClientLogin;
+    this.changelogIncludeCommitsGitAuthor =
+      changelogIncludeCommitsGitAuthor === '' ? true : changelogIncludeCommitsGitAuthor;
     // never automatically push to remote when amending a commit
 
     // prettier-ignore
@@ -249,7 +257,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       );
     }
 
-    if (this.options.changelogIncludeCommitsClientLogin && this.options.changelogIncludeCommitsGitAuthor) {
+    if (this.changelogIncludeCommitsClientLogin && this.changelogIncludeCommitsGitAuthor) {
       throw new ValidationError(
         'ENOTALLOWED',
         dedent`
@@ -267,8 +275,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
     // fetch all commits from remote server of the last release when user wants to include client login associated to each commits
     const remoteClient = this.options.createRelease || this.options.remoteClient;
-    const { conventionalCommits, changelogIncludeCommitsClientLogin } = this.options;
-    if (conventionalCommits && changelogIncludeCommitsClientLogin) {
+    if (this.options.conventionalCommits && this.changelogIncludeCommitsClientLogin) {
       if (!remoteClient) {
         throw new ValidationError(
           'EMISSINGCLIENT',
@@ -580,8 +587,6 @@ export class VersionCommand extends Command<VersionCommandOption> {
     const {
       conventionalCommits,
       changelogPreset,
-      changelogIncludeCommitsGitAuthor,
-      changelogIncludeCommitsClientLogin,
       changelogHeaderMessage,
       changelogVersionMessage,
       changelog = true,
@@ -651,8 +656,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
           changelogPreset,
           rootPath,
           tagPrefix: this.tagPrefix,
-          changelogIncludeCommitsGitAuthor,
-          changelogIncludeCommitsClientLogin,
+          changelogIncludeCommitsGitAuthor: this.changelogIncludeCommitsGitAuthor,
+          changelogIncludeCommitsClientLogin: this.changelogIncludeCommitsClientLogin,
           changelogHeaderMessage,
           changelogVersionMessage,
           commitsSinceLastRelease: this.commitsSinceLastRelease,
@@ -735,8 +740,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
             rootPath,
             tagPrefix: this.tagPrefix,
             version: this.globalVersion,
-            changelogIncludeCommitsGitAuthor,
-            changelogIncludeCommitsClientLogin,
+            changelogIncludeCommitsGitAuthor: this.changelogIncludeCommitsGitAuthor,
+            changelogIncludeCommitsClientLogin: this.changelogIncludeCommitsClientLogin,
             changelogHeaderMessage,
             changelogVersionMessage,
             commitsSinceLastRelease: this.commitsSinceLastRelease,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

providing `--changelog-include-commits-client-login` or `--changelog-include-commits-git-author` in CLI only (not from `lerna.json`) was actually parsed as an empty string and so ended up being interpreted as `false`

## Motivation and Context

fixes #310 

yargs hybrid options (boolean / string) cannot be interpreted as a boolean, so if we detect an empty string, we should automatically defined it as a `true` boolean.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
