### PR TITLE
fix(run): allow for loading of env files to be skipped

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -480,6 +480,9 @@
             "skipNxCache": {
               "$ref": "#/$defs/commandOptions/run/skipNxCache"
             },
+            "loadEnvFiles": {
+              "$ref": "#/$defs/commandOptions/run/loadEnvFiles"
+            },
 
             "npmClient": {
               "$ref": "#/$defs/globals/npmClient"
@@ -1264,6 +1267,10 @@
         "dryRun": {
           "type": "boolean",
           "description": "During `lerna run`, when true, displays the process command that would be performed without executing it."
+        },
+        "loadEnvFiles": {
+          "type": "boolean",
+          "description": "During `lerna run`, when false, skip loading of environment variables from .env files."
         },
         "skipNxCache": {
           "type": "boolean",

--- a/packages/cli/src/cli-commands/cli-run-commands.ts
+++ b/packages/cli/src/cli-commands/cli-run-commands.ts
@@ -78,6 +78,11 @@ export default {
           hidden: true,
           type: 'boolean',
         },
+        'load-env-files': {
+          group: 'Command Options:',
+          describe: 'When useNx is enabled, do we want to automatically load .env files',
+          type: 'boolean',
+        },
         'use-nx': {
           group: 'Command Options:',
           describe:

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -367,8 +367,8 @@ export interface RunCommandOption {
   /** proxy for `--no-bail`. */
   bail?: boolean;
 
-  // This option controls prefix for stream output so that it can be disabled to be friendly
-  // to tools like Visual Studio Code to highlight the raw results
+  /** When useNx is enabled, do we want to automatically load .env files */
+  loadEnvFiles?: boolean;
 
   /** Do not prefix streaming output. */
   noPrefix?: boolean;

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -62,6 +62,7 @@ $ lerna run --scope my-component test
     - [`--no-prefix`](#--no-prefix)
     - [`--profile`](#--profile)
     - [`--profile-location <location>`](#--profile-location-location)
+    - [`--load-env-files`](#load-env-files)
     - [`--use-nx`](#use-nx)
 
 ### `--npm-client <client>`
@@ -154,6 +155,13 @@ You can provide a custom location for the performance profile output. The path p
 $ lerna run build --profile --profile-location=logs/profile/
 ```
 
+
+### `--load-env-files`
+
+When the task runner is powered by Nx (via [`--use-nx`](#use-nx)) it will automatically load `.env` files for you. You can set `--load-env-files` to false if you want to disable this behavior for any reason.
+
+For more details about what `.env` files will be loaded by default please see: https://nx.dev/recipes/environment-variables/define-environment-variables
+
 ### `--use-nx`
 
 Enables integration with [Nx](https://nx.dev). Enabling this option will tell Lerna to delegate
@@ -202,7 +210,7 @@ Lerna by itself does not have knowledge of which tasks depend on others, so it d
 
 This is no longer a problem when Lerna uses Nx to run tasks. Nx, utilizing its [task graph](https://nx.dev/concepts/mental-model#the-task-graph), will automatically run dependent tasks first when necessary, so `--include-dependencies` is obsolete. However, it can still be used to include project dependencies that Lerna detects but Nx does not deem necessary and would otherwise exclude.
 
-### `--ignore`
+#### `--ignore`
 
 When used with Nx, `--ignore` will never cause `lerna run` to exclude any tasks that are deemed to be required by the Nx [task graph](https://nx.dev/concepts/mental-model#the-task-graph).
 

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -342,6 +342,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
 
     const extraOptions = {
       excludeTaskDependencies: mimicLernaDefaultBehavior,
+      loadDotEnvFiles: this.options.loadEnvFiles ?? true,
     };
 
     return { targetDependencies, options, extraOptions };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna [3375](https://github.com/lerna/lerna/pull/3375)

> Makes one subcomponent of the change of default task runner more explicit, namely the automatic loading of .env files.
> Also adds a flag to allow users to disable this behavior if they wish (added as a fix because it was an oversight for the v6 release)

## Motivation and Context

keep in sync with Lerna

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
