### PR TITLE
feat(version): use manual GitHub web interface when `GH_TOKEN` undefined

### DIFF
--- a/packages/core/src/git-clients/__tests__/github-client.spec.ts
+++ b/packages/core/src/git-clients/__tests__/github-client.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 jest.mock('@octokit/rest');
 jest.mock('../../child-process');
 
@@ -12,12 +10,6 @@ import { createGitHubClient, parseGitRepo } from '../index';
 describe('createGitHubClient', () => {
   beforeEach(() => {
     process.env = {};
-  });
-
-  it('errors if no GH_TOKEN env var', () => {
-    expect(() => {
-      createGitHubClient();
-    }).toThrow('A GH_TOKEN environment variable is required.');
   });
 
   it('doesnt error if GH_TOKEN env var is set', () => {

--- a/packages/core/src/git-clients/github-client.ts
+++ b/packages/core/src/git-clients/github-client.ts
@@ -9,19 +9,16 @@ export function createGitHubClient() {
   log.silly('createGitHubClient', '');
 
   const { GH_TOKEN, GHE_API_URL, GHE_VERSION } = process.env;
+  const options: { auth?: string; baseUrl?: string } = {};
 
-  if (!GH_TOKEN) {
-    throw new Error('A GH_TOKEN environment variable is required.');
+  if (GH_TOKEN) {
+    options.auth = `token ${GH_TOKEN}`;
   }
 
   if (GHE_VERSION) {
     // eslint-disable-next-line
     Octokit.plugin(require(`@octokit/plugin-enterprise-rest/ghe-${GHE_VERSION}`));
   }
-
-  const options: any = {
-    auth: `token ${GH_TOKEN}`,
-  };
 
   if (GHE_API_URL) {
     options.baseUrl = GHE_API_URL;

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -315,9 +315,11 @@ When run with this flag, `lerna version` will create an official GitHub or GitLa
 ##### GitHub Auth Token
 To authenticate with GitHub, the following environment variables can be defined.
 
-- `GH_TOKEN` (required) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens), please give it the `repo:public_repo` scope when creating the token.
+- `GH_TOKEN` (preferred) - Your GitHub authentication token (under Settings > Developer settings > Personal access tokens), please give it the `repo:public_repo` scope when creating the token.
 - `GHE_API_URL` - When using GitHub Enterprise, an absolute URL to the API.
 - `GHE_VERSION` - When using GitHub Enterprise, the currently installed GHE version. [Supports the following versions](https://github.com/octokit/plugin-enterprise-rest.js).
+
+> **Note:** even though `GH_TOKEN` is the preferred way to automate the creation of a GitHub Release (especially in a CI environment), we actually provide a more manual mode which is when the `GH_TOKEN` is not found. In this mode, we will create a link that once click will open the GitHub web interface form with the fields pre-populated. This mode is enabled automatically when the `GH_TOKEN` environment variable is not set and `--create-release github` is provided.
 
 ##### GitLab Auth Token
 To authenticate with GitLab, the following environment variables can be defined.

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@lerna-lite/core": "workspace:*",
     "chalk": "^4.1.2",
+    "new-github-release-url": "^1.0.0",
     "dedent": "^0.7.0",
     "load-json-file": "^6.2.0",
     "minimatch": "^5.1.0",

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -39,6 +39,7 @@ import { VersionCommand } from '../version-command';
 import cliCommands from '../../../cli/src/cli-commands/cli-version-commands';
 const lernaVersion = commandRunner(cliCommands);
 
+import chalk from 'chalk';
 import dedent from 'dedent';
 import npmlog from 'npmlog';
 import yargParser from 'yargs-parser';
@@ -173,6 +174,23 @@ describe.each([
       draft: false,
       prerelease: false,
     });
+  });
+
+  it('creates a single fixed release in dry-run mode', async () => {
+    process.env.GH_TOKEN = 'TOKEN';
+    const logSpy = jest.spyOn(npmlog, 'info');
+
+    const cwd = await initFixture('normal');
+
+    (recommendVersion as jest.Mock).mockResolvedValueOnce('1.1.0');
+
+    await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--git-dry-run'));
+
+    expect(logSpy).toHaveBeenCalledWith(
+      chalk.bold.magenta('[dry-run] >'),
+      `Create Release with repo options: `,
+      expect.anything()
+    );
   });
 
   it('creates a single fixed release in git dry-run mode', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,7 @@ importers:
       js-yaml: ^4.1.0
       load-json-file: ^6.2.0
       minimatch: ^5.1.0
+      new-github-release-url: ^1.0.0
       npmlog: ^6.0.2
       p-map: ^4.0.0
       p-pipe: ^3.1.0
@@ -599,6 +600,7 @@ importers:
       dedent: 0.7.0
       load-json-file: 6.2.0
       minimatch: 5.1.0
+      new-github-release-url: 1.0.0
       npmlog: 6.0.2
       p-map: 4.0.0
       p-pipe: 3.1.0
@@ -5193,6 +5195,13 @@ packages:
 
   /neo-async/2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+    dev: false
+
+  /new-github-release-url/1.0.0:
+    resolution: {integrity: sha512-dle7yf655IMjyFUqn6Nxkb18r4AOAkzRcgcZv6WZ0IqrOH4QCEZ8Sm6I7XX21zvHdBeeMeTkhR9qT2Z0EJDx6A==}
+    engines: {node: '>=10'}
+    dependencies:
+      type-fest: 0.4.1
     dev: false
 
   /node-addon-api/3.2.1:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When `--create-release github` is used without providing a `GH_TOKEN` environment variable, instead of throwing an error, we could use the library [new-github-release-url](https://github.com/sindresorhus/new-github-release-url) which will allow us to create a new GitHub Release with prefilled data by using the GitHub web interface, the lib is better described by the author as

> GitHub supports prefilling a new release by setting [certain search parameters](https://github.com/isaacs/github/issues/1410#issuecomment-442240267). This package simplifies generating such URL.

## Motivation and Context

Avoid throwing an error when `GH_TOKEN` is not provided, we can simply provide an alternative way to create a new GitHub release by using their web interface 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
