### PR TITLE
fix(run): only defer to Nx when targetDefaults are defined in nx.json

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -182,7 +182,7 @@ Nx will run tasks in an order and with a concurrency that it determines appropri
 
 **This behavior allows Nx to run tasks in the most efficient way possible, but it also means that some existing options for `lerna run` become obsolete as explained below.**
 
-> **Note** when Lerna is set to use Nx and detects `nx.json` in the workspace, it will defer to Nx to detect task dependencies. Some options for `lerna run` will behave differently. See [Using Lerna (Powered by Nx) to Run Tasks](./recipes/using-lerna-powered-by-nx-to-run-tasks) for more details.
+> **Note** when Lerna is set to use Nx and detects `nx.json` with `targetDefaults` in the workspace, it will defer to Nx to detect task dependencies. Some options for `lerna run` will behave differently. See [Using Lerna (Powered by Nx) to Run Tasks](./recipes/using-lerna-powered-by-nx-to-run-tasks) for more details.
 
 #### Obsolete Options when `useNx` is enabled
 
@@ -207,4 +207,4 @@ This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [
 
 When used with Nx, `--ignore` will never cause `lerna run` to exclude any tasks that are deemed to be required by the Nx [task graph](https://nx.dev/concepts/mental-model#the-task-graph).
 
-> **Tip** the effects on the options above will only apply if `nx.json` exists in the root. If `nx.json` does not exist and `useNx` is `true`, then they will behave just as they would with Lerna's base task runner (if `useNx` is `false`).
+> **Tip** the effects on the options above will only apply if `nx.json` exists in the root with the `targetDefaults` property defined. Otherwise, they will behave just as they would with Lerna's base task runner (if `useNx` is `false`).

--- a/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/lerna.json
+++ b/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/lerna.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "useNx": true
+}

--- a/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/nx.json
+++ b/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/nx.json
@@ -1,0 +1,16 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "useDaemonProcess": false,
+        "cacheableOperations": ["my-cacheable-script"]
+      }
+    }
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build", "prebuild"]
+    }
+  }
+}

--- a/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/package.json
+++ b/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "powered-by-nx"
+}

--- a/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-1/package.json
+++ b/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-1/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "scripts": {
+    "fail": "exit 1",
+    "my-script": "echo package-1",
+    "another-script:but-with-colons": "echo package-1-script-with-colons"
+  }
+}

--- a/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-2/package.json
+++ b/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "scripts": {
+    "fail": "exit 1"
+  },
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-3/package.json
+++ b/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-3/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "scripts": {
+    "my-script": "echo package-3"
+  },
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-4/package.json
+++ b/packages/run/src/__fixtures__/powered-by-nx-with-target-defaults/packages/package-4/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "scripts": {
+    "my-cacheable-script": "echo cacheable"
+  },
+  "dependencies": {
+    "package-1": "^0.0.0"
+  }
+}

--- a/packages/run/src/__tests__/__snapshots__/run-command.spec.ts.snap
+++ b/packages/run/src/__tests__/__snapshots__/run-command.spec.ts.snap
@@ -16,6 +16,13 @@ exports[`RunCommand in a basic repo omits package prefix with --stream --no-pref
 ]
 `;
 
+exports[`RunCommand in a basic repo run in --stream and --no-bail 1`] = `
+[
+  "packages/package-1 npm run my-script (prefixed: true)",
+  "packages/package-3 npm run my-script (prefixed: true)",
+]
+`;
+
 exports[`RunCommand in a basic repo runs a script in all packages with --parallel 1`] = `
 [
   "packages/package-1 npm run env (prefixed: true)",
@@ -26,6 +33,13 @@ exports[`RunCommand in a basic repo runs a script in all packages with --paralle
 `;
 
 exports[`RunCommand in a basic repo runs a script in packages with --stream 1`] = `
+[
+  "packages/package-1 npm run my-script (prefixed: true)",
+  "packages/package-3 npm run my-script (prefixed: true)",
+]
+`;
+
+exports[`RunCommand in a basic repo runs package prefix with --stream and expect it to be prefixed 1`] = `
 [
   "packages/package-1 npm run my-script (prefixed: true)",
   "packages/package-3 npm run my-script (prefixed: true)",

--- a/packages/run/src/__tests__/run-command-with-nx-no-target-defaults.spec.ts
+++ b/packages/run/src/__tests__/run-command-with-nx-no-target-defaults.spec.ts
@@ -31,7 +31,7 @@ describe('RunCommand', () => {
 
   // this is a temporary set of tests, which will be replaced by verdacio-driven tests
   // once the required setup is fully set up
-  describe('in a repo powered by Nx', () => {
+  describe('in a repo powered by Nx without defaultTargets', () => {
     let testDir;
     let collectedOutput = '';
     let originalStdout;

--- a/packages/run/src/__tests__/run-command-with-nx-no-target-defaults.spec.ts
+++ b/packages/run/src/__tests__/run-command-with-nx-no-target-defaults.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('../lib/npm-run-script');
+
+jest.mock('@lerna-lite/core', () => ({
+  ...(jest.requireActual('@lerna-lite/core') as any), // return the other real methods, below we'll mock only 2 of the methods
+  logOutput: jest.requireActual('../../../core/src/__mocks__/output').logOutput,
+  runTopologically: jest.requireActual('../../../core/src/utils/run-topologically').runTopologically,
+  QueryGraph: jest.requireActual('../../../core/src/utils/query-graph').QueryGraph,
+}));
+
+// also point to the local run command so that all mocks are properly used even by the command-runner
+jest.mock('@lerna-lite/run', () => jest.requireActual('../run-command'));
+
+// mocked modules
+import { npmRunScript, npmRunScriptStreaming } from '../lib/npm-run-script';
+import cliRunCommands from '../../../cli/src/cli-commands/cli-run-commands';
+
+// helpers
+import { commandRunner, initFixtureFactory, loggingOutput, normalizeRelativeDir } from '@lerna-test/helpers';
+const lernaRun = commandRunner(cliRunCommands);
+const initFixture = initFixtureFactory(__dirname);
+
+describe('RunCommand', () => {
+  (npmRunScript as jest.Mock).mockImplementation((script, { pkg }) =>
+    Promise.resolve({ exitCode: 0, stdout: pkg.name })
+  );
+  (npmRunScriptStreaming as jest.Mock).mockImplementation(() => Promise.resolve({ exitCode: 0 }));
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  // this is a temporary set of tests, which will be replaced by verdacio-driven tests
+  // once the required setup is fully set up
+  describe('in a repo powered by Nx', () => {
+    let testDir;
+    let collectedOutput = '';
+    let originalStdout;
+
+    beforeAll(async () => {
+      testDir = await initFixture('powered-by-nx');
+      process.env.NX_WORKSPACE_ROOT_PATH = testDir;
+      // @ts-ignore
+      jest.spyOn(process, 'exit').mockImplementation((code: any) => {
+        if (code !== 0) {
+          throw new Error();
+        }
+      });
+      originalStdout = process.stdout.write;
+      (process.stdout as any).write = (v) => {
+        collectedOutput = `${collectedOutput}\n${v}`;
+      };
+    });
+
+    afterAll(() => {
+      process.stdout.write = originalStdout;
+    });
+
+    it('runs a script in packages', async () => {
+      collectedOutput = '';
+      await lernaRun(testDir)('my-script');
+
+      expect(collectedOutput).toContain('package-1');
+      expect(collectedOutput).toContain('package-3');
+      expect(collectedOutput).toContain('Successfully ran target');
+
+      const logMessages = loggingOutput('verbose');
+      expect(logMessages).toContain(
+        'nx.json was not found or is missing targetDefaults. Task dependencies will not be automatically included.'
+      );
+    });
+  });
+});

--- a/packages/run/src/__tests__/run-command-with-nx-not-loaded.spec.ts
+++ b/packages/run/src/__tests__/run-command-with-nx-not-loaded.spec.ts
@@ -1,0 +1,45 @@
+jest.mock('nx/src/utils/output', () => undefined);
+jest.mock('../lib/npm-run-script');
+
+// also point to the local run command so that all mocks are properly used even by the command-runner
+jest.mock('@lerna-lite/run', () => jest.requireActual('../run-command'));
+
+// mocked modules
+import { npmRunScript } from '../lib/npm-run-script';
+import cliRunCommands from '../../../cli/src/cli-commands/cli-run-commands';
+
+// helpers
+import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
+const lernaRun = commandRunner(cliRunCommands);
+const initFixture = initFixtureFactory(__dirname);
+
+describe('RunCommand', () => {
+  (npmRunScript as jest.Mock).mockImplementation((script, { pkg }) =>
+    Promise.resolve({ exitCode: 0, stdout: pkg.name })
+  );
+
+  describe('in a repo powered by Nx', () => {
+    let testDir;
+    let errorSpy = jest.fn();
+
+    beforeAll(async () => {
+      testDir = await initFixture('powered-by-nx');
+      process.env.NX_WORKSPACE_ROOT_PATH = testDir;
+
+      // @ts-ignore
+      jest.spyOn(process, 'exit').mockImplementation((code: any) => {
+        if (code !== 0) {
+          errorSpy(code);
+        }
+      });
+    });
+
+    it('should throw when Nx is not loaded', async () => {
+      const command = lernaRun(testDir)('my-script');
+
+      await expect(command).rejects.toThrow(`Cannot read properties of undefined (reading 'output')`);
+
+      expect(errorSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/packages/run/src/__tests__/run-command-with-nx-not-loaded.spec.ts
+++ b/packages/run/src/__tests__/run-command-with-nx-not-loaded.spec.ts
@@ -37,7 +37,7 @@ describe('RunCommand', () => {
     it('should throw when Nx is not loaded', async () => {
       const command = lernaRun(testDir)('my-script');
 
-      await expect(command).rejects.toThrow(`Cannot read properties of undefined (reading 'output')`);
+      await expect(command).rejects.toThrow();
 
       expect(errorSpy).toHaveBeenCalledWith(1);
     });

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -12,7 +12,6 @@ jest.mock('@lerna-lite/run', () => jest.requireActual('../run-command'));
 
 import fs from 'fs-extra';
 import globby from 'globby';
-import { afterEach, afterAll } from 'jest-circus';
 import yargParser from 'yargs-parser';
 
 // make sure to import the output mock
@@ -361,7 +360,7 @@ describe('RunCommand', () => {
     let originalStdout;
 
     beforeAll(async () => {
-      testDir = await initFixture('powered-by-nx');
+      testDir = await initFixture('powered-by-nx-with-target-defaults');
       process.env.NX_WORKSPACE_ROOT_PATH = testDir;
       // @ts-ignore
       jest.spyOn(process, 'exit').mockImplementation((code: any) => {
@@ -410,7 +409,7 @@ describe('RunCommand', () => {
 
       const logMessages = loggingOutput('info');
       expect(logMessages).toContain(
-        'Using the "ignore" option when nx.json exists will exclude only tasks that are not determined to be required by Nx. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--ignore for details.'
+        'Using the "ignore" option when nx.json has targetDefaults defined will exclude only tasks that are not determined to be required by Nx. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--ignore for details.'
       );
     });
 
@@ -445,7 +444,7 @@ describe('RunCommand', () => {
 
       const [logMessage] = loggingOutput('warn');
       expect(logMessage).toContain(
-        '"parallel", "sort", and "no-sort" are ignored when nx.json exists. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.'
+        '"parallel", "sort", and "no-sort" are ignored when nx.json has targetDefaults defined. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks for details.'
       );
       expect(collectedOutput).toContain('package-1');
     });
@@ -457,7 +456,7 @@ describe('RunCommand', () => {
 
       const logMessages = loggingOutput('info');
       expect(logMessages).toContain(
-        'Using the "include-dependencies" option when nx.json exists will include both task dependencies detected by Nx and project dependencies detected by Lerna. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--include-dependencies for details.'
+        'Using the "include-dependencies" option when nx.json has targetDefaults defined will include both task dependencies detected by Nx and project dependencies detected by Lerna. See https://lerna.js.org/docs/recipes/using-lerna-powered-by-nx-to-run-tasks#--include-dependencies for details.'
       );
       expect(collectedOutput).toContain('package-1');
     });

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -221,7 +221,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
       process.env.CI = 'true';
     }
     performance.mark('init-local');
-    this.configureNxOutput();
+    await this.configureNxOutput();
     const { extraOptions, targetDependencies, options } = await this.prepNxOptions();
     if (this.packagesWithScript.length === 1) {
       const { runOne } = await import('nx/src/command-line/run-one');
@@ -381,7 +381,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
       const nxOutput = await import('nx/src/utils/output');
       nxOutput.output.cliName = 'Lerna (powered by Nx)';
       nxOutput.output.formatCommand = (taskId) => taskId;
-      return nxOutput as any;
+      return nxOutput as unknown;
     } catch (e) {
       this.logger.error(
         '\n',

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -346,9 +346,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
 
     const chain: Promise<any> = npmRunScriptStreaming(this.script, this.getOpts(pkg));
     if (!this.bail) {
-      chain.then((result: { exitCode: number; failed?: boolean; pkg: Package; stderr: any }) => {
-        return { ...result, pkg };
-      });
+      chain.then((result: { exitCode: number; failed?: boolean; pkg: Package; stderr: any }) => ({ ...result, pkg }));
     }
     return chain;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna [PR 3349](https://github.com/lerna/lerna/pull/3349)

> Change lerna run to only pass target dependencies to Nx when there are not target defaults already defined in nx.json

## Motivation and Context

> Follow up / partial reversion of Lerna issue 3345

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
