### PR TITLE
fix(run): fully defer to Nx for dep detection when nx.json exists

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -182,6 +182,8 @@ Nx will run tasks in an order and with a concurrency that it determines appropri
 
 **This behavior allows Nx to run tasks in the most efficient way possible, but it also means that some existing options for `lerna run` become obsolete as explained below.**
 
+> **Note** when Lerna is set to use Nx and detects `nx.json` in the workspace, it will defer to Nx to detect task dependencies. Some options for `lerna run` will behave differently. See [Using Lerna (Powered by Nx) to Run Tasks](./recipes/using-lerna-powered-by-nx-to-run-tasks) for more details.
+
 #### Obsolete Options when `useNx` is enabled
 
 ##### `--sort` and `--no-sort`
@@ -199,6 +201,10 @@ Nx will use the task graph to determine which tasks can be run in parallel and d
 
 Lerna by itself does not have knowledge of which tasks depend on others, so it defaults to excluding tasks on dependent projects when using [filter options](https://github.com/lerna/lerna/tree/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/core/filter-options#lernafilter-options) and relies on `--include-dependencies` to manually specify that dependent projects' tasks should be included.
 
-This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [task graph](https://nx.dev/concepts/mental-model#the-task-graph), will automatically run dependent tasks first when necessary, so `--include-dependencies` is obsolete.
+This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [task graph](https://nx.dev/concepts/mental-model#the-task-graph), will automatically run dependent tasks first when necessary, so `--include-dependencies` is obsolete. However, it can still be used to include project dependencies that Lerna detects but Nx does not deem necessary and would otherwise exclude.
+
+### `--ignore`
+
+When used with Nx, `--ignore` will never cause `lerna run` to exclude any tasks that are deemed to be required by the Nx [task graph](https://nx.dev/concepts/mental-model#the-task-graph).
 
 > **Tip** the effects on the options above will only apply if `nx.json` exists in the root. If `nx.json` does not exist and `useNx` is `true`, then they will behave just as they would with Lerna's base task runner (if `useNx` is `false`).

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -404,8 +404,14 @@ describe('RunCommand', () => {
     it('does not run a script in ignored packages', async () => {
       collectedOutput = '';
       await lernaRun(testDir)('my-script', '--ignore', 'package-@(2|3|4)');
+
       expect(collectedOutput).toContain('package-1');
       expect(collectedOutput).not.toContain('package-3');
+
+      const logMessages = loggingOutput('info');
+      expect(logMessages).toContain(
+        'Using the "ignore" option when nx.json exists will exclude only tasks that are not determined to be required by Nx. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--ignore for details.'
+      );
     });
 
     it('runs a script in packages with --stream', async () => {
@@ -439,7 +445,19 @@ describe('RunCommand', () => {
 
       const [logMessage] = loggingOutput('warn');
       expect(logMessage).toContain(
-        '"parallel", "sort", "no-sort", and "include-dependencies" are ignored when nx.json exists.'
+        '"parallel", "sort", and "no-sort" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.'
+      );
+      expect(collectedOutput).toContain('package-1');
+    });
+
+    it('should log some infos when using "includeDependencies" options with useNx', async () => {
+      collectedOutput = '';
+
+      await lernaRun(testDir)('my-script', '--include-dependencies');
+
+      const logMessages = loggingOutput('info');
+      expect(logMessages).toContain(
+        'Using the "include-dependencies" option when nx.json exists will include both task dependencies detected by Nx and project dependencies detected by Lerna. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--include-dependencies for details.'
       );
       expect(collectedOutput).toContain('package-1');
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per original Lerna [PR 3345](https://github.com/lerna/lerna/pull/3345)

> * Only sends "targetDependencies" from Lerna to Nx when nx.json does not exist.
> * Updates the warning when using `--include-dependencies` to indicate that Lerna will send Nx additional dependencies to run.
> * Updates docs to be more clear on the differing behavior.
> * Adds a note to the docs when installing Nx that `lerna run` will behave differently and links to the page describing the differences.


## Motivation and Context

stay in sync with original Lerna

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
