### PR TITLE
chore(version): change text in logs when using github release web interface

### DIFF
--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -249,6 +249,6 @@ describe('create --github-release without providing GH_TOKEN', () => {
 
     // prettier-ignore
     const releaseUrl = 'https://github.com/lerna/lerna/releases/new?tag=v1.0.1&title=v1.0.1&body=normal&prerelease=false';
-    expect(logSpy).toHaveBeenCalledWith('github', `🔗 ${releaseUrl} 🏷️ (GitHub Release web interface)`);
+    expect(logSpy).toHaveBeenCalledWith('github', `🏷️ (GitHub Release web interface) - 🔗 ${releaseUrl}`);
   });
 });

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -63,7 +63,7 @@ export function createRelease(
           body: notes,
         });
         log.verbose('github', 'GH_TOKEN environment variable is not set');
-        log.info('github', `🔗 ${releaseUrl} 🏷️ (GitHub Release web interface)`);
+        log.info('github', `🏷️ (GitHub Release web interface) - 🔗 ${releaseUrl}`);
         return Promise.resolve();
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

improve log when using the GitHub Release web interface when creating a new release

## Motivation and Context

The link that gets created could become very long, so it's better to show the link as the last part and moving all other text info before the link itself

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
