### PR TITLE
fix(version): `--changelog-header-message` should be added to all logs

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1263,7 +1263,7 @@
         },
         "changelogHeaderMessage": {
           "type": "string",
-          "description": "During `lerna version`, add a custom message at the top of your \"changelog.md\" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs."
+          "description": "During `lerna version`, add a custom message at the top of all \"changelog.md\" files. This option is only available when using --conventional-commits with changelogs."
         },
         "changelogIncludeCommitsGitAuthor": {
           "anyOf": [{ "type": "string" }, { "type": "boolean" }],

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -58,7 +58,7 @@ export default {
       },
       'changelog-header-message': {
         describe:
-          'Add a custom message at the top of your "changelog.md" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs.',
+          'Add a custom message at the top of all "changelog.md" files. This option is only available when using --conventional-commits with changelogs.',
         group: 'Version Command Options:',
         requiresArg: true,
         type: 'string',

--- a/packages/core/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/core/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -678,6 +678,7 @@ describe('conventional-commits', () => {
 
       const opts = {
         changelogPreset: 'conventional-changelog-angular',
+        changelogHeaderMessage: '# Custom Header Message',
         changelogIncludeCommitsGitAuthor: true,
       };
       const [changelogOne, changelogTwo] = await Promise.all([
@@ -688,6 +689,19 @@ describe('conventional-commits', () => {
       expect(changelogOne.newEntry.trimRight()).toMatchInlineSnapshot(`
         ## [1.0.1](/compare/package-1@1.0.0...package-1@1.0.1) (YYYY-MM-DD)
 
+
+        ### Bug Fixes
+
+        * **stuff:** changed ([SHA](https://github.com/lerna/conventional-commits-independent/commit/GIT_HEAD)) (Tester McPerson)
+      `);
+      expect(changelogOne.content.trimRight()).toMatchInlineSnapshot(`
+        # Change Log
+        # Custom Header Message
+
+        All notable changes to this project will be documented in this file.
+        See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+        ## [1.0.1](/compare/package-1@1.0.0...package-1@1.0.1) (YYYY-MM-DD)
 
         ### Bug Fixes
 

--- a/packages/core/src/conventional-commits/update-changelog.ts
+++ b/packages/core/src/conventional-commits/update-changelog.ts
@@ -101,7 +101,7 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
     const changelogVersion = type === 'root' ? changelogVersionMessage : '';
     const changelogHeader = CHANGELOG_HEADER.replace(
       /%s/g,
-      type === 'root' ? (changelogHeaderMessage?.length > 0 ? changelogHeaderMessage + EOL : '') : ''
+      changelogHeaderMessage?.length > 0 ? changelogHeaderMessage + EOL : ''
     );
 
     const content = [changelogHeader, changelogVersion, newEntry, changelogContents]
@@ -114,6 +114,7 @@ export async function updateChangelog(pkg: Package, type: ChangelogType, updateO
 
       return {
         logPath: changelogFileLoc,
+        content,
         newEntry,
       };
     });

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -188,7 +188,7 @@ export interface VersionCommandOption {
   /** Version changed packages as prereleases when using `--conventional-commits`. */
   conventionalPrerelease?: boolean | string;
 
-  /** Add a custom message at the top of your "changelog.md" which is located in the root of your project. This option is only available when using `--conventional-commits` with changelogs. */
+  /** Add a custom message at the top of all "changelog.md" files. This option is only available when using `--conventional-commits` with changelogs. */
   changelogHeaderMessage?: string;
 
   /**

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -288,7 +288,7 @@ lerna version --conventional-commits --changelog-include-commits-client-login " 
 
 ### `--changelog-header-message <msg>`
 
-Add a custom message at the top of your "changelog.md" which is located in the root of your project. This option is only available when using `--conventional-commits` and will only impact your project root "changelog.md".
+Add a custom message at the top of all "changelog.md" files. This option is only available when using `--conventional-commits` and will only impact your project root "changelog.md".
 
 ```sh
 lerna version --conventional-commits --changelog-header-message "My Custom Header Message"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add header messages to all package changelogs

## Motivation and Context

- fixes #325 
- add header message to all changelogs, not just root, with the option `--changelog-header-message` so that even if there's no changelog in the root (independent mode doesn't have root changelog)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
