### PR TITLE
fix(run): warn on incompatible arguments with useNx

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -175,3 +175,30 @@ Example of `nx.json`:
   }
 }
 ```
+
+When [Nx](https://nx.dev/) is installed and `nx.json` is detected in the current workspace with `useNx` set to `true` in `lerna.json`, Lerna will respect `nx.json` configuration during `lerna run` and delegate to the Nx task runner.
+
+Nx will run tasks in an order and with a concurrency that it determines appropriate based on the task graph that it creates. For more information, see [Nx Mental Model: The Task Graph](https://nx.dev/concepts/mental-model#the-task-graph).
+
+**This behavior allows Nx to run tasks in the most efficient way possible, but it also means that some existing options for `lerna run` become obsolete as explained below.**
+
+#### Obsolete Options when `useNx` is enabled
+
+##### `--sort` and `--no-sort`
+
+Nx will always run tasks in the order it deems is correct based on its knowledge of project and task dependencies, so `--sort` and `--no-sort` have no effect.
+
+##### `--parallel`
+
+Nx will use the task graph to determine which tasks can be run in parallel and do so automatically, so `--parallel` has no effect.
+
+> **Note** if you want to limit the concurrency of tasks, you can still use the [concurrency global option](https://github.com/lerna/lerna/blob/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/core/global-options/README.md#--concurrency) to accomplish this.
+
+
+##### `--include-dependencies`
+
+Lerna by itself does not have knowledge of which tasks depend on others, so it defaults to excluding tasks on dependent projects when using [filter options](https://github.com/lerna/lerna/tree/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/core/filter-options#lernafilter-options) and relies on `--include-dependencies` to manually specify that dependent projects' tasks should be included.
+
+This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [task graph](https://nx.dev/concepts/mental-model#the-task-graph), will automatically run dependent tasks first when necessary, so `--include-dependencies` is obsolete.
+
+> **Tip** the effects on the options above will only apply if `nx.json` exists in the root. If `nx.json` does not exist and `useNx` is `true`, then they will behave just as they would with Lerna's base task runner (if `useNx` is `false`).

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -429,5 +429,17 @@ describe('RunCommand', () => {
       await lernaRun(testDir)('my-cacheable-script', '--skip-nx-cache');
       expect(collectedOutput).not.toContain('Nx read the output from the cache');
     });
+
+    it('should display a console warning when using obsolete options with useNx', async () => {
+      collectedOutput = '';
+
+      await lernaRun(testDir)('my-script', '--sort');
+
+      const [logMessage] = loggingOutput('warn');
+      expect(logMessage).toContain(
+        '"parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists.'
+      );
+      expect(collectedOutput).toContain('package-1');
+    });
   });
 });

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -430,7 +430,7 @@ describe('RunCommand', () => {
       expect(collectedOutput).not.toContain('Nx read the output from the cache');
     });
 
-    it('should display a console warning when using obsolete options with useNx', async () => {
+    it('should log a warning when using obsolete options with useNx', async () => {
       collectedOutput = '';
 
       await lernaRun(testDir)('my-script', '--sort');

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -298,8 +298,6 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
           `"parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.`
         );
       }
-    } else {
-      this.logger.verbose(this.name, 'nx.json was not found. Task dependencies will not be automatically included.');
     }
 
     const extraOptions = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna PR

> Makes `lerna run` warn the user when `--sort`, `--no-sort`, `--include-dependencies`, and `--parallel` are used with a `nx.json` file.

## Motivation and Context

As per Lerna [PR 3326](https://github.com/lerna/lerna/pull/3326)

> This change is necessary to communicate that specific options are not available when using nx with a custom nx.json file.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
