### PR TITLE
fix(run): exclude dependencies with `--scope` when `nx.json` is not present

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -468,6 +468,9 @@
             "profileLocation": {
               "$ref": "#/$defs/commandOptions/shared/profileLocation"
             },
+            "verbose": {
+              "$ref": "#/$defs/commandOptions/shared/verbose"
+            },
             "skipNxCache": {
               "$ref": "#/$defs/commandOptions/run/skipNxCache"
             },
@@ -979,6 +982,9 @@
     },
     "ignorePrepublish": {
       "$ref": "#/$defs/commandOptions/shared/ignorePrepublish"
+    },
+    "verbose": {
+      "$ref": "#/$defs/commandOptions/shared/verbose"
     }
   },
   "$defs": {
@@ -1442,6 +1448,10 @@
         "ignorePrepublish": {
           "type": "boolean",
           "description": "During `lerna publish` and `lerna bootstrap`, when true, disable deprecated 'prepublish' lifecycle script."
+        },
+        "verbose": {
+          "type": "boolean",
+          "description": "When true, escalates loglevel to 'verbose' and shows nx verbose output if useNx is true."
         }
       }
     }

--- a/packages/cli/src/cli-commands/cli-run-commands.ts
+++ b/packages/cli/src/cli-commands/cli-run-commands.ts
@@ -76,6 +76,11 @@ export default {
           hidden: true,
           type: 'boolean',
         },
+        verbose: {
+          group: 'Command Options:',
+          describe: 'When "useNx" is true, show verbose output from dependent tasks.',
+          type: 'boolean',
+        },
       });
 
     return filterOptions(yargs);

--- a/packages/core/src/__tests__/command.spec.ts
+++ b/packages/core/src/__tests__/command.spec.ts
@@ -385,4 +385,103 @@ describe('core-command', () => {
       );
     });
   });
+
+  describe('loglevel with verbose option true', () => {
+    it('should be set to verbose if loglevel is error', async () => {
+      const command = testFactory({
+        loglevel: 'error',
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('verbose');
+    });
+
+    it('should be set to verbose if loglevel is warn', async () => {
+      const command = testFactory({
+        loglevel: 'warn',
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('verbose');
+    });
+
+    it('should be set to verbose if loglevel is info', async () => {
+      const command = testFactory({
+        loglevel: 'info',
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('verbose');
+    });
+
+    it('should remain set to verbose if loglevel is verbose', async () => {
+      const command = testFactory({
+        loglevel: 'verbose',
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('verbose');
+    });
+
+    it('should not be set to verbose if loglevel is silly', async () => {
+      const command = testFactory({
+        loglevel: 'silly',
+        verbose: true,
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('silly');
+    });
+  });
+
+  describe('loglevel without verbose option', () => {
+    it('should remain set to error if loglevel is error', async () => {
+      const command = testFactory({
+        loglevel: 'error',
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('error');
+    });
+
+    it('should remain set to warn if loglevel is warn', async () => {
+      const command = testFactory({
+        loglevel: 'warn',
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('warn');
+    });
+
+    it('should remain set to info if loglevel is info', async () => {
+      const command = testFactory({
+        loglevel: 'info',
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('info');
+    });
+
+    it('should remain set to verbose if loglevel is verbose', async () => {
+      const command = testFactory({
+        loglevel: 'verbose',
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('verbose');
+    });
+
+    it('should remain set to silly if loglevel is silly', async () => {
+      const command = testFactory({
+        loglevel: 'silly',
+      });
+      await command;
+
+      expect(command.options.loglevel).toEqual('silly');
+    });
+  });
 });

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -206,6 +206,10 @@ export class Command<T extends AvailableCommandOption> {
       // Environmental defaults prepared in previous step
       this.envDefaults
     );
+
+    if (this.options.verbose && this.options.loglevel !== 'silly') {
+      this.options.loglevel = 'verbose';
+    }
   }
 
   configureProperties() {

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -367,9 +367,9 @@ export interface RunCommandOption {
   /** npm script to run by the command. */
   script: string;
 
-  /** Enables integration with [Nx](https://nx.dev). */
-  useNx?: boolean;
-
   /** when "useNx" is enabled, do we want to skip caching with Nx? */
   skipNxCache?: boolean;
+
+  /** enables integration with [Nx](https://nx.dev). */
+  useNx?: boolean;
 }

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -206,17 +206,44 @@ export interface LernaConfig {
 export interface ProjectConfig extends LernaConfig, QueryGraphConfig {
   /** Lerna JSON Schema https://json-schema.org/ */
   $schema: string;
+
+  /** enabled when running in CI (Continuous Integration). */
   ci?: boolean;
+
+  /** how many threads to use when Lerna parallelizes the tasks (defaults to count of logical CPU cores) */
   concurrency: number | string;
+
+  /** current working directory */
   cwd: string;
+
+  /** Composed commands are called from other commands, like publish -> version */
   composed?: boolean;
+
+  /** Lerna CLI version */
   lernaVersion: string;
+
+  /** show progress bars. */
   progress?: boolean;
+
+  /** Only include packages that have been changed since the specified [ref]. */
   since?: string;
+
+  /** When true, Lerna will sort the packages topologically (dependencies before dependents). */
   sort?: boolean;
+
+  /** During `lerna exec` and `lerna run`, stream output with lines prefixed by originating package name. */
   stream?: boolean;
+
+  /** Enables integration with [Nx](https://nx.dev). */
   useNx?: boolean;
+
+  /** When useNx is true, show verbose output from dependent tasks. */
+  verbose?: boolean;
+
+  /** callback to execute when Promise rejected */
   onRejected?: (result: any) => void;
+
+  /** callback to execute when Promise resolved */
   onResolved?: (result: any) => void;
 }
 


### PR DESCRIPTION
## Description

As per Lerna PR

> When `nx.json` is not present, packages being run will no longer include their dependencies when those dependencies would be filtered out by --scope. Using the flag `--include-dependencies` will cause them to be included again, as expected.

## Motivation and Context

As per Lerna [PR 3316](https://github.com/lerna/lerna/pull/3316)

> This preserves the default behavior of `lerna run --scope` when `useNx` is true and `nx.json` does not exist.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
