### PR TITLE
fix(deps): npm-package-arg now normalize x, x@, x@*

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "make-dir": "^3.1.0",
     "minimatch": "^5.1.0",
     "node-fetch": "^2.6.7",
-    "npm-package-arg": "^9.1.2",
+    "npm-package-arg": "^10.0.0",
     "npmlog": "^7.0.1",
     "p-map": "^4.0.0",
     "p-queue": "^6.6.2",

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -271,7 +271,7 @@ export class Package {
         /^(workspace:)+(.*)$/.test(workspaceSpec)
       ) {
         if (workspaceSpec) {
-          if (resolved.fetchSpec === 'latest') {
+          if (resolved.fetchSpec === 'latest' || resolved.fetchSpec === '') {
             npmlog.error(
               `publish`,
               [

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -40,7 +40,7 @@
     "fs-extra": "^10.1.0",
     "has-unicode": "^2.0.1",
     "libnpmaccess": "^6.0.4",
-    "libnpmpublish": "^6.0.5",
+    "libnpmpublish": "^7.0.0",
     "npm-package-arg": "^10.0.0",
     "npm-packlist": "^7.0.1",
     "npm-registry-fetch": "^14.0.2",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -41,7 +41,7 @@
     "has-unicode": "^2.0.1",
     "libnpmaccess": "^6.0.4",
     "libnpmpublish": "^6.0.5",
-    "npm-package-arg": "^9.1.2",
+    "npm-package-arg": "^10.0.0",
     "npm-packlist": "^7.0.1",
     "npm-registry-fetch": "^14.0.2",
     "npmlog": "^7.0.1",

--- a/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
+++ b/packages/publish/src/__tests__/publish-workspace-protocol-specifiers.spec.ts
@@ -279,12 +279,12 @@ describe("workspace protocol 'workspace:' specifiers", () => {
         'publish',
         [
           `Your package named "package-6" has external dependencies not handled by Lerna-Lite and without workspace version suffix, `,
-          `we recommend using defined versions with workspace protocol. Your dependency is currently being published with "tiny-registry": "latest".`,
+          `we recommend using defined versions with workspace protocol. Your dependency is currently being published with "tiny-registry": "".`,
         ].join('')
       );
       expect((writePkg as any).updatedManifest('package-6').dependencies).toMatchObject({
         'package-1': '>=1.0.0', // workspace:>=1.0.0 will not be bumped without a flag
-        'tiny-registry': 'latest', // workspace:*
+        'tiny-registry': '', // workspace:*
         'tiny-tarball': '^2.3.4', // workspace:^2.3.4
       });
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
       make-dir: ^3.1.0
       minimatch: ^5.1.0
       node-fetch: ^2.6.7
-      npm-package-arg: ^9.1.2
+      npm-package-arg: ^10.0.0
       npm-registry-fetch: ^14.0.2
       npmlog: ^7.0.1
       p-map: ^4.0.0
@@ -247,7 +247,7 @@ importers:
       make-dir: 3.1.0
       minimatch: 5.1.0
       node-fetch: 2.6.7
-      npm-package-arg: 9.1.2
+      npm-package-arg: 10.0.0
       npmlog: 7.0.1
       p-map: 4.0.0
       p-queue: 6.6.2
@@ -432,9 +432,9 @@ importers:
       fs-extra: ^10.1.0
       has-unicode: ^2.0.1
       libnpmaccess: ^6.0.4
-      libnpmpublish: ^6.0.5
+      libnpmpublish: ^7.0.0
       load-json-file: ^6.2.0
-      npm-package-arg: ^9.1.2
+      npm-package-arg: ^10.0.0
       npm-packlist: ^7.0.1
       npm-registry-fetch: ^14.0.2
       npmlog: ^7.0.1
@@ -460,8 +460,8 @@ importers:
       fs-extra: 10.1.0
       has-unicode: 2.0.1
       libnpmaccess: 6.0.4
-      libnpmpublish: 6.0.5
-      npm-package-arg: 9.1.2
+      libnpmpublish: 7.0.0
+      npm-package-arg: 10.0.0
       npm-packlist: 7.0.1
       npm-registry-fetch: 14.0.2
       npmlog: 7.0.1
@@ -2649,7 +2649,7 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   /concat-stream/2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -5073,15 +5073,15 @@ packages:
       - supports-color
     dev: false
 
-  /libnpmpublish/6.0.5:
-    resolution: {integrity: sha512-LUR08JKSviZiqrYTDfywvtnsnxr+tOvBU0BF8H+9frt7HMvc6Qn6F8Ubm72g5hDTHbq8qupKfDvDAln2TVPvFg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  /libnpmpublish/7.0.0:
+    resolution: {integrity: sha512-yW9LyPq5YuWs2i0y9rZVNP9OeCBiJM/3iInPUtDPORCyF08vqN4A1crOTihd63uqfDEwE0xKSN3omH6qOd0mgw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      normalize-package-data: 4.0.0
-      npm-package-arg: 9.1.2
-      npm-registry-fetch: 13.3.1
+      normalize-package-data: 5.0.0
+      npm-package-arg: 10.0.0
+      npm-registry-fetch: 14.0.2
       semver: 7.3.8
-      ssri: 9.0.1
+      ssri: 10.0.0
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -5527,16 +5527,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.9.0
-      semver: 7.3.8
-      validate-npm-package-license: 3.0.4
-    dev: false
-
-  /normalize-package-data/4.0.0:
-    resolution: {integrity: sha512-m+GL22VXJKkKbw62ZaBBjv8u6IE3UI4Mh5QakIqs3fWiKe0Xyi6L97hakwZK41/LD4R/2ly71Bayx0NLMwLA/g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
-    dependencies:
-      hosted-git-info: 5.0.0
       is-core-module: 2.9.0
       semver: 7.3.8
       validate-npm-package-license: 3.0.4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per `npm-package-arg` (npa) new version 10.x PR which is a Breaking Change

> Right now, `name@` and `name` are parsed with `{type:'tag', fetchSpec: 'latest'}`, but `name@*` is parsed as `{type: 'range'}`. But since `''` is a valid semver range, it should be parsed the same as `*`.
> 
> This also saves npm-package-arg from guessing the default tag, which currently poses some semantic hazards. npm (via npm-pick-manifest) will prefer its default tag if given a range that includes it. But `name@latest` should always and only resolve to that specific version in the dist-tags. So npm-pick-manifest and pacote have to detect this and do some extra work to figure out if `latest` was actually specified or just guessed as a default.

> 1. `npa('name@')`
> 2. `npa('name')`
> 3. `npa('name@*')`

> All 3 should parse the same, like (3) above. Effectively, a `''` spec should be changed to `'*'` and interpreted accordingly..

The new npa v10 version now normalize all 3 above to the same result `{type: 'range', fetchSpec: ''}`

## Motivation and Context

When providing "pkg-1": "*", it will no longer return `fetchSpec: 'latest'` with v10.x, instead it will now return an empty string as in `fetchSpec: ''` 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
