### PR TITLE
fix: bump min Node version to >=14.17.0 to align with external deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0",
     "pnpm": "7"
   },

--- a/packages/changed/package.json
+++ b/packages/changed/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/info/package.json
+++ b/packages/info/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/listable/package.json
+++ b/packages/listable/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/optional-cmd-common/package.json
+++ b/packages/optional-cmd-common/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/ghiscoding/lerna-lite/issues"
   },
   "engines": {
-    "node": ">=14.15.0",
+    "node": ">=14.17.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

bump Node min version from 14.15.0 to at least >=14.17.0 to align with recent dependencies upgrades like `pacote`, `npm-registry-fetch`, `ssri` and `write-file-atomic`

## Motivation and Context

to stay compatible with recent external dependencies upgrades

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
