### PR TITLE
feat(version): add `--allow-peer-dependencies-update`, closes #333

### DIFF
--- a/__fixtures__/lockfile-pnpm/packages/package-2/package.json
+++ b/__fixtures__/lockfile-pnpm/packages/package-2/package.json
@@ -3,5 +3,8 @@
   "version": "2.3.4",
   "dependencies": {
     "@my-workspace/package-1": "workspace:^2.3.4"
+  },
+  "peerDependencies": {
+    "@my-workspace/package-1": "workspace:^2.3.4"
   }
 }

--- a/__fixtures__/lockfile-pnpm/packages/package-4/package.json
+++ b/__fixtures__/lockfile-pnpm/packages/package-4/package.json
@@ -4,5 +4,8 @@
   "dependencies": {
     "@my-workspace/package-1": "workspace:2.3.4",
     "@my-workspace/package-2": "workspace:~"
+  },
+  "peerDependencies": {
+    "@my-workspace/package-1": "workspace:>=2.0.0"
   }
 }

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -536,6 +536,9 @@
             "allowBranch": {
               "$ref": "#/$defs/commandOptions/version/allowBranch"
             },
+            "allowUpdatingPeerDeps": {
+              "$ref": "#/$defs/commandOptions/version/allowUpdatingPeerDeps"
+            },
             "amend": {
               "$ref": "#/$defs/commandOptions/version/amend"
             },
@@ -864,6 +867,9 @@
 
     "allowBranch": {
       "$ref": "#/$defs/commandOptions/version/allowBranch"
+    },
+    "allowUpdatingPeerDeps": {
+      "$ref": "#/$defs/commandOptions/version/allowUpdatingPeerDeps"
     },
     "amend": {
       "$ref": "#/$defs/commandOptions/version/amend"
@@ -1258,6 +1264,10 @@
             }
           ],
           "description": "For `lerna version`, the branches to allow versioning from."
+        },
+        "allowUpdatingPeerDeps": {
+          "type": "boolean",
+          "description": "For `lerna version`, allow updating peer dependencies versions. Note that `peerDependencies` with semver range (ie `>=2.0.0`) will never be bumped even with this flag enabled."
         },
         "amend": {
           "type": "boolean",

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -536,8 +536,8 @@
             "allowBranch": {
               "$ref": "#/$defs/commandOptions/version/allowBranch"
             },
-            "allowUpdatingPeerDeps": {
-              "$ref": "#/$defs/commandOptions/version/allowUpdatingPeerDeps"
+            "allowPeerDepsUpdate": {
+              "$ref": "#/$defs/commandOptions/version/allowPeerDepsUpdate"
             },
             "amend": {
               "$ref": "#/$defs/commandOptions/version/amend"
@@ -868,8 +868,8 @@
     "allowBranch": {
       "$ref": "#/$defs/commandOptions/version/allowBranch"
     },
-    "allowUpdatingPeerDeps": {
-      "$ref": "#/$defs/commandOptions/version/allowUpdatingPeerDeps"
+    "allowPeerDepsUpdate": {
+      "$ref": "#/$defs/commandOptions/version/allowPeerDepsUpdate"
     },
     "amend": {
       "$ref": "#/$defs/commandOptions/version/amend"
@@ -1265,7 +1265,7 @@
           ],
           "description": "For `lerna version`, the branches to allow versioning from."
         },
-        "allowUpdatingPeerDeps": {
+        "allowPeerDepsUpdate": {
           "type": "boolean",
           "description": "For `lerna version`, allow updating peer dependencies versions. Note that `peerDependencies` with semver range (ie `>=2.0.0`) will never be bumped even with this flag enabled."
         },

--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -536,8 +536,8 @@
             "allowBranch": {
               "$ref": "#/$defs/commandOptions/version/allowBranch"
             },
-            "allowPeerDepsUpdate": {
-              "$ref": "#/$defs/commandOptions/version/allowPeerDepsUpdate"
+            "allowPeerDependenciesUpdate": {
+              "$ref": "#/$defs/commandOptions/version/allowPeerDependenciesUpdate"
             },
             "amend": {
               "$ref": "#/$defs/commandOptions/version/amend"
@@ -868,8 +868,8 @@
     "allowBranch": {
       "$ref": "#/$defs/commandOptions/version/allowBranch"
     },
-    "allowPeerDepsUpdate": {
-      "$ref": "#/$defs/commandOptions/version/allowPeerDepsUpdate"
+    "allowPeerDependenciesUpdate": {
+      "$ref": "#/$defs/commandOptions/version/allowPeerDependenciesUpdate"
     },
     "amend": {
       "$ref": "#/$defs/commandOptions/version/amend"
@@ -1265,7 +1265,7 @@
           ],
           "description": "For `lerna version`, the branches to allow versioning from."
         },
-        "allowPeerDepsUpdate": {
+        "allowPeerDependenciesUpdate": {
           "type": "boolean",
           "description": "For `lerna version`, allow updating peer dependencies versions. Note that `peerDependencies` with semver range (ie `>=2.0.0`) will never be bumped even with this flag enabled."
         },

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -387,7 +387,7 @@ describe('Package', () => {
         `);
       });
 
-      it('bumps peerDependencies when allowUpdatingPeerDeps flag is enabled except for dependencies with semver range operator', () => {
+      it('bumps peerDependencies when allowPeerDepsUpdate flag is enabled except for dependencies with semver range operator', () => {
         const pkg = factory({
           peerDependencies: {
             a: '^1.0.0',
@@ -411,7 +411,7 @@ describe('Package', () => {
         `);
       });
 
-      it('bumps peerDependencies canary versions when allowUpdatingPeerDeps flag is enabled except for dependencies with semver range operator', () => {
+      it('bumps peerDependencies canary versions when allowPeerDepsUpdate flag is enabled except for dependencies with semver range operator', () => {
         const pkg = factory({
           peerDependencies: {
             a: '^1.0.0-alpha.0',
@@ -435,7 +435,7 @@ describe('Package', () => {
         `);
       });
 
-      it('bumps peerDependencies canary with SHA versions when allowUpdatingPeerDeps flag is enabled except for dependencies with semver range operator', () => {
+      it('bumps peerDependencies canary with SHA versions when allowPeerDepsUpdate flag is enabled except for dependencies with semver range operator', () => {
         const pkg = factory({
           peerDependencies: {
             a: '^1.0.0-alpha.0+SHA',
@@ -490,7 +490,7 @@ describe('Package', () => {
         `);
       });
 
-      it('works with `workspace:` protocol range and bumps both when dependencies and peerDependencies are found and allowUpdatingPeerDeps flag is enabled', () => {
+      it('works with `workspace:` protocol range and bumps both when dependencies and peerDependencies are found and allowPeerDepsUpdate flag is enabled', () => {
         const pkg = factory({
           dependencies: {
             a: 'workspace:^1.0.0',
@@ -530,7 +530,7 @@ describe('Package', () => {
         `);
       });
 
-      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowUpdatingPeerDeps flag is disabled', () => {
+      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowPeerDepsUpdate flag is disabled', () => {
         const pkg = factory({
           dependencies: {
             a: 'workspace:^1.0.0',
@@ -565,7 +565,7 @@ describe('Package', () => {
         `);
       });
 
-      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowUpdatingPeerDeps flag is enabled but the version is a range', () => {
+      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowPeerDepsUpdate flag is enabled but the version is a range', () => {
         const pkg = factory({
           dependencies: {
             a: 'workspace:^1.0.0',
@@ -682,7 +682,7 @@ describe('Package', () => {
         const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.workspaceSpec = 'workspace:1.0.0';
 
-        pkg.updateLocalDependency(resolved, '2.0.0', '^', true); // last arg is allowUpdatingPeerDeps=true
+        pkg.updateLocalDependency(resolved, '2.0.0', '^', true); // last arg is allowPeerDepsUpdate=true
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
@@ -738,7 +738,7 @@ describe('Package', () => {
         const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.workspaceSpec = 'workspace:^1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowUpdatingPeerDeps=true, workspaceStrictMatch=true
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowPeerDepsUpdate=true, workspaceStrictMatch=true
         pkg.updateLocalDependency(resolvedB, '1.1.0', '^', true, true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
@@ -772,7 +772,7 @@ describe('Package', () => {
         const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.workspaceSpec = 'workspace:~1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowUpdatingPeerDeps=true, workspaceStrictMatch=true
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowPeerDepsUpdate=true, workspaceStrictMatch=true
         pkg.updateLocalDependency(resolvedB, '1.1.0', '~', true, true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
@@ -807,7 +807,7 @@ describe('Package', () => {
         const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.workspaceSpec = 'workspace:^1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', false, true, 'publish'); // allowUpdatingPeerDeps=false, workspaceStrictMatch=true
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', false, true, 'publish'); // allowPeerDepsUpdate=false, workspaceStrictMatch=true
         pkg.updateLocalDependency(resolvedB, '1.1.0', '^', false, true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -365,7 +365,7 @@ describe('Package', () => {
         expect((resolved.hosted as any).committish).toBe('semver:^2.0.0');
       });
 
-      it('dot not bump peerDependencies by default without a flag', () => {
+      it('does not bump peerDependencies by default without a flag', () => {
         const pkg = factory({
           peerDependencies: {
             a: '^1.0.0',
@@ -406,6 +406,54 @@ describe('Package', () => {
             "peerDependencies": {
               "a": "^2.0.0",
               "b": ">=1.0.0",
+            },
+          }
+        `);
+      });
+
+      it('bumps peerDependencies canary versions when allowUpdatingPeerDeps flag is enabled except for dependencies with semver range operator', () => {
+        const pkg = factory({
+          peerDependencies: {
+            a: '^1.0.0-alpha.0',
+            b: '>=1.0.0-alpha.0', // range will not be bumped
+          },
+        });
+
+        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0-alpha.0', '.');
+        const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0-alpha.0', '.');
+
+        pkg.updateLocalDependency(resolvedA, '1.0.0-alpha.1', '^', true);
+        pkg.updateLocalDependency(resolvedB, '1.0.0-alpha.1', '^', true);
+
+        expect(pkg.toJSON()).toMatchInlineSnapshot(`
+          {
+            "peerDependencies": {
+              "a": "^1.0.0-alpha.1",
+              "b": ">=1.0.0-alpha.0",
+            },
+          }
+        `);
+      });
+
+      it('bumps peerDependencies canary with SHA versions when allowUpdatingPeerDeps flag is enabled except for dependencies with semver range operator', () => {
+        const pkg = factory({
+          peerDependencies: {
+            a: '^1.0.0-alpha.0+SHA',
+            b: '>=1.0.0-alpha.0+SHA', // range will not be bumped
+          },
+        });
+
+        const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0-alpha.0+SHA', '.');
+        const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0-alpha.0+SHA', '.');
+
+        pkg.updateLocalDependency(resolvedA, '1.0.0-alpha.1+SHA', '^', true);
+        pkg.updateLocalDependency(resolvedB, '1.0.0-alpha.1+SHA', '^', true);
+
+        expect(pkg.toJSON()).toMatchInlineSnapshot(`
+          {
+            "peerDependencies": {
+              "a": "^1.0.0-alpha.1+SHA",
+              "b": ">=1.0.0-alpha.0+SHA",
             },
           }
         `);

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -492,7 +492,7 @@ describe('Package', () => {
             e: '^1.0.0',
           },
           peerDependencies: {
-            a: 'workspace:^1.0.0',
+            a: 'workspace:>=1.0.0',
           },
         });
 
@@ -511,7 +511,7 @@ describe('Package', () => {
               "e": "^1.0.0",
             },
             "peerDependencies": {
-              "a": "workspace:^1.0.0",
+              "a": "workspace:>=1.0.0",
             },
           }
         `);
@@ -749,7 +749,7 @@ describe('Package', () => {
           },
           peerDependencies: {
             // nothing wil be bumped by default without flag enabled
-            a: '>=1.0.0',
+            a: 'workspace:>=1.0.0',
             b: '~1.0.0',
           },
         });
@@ -783,6 +783,9 @@ describe('Package', () => {
             a: 'workspace:*',
             b: 'workspace:^2.2.4',
           },
+          peerDependencies: {
+            b: 'workspace:>=2.0.0',
+          },
         });
 
         const resolvedA: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
@@ -805,6 +808,9 @@ describe('Package', () => {
           {
             "dependencies": {
               "a": "latest",
+              "b": "^2.2.4",
+            },
+            "peerDependencies": {
               "b": "^2.2.4",
             },
           }

--- a/packages/core/src/__tests__/package.spec.ts
+++ b/packages/core/src/__tests__/package.spec.ts
@@ -387,7 +387,7 @@ describe('Package', () => {
         `);
       });
 
-      it('bumps peerDependencies when allowPeerDepsUpdate flag is enabled except for dependencies with semver range operator', () => {
+      it('bumps peerDependencies when allowPeerDependenciesUpdate flag is enabled except for dependencies with semver range operator', () => {
         const pkg = factory({
           peerDependencies: {
             a: '^1.0.0',
@@ -411,7 +411,7 @@ describe('Package', () => {
         `);
       });
 
-      it('bumps peerDependencies canary versions when allowPeerDepsUpdate flag is enabled except for dependencies with semver range operator', () => {
+      it('bumps peerDependencies canary versions when allowPeerDependenciesUpdate flag is enabled except for dependencies with semver range operator', () => {
         const pkg = factory({
           peerDependencies: {
             a: '^1.0.0-alpha.0',
@@ -435,7 +435,7 @@ describe('Package', () => {
         `);
       });
 
-      it('bumps peerDependencies canary with SHA versions when allowPeerDepsUpdate flag is enabled except for dependencies with semver range operator', () => {
+      it('bumps peerDependencies canary with SHA versions when allowPeerDependenciesUpdate flag is enabled except for dependencies with semver range operator', () => {
         const pkg = factory({
           peerDependencies: {
             a: '^1.0.0-alpha.0+SHA',
@@ -490,7 +490,7 @@ describe('Package', () => {
         `);
       });
 
-      it('works with `workspace:` protocol range and bumps both when dependencies and peerDependencies are found and allowPeerDepsUpdate flag is enabled', () => {
+      it('works with `workspace:` protocol range and bumps both when dependencies and peerDependencies are found and allowPeerDependenciesUpdate flag is enabled', () => {
         const pkg = factory({
           dependencies: {
             a: 'workspace:^1.0.0',
@@ -530,7 +530,7 @@ describe('Package', () => {
         `);
       });
 
-      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowPeerDepsUpdate flag is disabled', () => {
+      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowPeerDependenciesUpdate flag is disabled', () => {
         const pkg = factory({
           dependencies: {
             a: 'workspace:^1.0.0',
@@ -565,7 +565,7 @@ describe('Package', () => {
         `);
       });
 
-      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowPeerDepsUpdate flag is enabled but the version is a range', () => {
+      it('works with `workspace:` protocol range and DOES NOT update peerDependencies when allowPeerDependenciesUpdate flag is enabled but the version is a range', () => {
         const pkg = factory({
           dependencies: {
             a: 'workspace:^1.0.0',
@@ -682,7 +682,7 @@ describe('Package', () => {
         const resolved: NpaResolveResult = npa.resolve('a', '^1.0.0', '.');
         resolved.workspaceSpec = 'workspace:1.0.0';
 
-        pkg.updateLocalDependency(resolved, '2.0.0', '^', true); // last arg is allowPeerDepsUpdate=true
+        pkg.updateLocalDependency(resolved, '2.0.0', '^', true); // last arg is allowPeerDependenciesUpdate=true
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
           {
@@ -738,7 +738,7 @@ describe('Package', () => {
         const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.workspaceSpec = 'workspace:^1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowPeerDepsUpdate=true, workspaceStrictMatch=true
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowPeerDependenciesUpdate=true, workspaceStrictMatch=true
         pkg.updateLocalDependency(resolvedB, '1.1.0', '^', true, true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
@@ -772,7 +772,7 @@ describe('Package', () => {
         const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.workspaceSpec = 'workspace:~1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowPeerDepsUpdate=true, workspaceStrictMatch=true
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', true, true, 'publish'); // allowPeerDependenciesUpdate=true, workspaceStrictMatch=true
         pkg.updateLocalDependency(resolvedB, '1.1.0', '~', true, true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`
@@ -807,7 +807,7 @@ describe('Package', () => {
         const resolvedB: NpaResolveResult = npa.resolve('b', '^1.0.0', '.');
         resolvedB.workspaceSpec = 'workspace:^1.0.0';
 
-        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', false, true, 'publish'); // allowPeerDepsUpdate=false, workspaceStrictMatch=true
+        pkg.updateLocalDependency(resolvedA, '2.0.0', '^', false, true, 'publish'); // allowPeerDependenciesUpdate=false, workspaceStrictMatch=true
         pkg.updateLocalDependency(resolvedB, '1.1.0', '^', false, true, 'publish');
 
         expect(pkg.toJSON()).toMatchInlineSnapshot(`

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -321,7 +321,9 @@ export class Command<T extends AvailableCommandOption> {
       chain = chain.then((packages) => {
         this.packageGraph = new PackageGraph(
           packages || [],
-          (this.options as VersionCommandOption).allowPeerDepsUpdate ? 'allPlusPeerDependencies' : 'allDependencies'
+          (this.options as VersionCommandOption).allowPeerDependenciesUpdate
+            ? 'allPlusPeerDependencies'
+            : 'allDependencies'
         );
       });
     }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -321,7 +321,7 @@ export class Command<T extends AvailableCommandOption> {
       chain = chain.then((packages) => {
         this.packageGraph = new PackageGraph(
           packages || [],
-          (this.options as VersionCommandOption).allowUpdatingPeerDeps ? 'allPlusPeerDependencies' : 'allDependencies'
+          (this.options as VersionCommandOption).allowPeerDepsUpdate ? 'allPlusPeerDependencies' : 'allDependencies'
         );
       });
     }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -319,7 +319,10 @@ export class Command<T extends AvailableCommandOption> {
     if (this.commandName !== 'info') {
       chain = chain.then(() => this.project.getPackages());
       chain = chain.then((packages) => {
-        this.packageGraph = new PackageGraph(packages || []);
+        this.packageGraph = new PackageGraph(
+          packages || [],
+          (this.options as VersionCommandOption).allowUpdatingPeerDeps ? 'allPlusPeerDependencies' : 'allDependencies'
+        );
       });
     }
 

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -176,7 +176,7 @@ export interface VersionCommandOption {
    * allow updating peer dependencies versions.
    * Note that `peerDependencies` with semver range (ie `>=2.0.0`) will never be bumped even with this flag enabled.
    */
-  allowPeerDepsUpdate?: boolean;
+  allowPeerDependenciesUpdate?: boolean;
 
   /** Amend the existing commit, instead of generating a new one. */
   amend?: boolean;

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -176,7 +176,7 @@ export interface VersionCommandOption {
    * allow updating peer dependencies versions.
    * Note that `peerDependencies` with semver range (ie `>=2.0.0`) will never be bumped even with this flag enabled.
    */
-  allowUpdatingPeerDeps?: boolean;
+  allowPeerDepsUpdate?: boolean;
 
   /** Amend the existing commit, instead of generating a new one. */
   amend?: boolean;

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -172,6 +172,12 @@ export interface VersionCommandOption {
   /** Specify which branches to allow versioning from. */
   allowBranch?: string[];
 
+  /**
+   * allow updating peer dependencies versions.
+   * Note that `peerDependencies` with semver range (ie `>=2.0.0`) will never be bumped even with this flag enabled.
+   */
+  allowUpdatingPeerDeps?: boolean;
+
   /** Amend the existing commit, instead of generating a new one. */
   amend?: boolean;
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -135,7 +135,7 @@ export interface ProfileData {
 
 export interface QueryGraphConfig {
   /** "dependencies" excludes devDependencies from graph */
-  graphType?: 'all' | 'allDependencies' | 'dependencies';
+  graphType?: 'all' | 'allDependencies' | 'allPlusPeerDependencies' | 'dependencies';
 
   /** Treatment of local sibling dependencies, default "auto" */
   localDependencies?: 'auto' | 'force' | 'explicit';
@@ -179,8 +179,8 @@ export type NpaResolveResult = (
   | npa.AliasResult
   | npa.RegistryResult
 ) & {
-  explicitWorkspace?: boolean;
-  workspaceTarget?: string;
+  /** the specifier part used when deailing with a `workspace:` protocol resource */
+  workspaceSpec?: string;
 };
 
 /** Passed between concurrent executions */

--- a/packages/core/src/package-graph/__tests__/package-graph.spec.ts
+++ b/packages/core/src/package-graph/__tests__/package-graph.spec.ts
@@ -57,10 +57,10 @@ describe('PackageGraph', () => {
       ];
       const graph = new PackageGraph(pkgs);
 
-      expect(graph.get('pkg-1').externalDependencies.has('pkg-2')).toBe(true);
-      expect(graph.get('pkg-2').localDependents.has('pkg-1')).toBe(false);
-      expect(graph.get('pkg-2').localDependencies.has('pkg-1')).toBe(true);
-      expect(graph.get('pkg-3').localDependencies.has('pkg-2')).toBe(true);
+      expect(graph.get('pkg-1')!.externalDependencies.has('pkg-2')).toBe(true);
+      expect(graph.get('pkg-2')!.localDependents.has('pkg-1')).toBe(false);
+      expect(graph.get('pkg-2')!.localDependencies.has('pkg-1')).toBe(true);
+      expect(graph.get('pkg-3')!.localDependencies.has('pkg-2')).toBe(true);
     });
 
     it('localizes all non-satisfied siblings when forced', () => {
@@ -117,6 +117,9 @@ describe('PackageGraph', () => {
             dependencies: {
               'pkg-1': 'workspace:^1.0.0',
             },
+            peerDependencies: {
+              'pkg-1': 'workspace:^1.0.0',
+            },
           } as unknown as RawManifest,
           '/test/pkg-3'
         ),
@@ -140,6 +143,9 @@ describe('PackageGraph', () => {
               'pkg-3': 'workspace:^1.0.0',
               'pkg-4': 'workspace:>=1.0.0',
             },
+            peerDependencies: {
+              'pkg-1': 'workspace:^1.0.0',
+            },
           } as unknown as RawManifest,
           '/test/pkg-5'
         ),
@@ -153,13 +159,13 @@ describe('PackageGraph', () => {
       expect(pkg1.localDependents.has('pkg-3')).toBe(true);
       expect(pkg3.localDependencies.has('pkg-1')).toBe(true);
       expect(pkg4.localDependencies.has('pkg-1')).toBe(true);
-      expect(pkg4.localDependencies.get('pkg-1').workspaceTarget).toBe('workspace:*');
+      expect(pkg4.localDependencies.get('pkg-1').workspaceSpec).toBe('workspace:*');
       expect(pkg5.localDependencies.has('pkg-1')).toBe(true);
       expect(pkg5.localDependencies.has('pkg-2')).toBe(true);
-      expect(pkg5.localDependencies.get('pkg-1').workspaceTarget).toBe('workspace:^');
-      expect(pkg5.localDependencies.get('pkg-2').workspaceTarget).toBe('workspace:~');
-      expect(pkg5.localDependencies.get('pkg-3').workspaceTarget).toBe('workspace:^1.0.0');
-      expect(pkg5.localDependencies.get('pkg-4').workspaceTarget).toBe('workspace:>=1.0.0');
+      expect(pkg5.localDependencies.get('pkg-1').workspaceSpec).toBe('workspace:^');
+      expect(pkg5.localDependencies.get('pkg-2').workspaceSpec).toBe('workspace:~');
+      expect(pkg5.localDependencies.get('pkg-3').workspaceSpec).toBe('workspace:^1.0.0');
+      expect(pkg5.localDependencies.get('pkg-4').workspaceSpec).toBe('workspace:>=1.0.0');
     });
   });
 
@@ -167,7 +173,7 @@ describe('PackageGraph', () => {
     it('proxies Package properties', () => {
       const pkg = new Package({ name: 'my-pkg', version: '1.2.3' } as unknown as RawManifest, '/path/to/my-pkg');
       const graph = new PackageGraph([pkg]);
-      const node = graph.get('my-pkg');
+      const node = graph.get('my-pkg') as PackageGraphNode;
 
       // most of these properties are non-enumerable, so a snapshot doesn't work
       expect(node.name).toBe('my-pkg');
@@ -190,7 +196,7 @@ describe('PackageGraph', () => {
     it('computes prereleaseId from prerelease version', () => {
       const node = new PackageGraph([
         new Package({ name: 'my-pkg', version: '1.2.3-rc.4' } as unknown as RawManifest, '/path/to/my-pkg'),
-      ]).get('my-pkg');
+      ]).get('my-pkg') as PackageGraphNode;
 
       expect(node.prereleaseId).toBe('rc');
     });
@@ -199,7 +205,7 @@ describe('PackageGraph', () => {
       it("returns the node's name", () => {
         const node = new PackageGraph([
           new Package({ name: 'pkg-name', version: '0.1.2' } as unknown as RawManifest, '/path/to/pkg-name'),
-        ]).get('pkg-name');
+        ]).get('pkg-name') as PackageGraphNode;
 
         expect(node.toString()).toBe('pkg-name');
       });
@@ -232,8 +238,8 @@ describe('PackageGraph', () => {
       ];
       const graph = new PackageGraph(packages, 'allDependencies');
 
-      expect(graph.get('my-package-1').localDependencies.size).toBe(0);
-      expect(graph.get('my-package-2').localDependencies.has('my-package-1')).toBe(true);
+      expect(graph.get('my-package-1')!.localDependencies.size).toBe(0);
+      expect(graph.get('my-package-2')!.localDependencies.has('my-package-1')).toBe(true);
     });
 
     it('should skip gitCommittish of packages that are not in localDependencies', () => {
@@ -261,8 +267,8 @@ describe('PackageGraph', () => {
       ];
       const graph = new PackageGraph(packages, 'dependencies');
 
-      expect(graph.get('my-package-1').localDependencies.size).toBe(0);
-      expect(graph.get('my-package-2').localDependencies.size).toBe(0);
+      expect(graph.get('my-package-1')!.localDependencies.size).toBe(0);
+      expect(graph.get('my-package-2')!.localDependencies.size).toBe(0);
     });
 
     it('should return the localDependencies for matched gitCommittish', () => {
@@ -290,7 +296,7 @@ describe('PackageGraph', () => {
       ];
       const graph = new PackageGraph(packages);
 
-      expect(graph.get('my-package-2').localDependencies.has('my-package-1')).toBe(true);
+      expect(graph.get('my-package-2')!.localDependencies.has('my-package-1')).toBe(true);
     });
   });
 
@@ -321,7 +327,7 @@ describe('PackageGraph', () => {
       ].map((json) => new Package(json as unknown as RawManifest, `/test/${json.name}`, '/test'));
       const graph = new PackageGraph(pkgs);
 
-      const search = filtered.map((name) => graph.get(name).pkg);
+      const search = filtered.map((name) => graph.get(name)!.pkg);
       const result = graph[method](search);
 
       expect(result.map((pkg) => pkg.name)).toEqual(expected);

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -312,7 +312,7 @@ export class Package {
       // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
       // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but these would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
       // prettier-ignore
-      if (allowPeerDepsUpdate && /^(workspace:)?[~|^]?[^\+]([\d\w\.\-\+]+)$/i.test(this.peerDependencies[depName] || '')) {
+      if (allowPeerDepsUpdate && /^(workspace:)?[~^]?[\d\.]+([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
       }
       // when peer bump is disabled, we could end up with peerDependencies not being reviewed

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -378,14 +378,10 @@ export class Package {
       }
     }
 
-    // when publishing, make sure to never publish any dependencies with a `workspace:` protocol prefix and simply remove it when found
-    if (updatedByCommand === 'publish') {
-      if (localDependencies?.[depName].startsWith('workspace:')) {
-        localDependencies[depName] = localDependencies[depName].replace('workspace:', '');
-      }
-      if (this.peerDependencies?.[depName].startsWith('workspace:')) {
-        this.peerDependencies[depName] = this.peerDependencies[depName].replace('workspace:', '');
-      }
+    // when allowUpdatingPeerDeps is disabled, we could end up with peerDependencies not being reviewed
+    // and still having the `workspace:` prefix so make sure to remove any of these prefixes
+    if (updatedByCommand === 'publish' && this.peerDependencies?.[depName].startsWith('workspace:')) {
+      this.peerDependencies[depName] = this.peerDependencies[depName].replace('workspace:', '');
     }
   }
 

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -299,7 +299,7 @@ export class Package {
     resolved: NpaResolveResult,
     depVersion: string,
     savePrefix: string,
-    allowPeerDepsUpdate = false,
+    allowPeerDependenciesUpdate = false,
     workspaceStrictMatch = true,
     updatedByCommand?: CommandType
   ) {
@@ -312,7 +312,7 @@ export class Package {
       // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
       // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but these would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
       // prettier-ignore
-      if (allowPeerDepsUpdate && /^(workspace:)?[~^]?[\d\.]+([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
+      if (allowPeerDependenciesUpdate && /^(workspace:)?[~^]?[\d\.]+([\-]+[\w\.\-\+]+)*$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
       }
       // when peer bump is disabled, we could end up with peerDependencies not being reviewed

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -311,7 +311,8 @@ export class Package {
     if (this.peerDependencies?.[depName]) {
       // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
       // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but these would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
-      if (allowUpdatingPeerDeps && /^(workspace:)?[~|^]?([0-9\.]+)$/.test(this.peerDependencies[depName] || '')) {
+      // prettier-ignore
+      if (allowUpdatingPeerDeps && /^(workspace:)?[~|^]?[^\+]([\d\w\.\-\+]+)$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
       }
       // when peer bump is disabled, we could end up with peerDependencies not being reviewed

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -307,12 +307,17 @@ export class Package {
     const localDependencies = this.retrievePackageDependencies(depName);
     const updatingDependencies = [localDependencies];
 
-    // when user wants to also bump peerDependencies we'll loop through them as well,
-    // however only do it when not a range operator, ie this would bump ("^2.0.0") but these would not (">=2.0.0" or "workspace:<2.0.0")
-    if (allowUpdatingPeerDeps) {
-      // prettier-ignore
-      if (this.peerDependencies?.[depName] && /^(workspace:)?[~|^]?([0-9\.])*$/.test(this.peerDependencies[depName] || '')) {
+    // when we have peer dependencies, we might need to perform certain things
+    if (this.peerDependencies?.[depName]) {
+      // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
+      // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but these would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
+      if (allowUpdatingPeerDeps && /^(workspace:)?[~|^]?([0-9\.]+)$/.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
+      }
+      // when peer bump is disabled, we could end up with peerDependencies not being reviewed
+      // and some might still have the `workspace:` prefix so make sure to remove any of these prefixes
+      else if (updatedByCommand === 'publish' && this.peerDependencies[depName].startsWith('workspace:')) {
+        this.peerDependencies[depName] = this.peerDependencies[depName].replace('workspace:', '');
       }
     }
 
@@ -376,12 +381,6 @@ export class Package {
         // always serialize the full url (identical to previous resolved.saveSpec)
         depCollection[depName] = hosted.toString({ noGitPlus: false, noCommittish: false });
       }
-    }
-
-    // when allowUpdatingPeerDeps is disabled, we could end up with peerDependencies not being reviewed
-    // and still having the `workspace:` prefix so make sure to remove any of these prefixes
-    if (updatedByCommand === 'publish' && this.peerDependencies?.[depName].startsWith('workspace:')) {
-      this.peerDependencies[depName] = this.peerDependencies[depName].replace('workspace:', '');
     }
   }
 

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -299,7 +299,7 @@ export class Package {
     resolved: NpaResolveResult,
     depVersion: string,
     savePrefix: string,
-    allowUpdatingPeerDeps = false,
+    allowPeerDepsUpdate = false,
     workspaceStrictMatch = true,
     updatedByCommand?: CommandType
   ) {
@@ -312,7 +312,7 @@ export class Package {
       // when user allows peer bump and is a regular semver version, we'll push it to the array of dependencies to potentially bump
       // however we won't when the semver has a range with operator, ie this would bump ("^2.0.0") but these would not (">=2.0.0" or "workspace:<2.0.0" or "workspace:*")
       // prettier-ignore
-      if (allowUpdatingPeerDeps && /^(workspace:)?[~|^]?[^\+]([\d\w\.\-\+]+)$/i.test(this.peerDependencies[depName] || '')) {
+      if (allowPeerDepsUpdate && /^(workspace:)?[~|^]?[^\+]([\d\w\.\-\+]+)$/i.test(this.peerDependencies[depName] || '')) {
         updatingDependencies.push(this.peerDependencies);
       }
       // when peer bump is disabled, we could end up with peerDependencies not being reviewed

--- a/packages/core/src/utils/query-graph.ts
+++ b/packages/core/src/utils/query-graph.ts
@@ -47,7 +47,11 @@ export class QueryGraph {
     { graphType = 'allDependencies', localDependencies = 'auto', rejectCycles } = {} as QueryGraphConfig
   ) {
     // Create dependency graph
-    this.graph = new PackageGraph(packages, graphType as 'allDependencies' | 'dependencies', localDependencies);
+    this.graph = new PackageGraph(
+      packages,
+      graphType as 'allDependencies' | 'allPlusPeerDependencies' | 'dependencies',
+      localDependencies
+    );
 
     // Evaluate cycles
     this.cycles = this.graph.collapseCycles(rejectCycles);

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -442,6 +442,8 @@ So for example, if we have `foo`, `bar`, `qar`, `zoo` in the workspace and they 
 }
 ```
 
+> **Note** semver range with an operator (ie `workspace:>=2.0.0`) are also supported but will never be mutated.
+
 #### with `--workspace-strict-match` (default)
 
 When using strict match (default), it will be transformed and publish with the following:

--- a/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-5/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-5/package.json
@@ -4,5 +4,9 @@
   "dependencies": {
     "package-4": "workspace:^1.0.0",
     "package-6": "workspace:~1.0.0"
+  },
+  "peerDependencies": {
+    "package-4": "workspace:>=1.0.0",
+    "package-6": "workspace:~1.0.0"
   }
 }

--- a/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-6/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-6/package.json
@@ -5,5 +5,8 @@
     "package-1": "workspace:>=1.0.0",
     "tiny-registry": "workspace:*",
     "tiny-tarball": "workspace:^2.3.4"
+  },
+  "peerDependencies": {
+    "package-1": ">=1.0.0"
   }
 }

--- a/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-7/package.json
+++ b/packages/publish/src/__tests__/__fixtures__/workspace-protocol-specs/packages/package-7/package.json
@@ -4,5 +4,9 @@
   "private": true,
   "dependencies": {
     "package-1": "^1.0.0"
+  },
+  "peerDependencies": {
+    "package-2": "^1.0.0",
+    "package-3": ">=1.0.0"
   }
 }

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -157,13 +157,13 @@ describe("workspace protocol 'workspace:' specifiers", () => {
   });
 
   describe('workspace-strict-match enabled', () => {
-    it('overwrites workspace protocol with local minor bumped version before npm publish but after git commit & also expect bump peerDependencies when allowPeerDepsUpdate flag is enabled', async () => {
+    it('overwrites workspace protocol with local minor bumped version before npm publish but after git commit & also expect bump peerDependencies when allowPeerDependenciesUpdate flag is enabled', async () => {
       const cwd = await initFixture('workspace-protocol-specs');
 
       await gitTag(cwd, 'v1.0.0');
       await setupChanges(cwd);
       await new PublishCommand(
-        createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match', '--allow-peer-deps-update')
+        createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match', '--allow-peer-dependencies-update')
       );
 
       expect((writePkg as any).updatedVersions()).toEqual({

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -157,13 +157,13 @@ describe("workspace protocol 'workspace:' specifiers", () => {
   });
 
   describe('workspace-strict-match enabled', () => {
-    it('overwrites workspace protocol with local minor bumped version before npm publish but after git commit & also expect bump peerDependencies when allowUpdatingPeerDeps flag is enabled', async () => {
+    it('overwrites workspace protocol with local minor bumped version before npm publish but after git commit & also expect bump peerDependencies when allowPeerDepsUpdate flag is enabled', async () => {
       const cwd = await initFixture('workspace-protocol-specs');
 
       await gitTag(cwd, 'v1.0.0');
       await setupChanges(cwd);
       await new PublishCommand(
-        createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match', '--allow-updating-peer-deps')
+        createArgv(cwd, '--bump', 'minor', '--yes', '--workspace-strict-match', '--allow-peer-deps-update')
       );
 
       expect((writePkg as any).updatedVersions()).toEqual({

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -574,6 +574,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
+          this.options.allowUpdatingPeerDeps,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -599,6 +600,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
+          this.options.allowUpdatingPeerDeps,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -611,7 +613,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
   resolveLocalDependencyWorkspaceProtocols() {
     // resolve workspace protocol: translates to their actual version target/range
     const publishingPackagesWithLocalWorkspaces = this.updates.filter((node: PackageGraphNode) =>
-      Array.from(node.localDependencies.values()).some((resolved: NpaResolveResult) => resolved.explicitWorkspace)
+      Array.from(node.localDependencies.values()).some((resolved: NpaResolveResult) => resolved.workspaceSpec)
     );
 
     return pMap(publishingPackagesWithLocalWorkspaces, (node: PackageGraphNode) => {
@@ -627,6 +629,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
+          this.options.allowUpdatingPeerDeps,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -736,7 +739,13 @@ export class PublishCommand extends Command<PublishCommandOption> {
        * Therefore until we remove graphType altogether in v6, we provide a way for users to opt into the old default behavior
        * by setting the `graphType` option to `dependencies`.
        */
-      graphType: this.options.graphType === 'dependencies' ? 'dependencies' : 'allDependencies',
+      // prettier-ignore
+      graphType:
+        this.options.graphType === 'dependencies'
+          ? 'dependencies'
+          : this.options.allowUpdatingPeerDeps
+            ? 'allPlusPeerDependencies'
+            : 'allDependencies',
     });
   }
 

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -574,7 +574,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
-          this.options.allowPeerDepsUpdate,
+          this.options.allowPeerDependenciesUpdate,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -600,7 +600,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
-          this.options.allowPeerDepsUpdate,
+          this.options.allowPeerDependenciesUpdate,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -629,7 +629,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
-          this.options.allowPeerDepsUpdate,
+          this.options.allowPeerDependenciesUpdate,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -743,7 +743,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
       graphType:
         this.options.graphType === 'dependencies'
           ? 'dependencies'
-          : this.options.allowPeerDepsUpdate
+          : this.options.allowPeerDependenciesUpdate
             ? 'allPlusPeerDependencies'
             : 'allDependencies',
     });

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -574,7 +574,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
-          this.options.allowUpdatingPeerDeps,
+          this.options.allowPeerDepsUpdate,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -600,7 +600,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
-          this.options.allowUpdatingPeerDeps,
+          this.options.allowPeerDepsUpdate,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -629,7 +629,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
           resolved,
           depVersion,
           this.savePrefix,
-          this.options.allowUpdatingPeerDeps,
+          this.options.allowPeerDepsUpdate,
           this.options.workspaceStrictMatch,
           this.commandName
         );
@@ -743,7 +743,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
       graphType:
         this.options.graphType === 'dependencies'
           ? 'dependencies'
-          : this.options.allowUpdatingPeerDeps
+          : this.options.allowPeerDepsUpdate
             ? 'allPlusPeerDependencies'
             : 'allDependencies',
     });

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -71,7 +71,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
   - [Prerelease](#prerelease)
   - [Options](#options)
     - [`--allow-branch <glob>`](#--allow-branch-glob)
-    - [`--allow-peer-deps-update`](#--allow-peer-deps-update) (new)
+    - [`--allow-peer-dependencies-update`](#--allow-peer-dependencies-update) (new)
     - [`--amend`](#--amend)
     - [`--changelog-preset`](#--changelog-preset)
     - [`--conventional-commits`](#--conventional-commits)
@@ -153,10 +153,10 @@ Please use with caution.
 lerna version --allow-branch hotfix/oops-fix-the-thing
 ```
 
-### `--allow-peer-deps-update`
+### `--allow-peer-dependencies-update`
 
 ```sh
-lerna version --allow-peer-deps-update
+lerna version --allow-peer-dependencies-update
 ```
 
 By default peer dependencies versions will not be bumped unless this flag is enabled. When the package to be bumped is found in regular `dependencies` (or `devDependencies`) and also in `peerDependencies`, then it will bump both of them to the same version.

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -152,6 +152,16 @@ Please use with caution.
 lerna version --allow-branch hotfix/oops-fix-the-thing
 ```
 
+### `--allow-updating-peer-deps`
+
+```sh
+lerna version --allow-updating-peer-deps
+```
+
+By default peer dependencies versions will not be bumped unless this flag is enabled. When the package to be bumped is found in regular `dependencies` (or `devDependencies`) and also in `peerDependencies`, then it will bump both of them to the same version.
+
+**Note** we will never bump a peer dependency that is including a semver range (ie `>=2.0.0`) even if this flag is enabled.
+
 ### `--amend`
 
 ```sh

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -71,6 +71,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
   - [Prerelease](#prerelease)
   - [Options](#options)
     - [`--allow-branch <glob>`](#--allow-branch-glob)
+    - [`--allow-updating-peer-deps`](#--allow-updating-peer-deps)
     - [`--amend`](#--amend)
     - [`--changelog-preset`](#--changelog-preset)
     - [`--conventional-commits`](#--conventional-commits)

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -160,6 +160,8 @@ lerna version --allow-updating-peer-deps
 
 By default peer dependencies versions will not be bumped unless this flag is enabled. When the package to be bumped is found in regular `dependencies` (or `devDependencies`) and also in `peerDependencies`, then it will bump both of them to the same version.
 
+You should really know what you're doing before enabling this option, the npm standard is to never mutate (bump) any `peerDependencies` during publish (see Lerna [PR #1187](https://github.com/lerna/lerna/pull/1187) which disabled it in the first place).
+
 **Note** we will never bump a peer dependency that is including a semver range (ie `>=2.0.0`) even if this flag is enabled.
 
 ### `--amend`

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -71,7 +71,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
   - [Prerelease](#prerelease)
   - [Options](#options)
     - [`--allow-branch <glob>`](#--allow-branch-glob)
-    - [`--allow-updating-peer-deps`](#--allow-updating-peer-deps) (new)
+    - [`--allow-peer-deps-update`](#--allow-peer-deps-update) (new)
     - [`--amend`](#--amend)
     - [`--changelog-preset`](#--changelog-preset)
     - [`--conventional-commits`](#--conventional-commits)
@@ -153,10 +153,10 @@ Please use with caution.
 lerna version --allow-branch hotfix/oops-fix-the-thing
 ```
 
-### `--allow-updating-peer-deps`
+### `--allow-peer-deps-update`
 
 ```sh
-lerna version --allow-updating-peer-deps
+lerna version --allow-peer-deps-update
 ```
 
 By default peer dependencies versions will not be bumped unless this flag is enabled. When the package to be bumped is found in regular `dependencies` (or `devDependencies`) and also in `peerDependencies`, then it will bump both of them to the same version.

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -161,14 +161,12 @@ lerna version --allow-updating-peer-deps
 
 By default peer dependencies versions will not be bumped unless this flag is enabled. When the package to be bumped is found in regular `dependencies` (or `devDependencies`) and also in `peerDependencies`, then it will bump both of them to the same version.
 
-You should really know what you're doing before enabling this option, the npm standard is to never mutate (bump) any `peerDependencies` during publish (see Lerna [PR #1187](https://github.com/lerna/lerna/pull/1187) which disabled it in the first place).
-
 > **Note** peer dependency that includes a semver range with an operator (ie `>=2.0.0`) will never be mutated even if this flag is enabled.
 
-> **Note** Please use with caution when enabling this option, it is not recommended for most users since the npm standard is to never mutate (bump) any `peerDependencies` when publishing new version, at least not without a user intervention, as explained by core Lerna maintainer:
+> **Note** Please use with caution when enabling this option, it is not recommended for most users since the npm standard is to never mutate (bump) any `peerDependencies` when publishing new version in an automated fashion, at least not without a user intervention, as explained by core Lerna maintainer:
 
-> Changes to a peer version range are always semver major, and should be as broad as possible.
-> Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior).
+> > _Changes to a peer version range are always semver major, and should be as broad as possible._
+> > _Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior)._
 
 
 ### `--amend`

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -168,6 +168,50 @@ By default peer dependencies versions will not be bumped unless this flag is ena
 > > _Changes to a peer version range are always semver major, and should be as broad as possible._
 > > _Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior)._
 
+#### Examples
+##### with flag enabled
+with the new flag both deps would be updated and bumped, for example if we do a `minor` bump
+```sh
+{
+  "name": "B",
+  "dependencies": {
+    "A": "workspace:^1.2.0"   // will update to "workspace:^1.3.0",
+    "B": "^0.4.0":            // will update to "^0.5.0"
+   },
+  "peerDependencies": {
+    "A": "workspace:^1.2.0"   // will update to "workspace:^1.3.0"
+    "B": ">=0.2.0":           // will not be updateed because range with operator (>=) are skipped
+  }
+}
+```
+
+##### without flag
+without the flag it will only update the first package it finds, that is `dependencies` in this case, so peer deps would never be updateed
+```sh
+{
+  "name": "B",
+  "dependencies": {
+    "A": "workspace:^1.2.0"   // will update to "workspace:^1.3.0"
+    "B": "^0.4.0":            // will update to "^0.5.0"
+   },
+  "peerDependencies": {
+    "A": "workspace:^1.2.0"   // will NEVER be updateed
+    "B": ">=0.2.0":           // will NEVER be updateed
+  }
+}
+```
+
+#### Some Exclusions
+with the flag enabled, it will update regular semver like these
+- `1.2.3`
+- `^1.2.3`
+- `^1.4.0-alpha.0`
+- `workspace:^1.2.3`
+
+but it will never change version with ranges
+- `>=1.0.0`
+- `>=1.0.0 <2.0.0`
+- `^1 | ^2 | ^3`
 
 ### `--amend`
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -163,7 +163,13 @@ By default peer dependencies versions will not be bumped unless this flag is ena
 
 You should really know what you're doing before enabling this option, the npm standard is to never mutate (bump) any `peerDependencies` during publish (see Lerna [PR #1187](https://github.com/lerna/lerna/pull/1187) which disabled it in the first place).
 
-**Note** we will never bump a peer dependency that is including a semver range (ie `>=2.0.0`) even if this flag is enabled.
+> **Note** peer dependency that includes a semver range with an operator (ie `>=2.0.0`) will never be mutated even if this flag is enabled.
+
+> **Note** Please use with caution when enabling this option, it is not recommended for most users since the npm standard is to never mutate (bump) any `peerDependencies` when publishing new version, at least not without a user intervention, as explained by core Lerna maintainer:
+
+> Changes to a peer version range are always semver major, and should be as broad as possible.
+> Until we can get fancier, we should never automatically modify them to match the new version being published (which is the current incorrect behavior).
+
 
 ### `--amend`
 
@@ -715,3 +721,5 @@ Will apply the following updates to your `package.json` (assuming a `minor` vers
   }
 }
 ```
+
+> **Note** semver range with an operator (ie `workspace:>=2.0.0`) are also supported but will never be mutated.

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -71,7 +71,7 @@ Running `lerna version --conventional-commits` without the above flags will rele
   - [Prerelease](#prerelease)
   - [Options](#options)
     - [`--allow-branch <glob>`](#--allow-branch-glob)
-    - [`--allow-updating-peer-deps`](#--allow-updating-peer-deps)
+    - [`--allow-updating-peer-deps`](#--allow-updating-peer-deps) (new)
     - [`--amend`](#--amend)
     - [`--changelog-preset`](#--changelog-preset)
     - [`--conventional-commits`](#--conventional-commits)

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -186,7 +186,7 @@ with the new flag both deps would be updated and bumped, for example if we do a 
 ```
 
 ##### without flag
-without the flag it will only update the first package it finds, that is `dependencies` in this case, so peer deps would never be updateed
+without the flag it will only update the first package it finds, that is `dependencies` in this case, so peer deps would never be updated
 ```sh
 {
   "name": "B",
@@ -208,7 +208,7 @@ with the flag enabled, it will update regular semver like these
 - `^1.4.0-alpha.0`
 - `workspace:^1.2.3`
 
-but it will never change version with ranges
+but it will never update or change versions with ranges
 - `>=1.0.0`
 - `>=1.0.0 <2.0.0`
 - `^1 | ^2 | ^3`

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -627,7 +627,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
               resolved,
               depVersion,
               this.savePrefix,
-              this.options.allowPeerDepsUpdate,
+              this.options.allowPeerDependenciesUpdate,
               this.options.workspaceStrictMatch,
               this.commandName
             );
@@ -686,7 +686,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       runTopologically(this.packagesToVersion, mapUpdate, {
         concurrency: this.concurrency,
         rejectCycles: this.options.rejectCycles,
-        graphType: this.options.allowPeerDepsUpdate ? 'allPlusPeerDependencies' : 'allDependencies',
+        graphType: this.options.allowPeerDependenciesUpdate ? 'allPlusPeerDependencies' : 'allDependencies',
       })
     );
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -627,7 +627,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
               resolved,
               depVersion,
               this.savePrefix,
-              this.options.allowUpdatingPeerDeps,
+              this.options.allowPeerDepsUpdate,
               this.options.workspaceStrictMatch,
               this.commandName
             );
@@ -686,7 +686,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       runTopologically(this.packagesToVersion, mapUpdate, {
         concurrency: this.concurrency,
         rejectCycles: this.options.rejectCycles,
-        graphType: this.options.allowUpdatingPeerDeps ? 'allPlusPeerDependencies' : 'allDependencies',
+        graphType: this.options.allowPeerDepsUpdate ? 'allPlusPeerDependencies' : 'allDependencies',
       })
     );
 

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -627,6 +627,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
               resolved,
               depVersion,
               this.savePrefix,
+              this.options.allowUpdatingPeerDeps,
               this.options.workspaceStrictMatch,
               this.commandName
             );
@@ -685,6 +686,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       runTopologically(this.packagesToVersion, mapUpdate, {
         concurrency: this.concurrency,
         rejectCycles: this.options.rejectCycles,
+        graphType: this.options.allowUpdatingPeerDeps ? 'allPlusPeerDependencies' : 'allDependencies',
       })
     );
 


### PR DESCRIPTION
- supersede #362

## Description

Add a new option `--allow-peer-dependencies-update`  option on the version command which will help to update peer dependencies before publishing them. This option is opt-in and disabled by default because of what the original Lerna maintainer wrote in Lerna issue [#1018](https://github.com/lerna/lerna/issues/1018)
> `peerDependencies` shouldn't be updated by `lerna publish`

This option is not recommended for most users, for them `peerDependencies` will remain untouched unless the user really wants it enabled and has more knowledge in this regard. However even when this flag is enabled, it will never mutate/update peer dependencies with semver range operator (ie `>=2.0.0`).

Regex used

For this implementation, we'll use this regex to identify if the peer dependency is allowed to be updated or not ([regex101](https://regex101.com/r/u87ZrZ/1))
```sh
/^(workspace:)?[~^]?[\d\.]+([\-]+[\w\.\-\+]+)*$/i
```

**Note**

While at it, the code in `package` and `package-graph` related to `workspace:` protocol were refactored a bit to follow similar implementation as to what Lerna as recently done, even though the implementation is different at least the naming is now similar. 

## Motivation and Context

Provide a way to bump peer dependencies but only via a flag, this behavior will be disabled by default, this will close #333 

- closes #333 

The main code change for this new option is in the `updateLocalDependency()` method found in `package.ts`, a new argument `allowPeerDepsUpdate` was added and when enabled it will add `peerDependencies` into the loop of dependencies to be inspected for updates. The loop is also new in that same method, since prior to this we would only update/bump the 1st dependency found, however now if the flag is enabled, we also include (loop) the peer dependency as well so instead of updating 1 dependency (by name), we might update up to 2 of with the same name

in summary, calling `lerna version --allow-peer-dependencies-update` (or the equivalent `lerna.json` config) on this package
```json
{
  "name": "B",
  "dependencies": {
    "A": "workspace:^1.2.0"
   },
  "peerDependencies": {
    "A": "workspace:^1.2.0"
  }
}
```
will bump both the `dependencies` and `peerDependencies` to `^1.3.0` on a `minor` bump (note again that a semver range `>=` will never be bumped)

## How Has This Been Tested?

added a lot more unit tests to cover `package.ts`, `package-graph`, `publish` and `version`

## What will be valid and update?
It will update (bump) regular semver like these
- `1.2.3`
- `^1.2.3`
- `^1.4.0-alpha.0`
- `workspace:^1.2.3`

but it won't mutate/update things like
- `>=1.0.0`
- `>=1.0.0 <2.0.0`
- `^1 | ^2 | ^3`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
