### PR TITLE
fix(npm-publish): Allows disabling of strict SSL checks

### DIFF
--- a/packages/publish/src/__tests__/npm-publish.spec.ts
+++ b/packages/publish/src/__tests__/npm-publish.spec.ts
@@ -19,6 +19,7 @@ import path from 'path';
 
 // file under test
 import { npmPublish } from '../lib/npm-publish';
+import { LibNpmPublishOptions } from '../models';
 
 describe('npm-publish', () => {
   const mockTarData = Buffer.from('MOCK');
@@ -181,6 +182,20 @@ describe('npm-publish', () => {
 
     expect(publish).not.toHaveBeenCalled();
     expect(runLifecycle).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([['true'], [true], ['false'], [false]])('aliases strict-ssl to strictSSL', async (strictSSLValue) => {
+    const opts = { 'strict-ssl': strictSSLValue } as Partial<LibNpmPublishOptions>;
+
+    await npmPublish(pkg, tarFilePath, opts);
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        strictSSL: strictSSLValue,
+      })
+    );
   });
 
   it('calls publish lifecycles', async () => {

--- a/packages/publish/src/lib/npm-publish.ts
+++ b/packages/publish/src/lib/npm-publish.ts
@@ -21,6 +21,8 @@ function flattenOptions(obj: Omit<LibNpmPublishOptions, 'defaultTag'>): LibNpmPu
     // eslint-disable-next-line dot-notation -- (npm v7 compat)
     defaultTag: obj['tag'] || 'latest',
     dryRun: obj['dry-run'] || obj['git-dry-run'],
+    // libnpmpublish / npm-registry-fetch check strictSSL rather than strict-ssl
+    strictSSL: obj['strict-ssl'],
     ...obj,
   };
 }

--- a/packages/publish/src/models/index.ts
+++ b/packages/publish/src/models/index.ts
@@ -6,11 +6,23 @@ export interface DistTagOptions extends fetch.FetchOptions {
   tag: string;
 }
 
+export type KebabCase<S> = S extends `${infer C}${infer T}`
+  ? KebabCase<T> extends infer U
+    ? U extends string
+      ? T extends Uncapitalize<T>
+        ? `${Uncapitalize<C>}${U}`
+        : `${Uncapitalize<C>}-${U}`
+      : never
+    : never
+  : S;
+
 /** LibNpmPublishOptions -  https://github.com/npm/libnpmpublish#opts */
-export interface LibNpmPublishOptions extends fetch.FetchOptions {
+export interface LibNpmPublishOptions extends KebabCase<fetch.FetchOptions> {
   access?: 'public' | 'restricted';
   defaultTag: string;
   dryRun?: boolean;
+  // libnpmpublish / npm-registry-fetch check strictSSL rather than strict-ssl
+  strictSSL?: boolean | 'true' | 'false';
   /* Passed to libnpmpublish as `opts.defaultTag` to preserve npm v6 back-compat */
   tag?: string;
 }


### PR DESCRIPTION
## Description

As per Lerna [PR 2952](https://github.com/lerna/lerna/pull/2952)

> Alias `strict-ssl` npm configuration setting to `strictSSL` publish `opts`.

## Motivation and Context

As per Lerna PR

> Since lerna 4, `npm_config_strict_ssl=false` is not respected by the publish process. My team publishes to an internal private registry for CI builds to avoid polluting our `npm view [package] versions` unnecessarily, but we don't (currently?) have SSL working on that garbage heap.
> 
> While `strict-ssl` is resolved out of environment and npm settings in `@lerna/npm-conf`, there's nothing downstream looking for that. [`libnpmpublish`](https://www.npmjs.com/package/libnpmpublish) passes all extra arguments directly down to [`npm-registry-fetch`](https://www.npmjs.com/package/npm-registry-fetch), but `npm-registry-fetch` is reading for `strictSSL` rather than `strict-ssl`.

## How Has This Been Tested?

As per Lerna PR

> Prior to implementing the changes, adding `npm_config_strict_ssl=false` either A) prepended on the command line (`npm_config_strict_ssl=false npx lerna publish ....`) as environment; or B) applied in a root-level `.npmrc` file would have no impact. This can be validated by running the lerna command in VS Code's `JavaScript Debug Terminal` and placing a breakpoint on this line:

> When in the un-aliased state, the `opts` / `innerOpts` will still show a `strict-ssl` value, but if you `Go to Definition` or `step into` `libnpmpublish`'s `publish` method and follow down through to `npm-registry-fetch`'s default export method, you'll find that it's passing the `opts.strictSSL` property through to [`make-fetch-happen`'s `fetch` method](https://www.youtube.com/watch?v=Pubd-spHN-0):
> 
> 
> After implementing the alias change to `npm-publish.js` and re-running, the breakpoint will now show `strict-ssl` **AND** `strictSSL` in the `opts`. You can follow them down the function calls and see the value get passed correctly all the way to `fetch`.
> 
> I've included a unit test to validate this functionality performs the aliasing as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
