### PR TITLE
fix(deps): libnpmaccess was rewritten, lsPackages is now getPackages

### DIFF
--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -39,7 +39,7 @@
     "columnify": "^1.6.0",
     "fs-extra": "^10.1.0",
     "has-unicode": "^2.0.1",
-    "libnpmaccess": "^6.0.4",
+    "libnpmaccess": "^7.0.0",
     "libnpmpublish": "^7.0.0",
     "npm-package-arg": "^10.0.0",
     "npm-packlist": "^7.0.1",

--- a/packages/publish/src/__tests__/verify-npm-package-access.spec.ts
+++ b/packages/publish/src/__tests__/verify-npm-package-access.spec.ts
@@ -7,7 +7,7 @@ import { verifyNpmPackageAccess } from '../lib/verify-npm-package-access';
 import { initFixtureFactory } from '@lerna-test/helpers';
 const initFixture = initFixtureFactory(__dirname);
 
-(access.lsPackages as unknown as jest.Mock).mockImplementation(() =>
+(access.getPackages as unknown as jest.Mock).mockImplementation(() =>
   Promise.resolve({
     'package-1': 'read-write',
     'package-2': 'read-write',
@@ -37,7 +37,7 @@ describe('verifyNpmPackageAccess', () => {
 
     await verifyNpmPackageAccess(packages, 'lerna-test', opts as FetchConfig);
 
-    expect(access.lsPackages).toHaveBeenLastCalledWith(
+    expect(access.getPackages).toHaveBeenLastCalledWith(
       'lerna-test',
       expect.objectContaining({
         registry: 'https://registry.npmjs.org/',
@@ -50,7 +50,7 @@ describe('verifyNpmPackageAccess', () => {
     const packages = await Project.getPackages(cwd);
     const opts = { registry: 'https://registry.npmjs.org/' };
 
-    (access.lsPackages as unknown as jest.Mock).mockImplementationOnce(() =>
+    (access.getPackages as unknown as jest.Mock).mockImplementationOnce(() =>
       Promise.resolve({
         'package-1': 'read-write',
         // unpublished packages don't show up in ls-packages
@@ -60,15 +60,15 @@ describe('verifyNpmPackageAccess', () => {
 
     await verifyNpmPackageAccess(packages, 'lerna-test', opts as FetchConfig);
 
-    expect(access.lsPackages).toHaveBeenCalled();
+    expect(access.getPackages).toHaveBeenCalled();
   });
 
   test('allows null result to pass with warning', async () => {
     const packages = await Project.getPackages(cwd);
     const opts = { registry: 'https://registry.npmjs.org/' };
 
-    (access.lsPackages as unknown as jest.Mock).mockImplementationOnce(() =>
-      // access.lsPackages() returns null when _no_ results returned
+    (access.getPackages as unknown as jest.Mock).mockImplementationOnce(() =>
+      // access.getPackages() returns null when _no_ results returned
       Promise.resolve(null)
     );
 
@@ -84,7 +84,7 @@ describe('verifyNpmPackageAccess', () => {
     const packages = await Project.getPackages(cwd);
     const opts = { registry: 'https://registry.npmjs.org/' };
 
-    (access.lsPackages as unknown as jest.Mock).mockImplementationOnce(() =>
+    (access.getPackages as unknown as jest.Mock).mockImplementationOnce(() =>
       Promise.resolve({
         'package-1': 'read-write',
         'package-2': 'read-only',
@@ -101,7 +101,7 @@ describe('verifyNpmPackageAccess', () => {
     const registry = 'http://outdated-npm-enterprise.mycompany.com:12345/';
     const opts = { registry };
 
-    (access.lsPackages as unknown as jest.Mock).mockImplementationOnce(() => {
+    (access.getPackages as unknown as jest.Mock).mockImplementationOnce(() => {
       const err = new Error('npm-enterprise-what') as Error & { code: string };
       err.code = 'E500';
       return Promise.reject(err);
@@ -121,7 +121,7 @@ describe('verifyNpmPackageAccess', () => {
     const registry = 'https://artifactory-partial-implementation.corpnet.mycompany.com/';
     const opts = { registry };
 
-    (access.lsPackages as unknown as jest.Mock).mockImplementationOnce(() => {
+    (access.getPackages as unknown as jest.Mock).mockImplementationOnce(() => {
       const err = new Error('artifactory-why') as Error & { code: string };
       err.code = 'E404';
       return Promise.reject(err);
@@ -140,7 +140,7 @@ describe('verifyNpmPackageAccess', () => {
     const packages = await Project.getPackages(cwd);
     const opts = {};
 
-    (access.lsPackages as unknown as jest.Mock).mockImplementationOnce(() => {
+    (access.getPackages as unknown as jest.Mock).mockImplementationOnce(() => {
       const err = new Error('gonna-need-a-bigger-boat');
 
       return Promise.reject(err);

--- a/packages/publish/src/lib/verify-npm-package-access.ts
+++ b/packages/publish/src/lib/verify-npm-package-access.ts
@@ -18,10 +18,10 @@ export function verifyNpmPackageAccess(packages: Package[], username: string, op
 
   opts.log.silly('verifyNpmPackageAccess', '');
 
-  return pulseTillDone(access.lsPackages(username, opts)).then(success, failure);
+  return pulseTillDone(access.getPackages(username, opts)).then(success, failure);
 
   function success(result: any) {
-    // when _no_ results received, access.lsPackages returns null
+    // when _no_ results received, access.getPackages returns null
     // we can only assume that the packages in question have never been published
     if (result === null) {
       opts.log.warn(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,7 +431,7 @@ importers:
       columnify: ^1.6.0
       fs-extra: ^10.1.0
       has-unicode: ^2.0.1
-      libnpmaccess: ^6.0.4
+      libnpmaccess: ^7.0.0
       libnpmpublish: ^7.0.0
       load-json-file: ^6.2.0
       npm-package-arg: ^10.0.0
@@ -459,7 +459,7 @@ importers:
       columnify: 1.6.0
       fs-extra: 10.1.0
       has-unicode: 2.0.1
-      libnpmaccess: 6.0.4
+      libnpmaccess: 7.0.0
       libnpmpublish: 7.0.0
       npm-package-arg: 10.0.0
       npm-packlist: 7.0.1
@@ -5060,14 +5060,12 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /libnpmaccess/6.0.4:
-    resolution: {integrity: sha512-qZ3wcfIyUoW0+qSFkMBovcTrSGJ3ZeyvpR7d5N9pEYv/kXs8sHP2wiqEIXBKLFrZlmM0kR0RJD7mtfLngtlLag==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  /libnpmaccess/7.0.0:
+    resolution: {integrity: sha512-WwDa6CExp74s0FKI1eP2pbJ4hMiq5x6kl9XqE0F7RDpmk8sgqvNcCAr/JmMdfpUTqUq6KNddT3bnYBCT/pxniQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      aproba: 2.0.0
-      minipass: 3.1.6
-      npm-package-arg: 9.1.2
-      npm-registry-fetch: 13.3.1
+      npm-package-arg: 10.0.0
+      npm-registry-fetch: 14.0.2
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -5615,22 +5613,6 @@ packages:
       npm-normalize-package-bin: 3.0.0
       npm-package-arg: 10.0.0
       semver: 7.3.8
-    dev: false
-
-  /npm-registry-fetch/13.3.1:
-    resolution: {integrity: sha512-eukJPi++DKRTjSBRcDZSDDsGqRK3ehbxfFUcgaRd0Yp6kRwOwh2WVn0r+8rMB4nnuzvAk6rQVzl6K5CkYOmnvw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      make-fetch-happen: 10.1.7
-      minipass: 3.1.6
-      minipass-fetch: 2.1.0
-      minipass-json-stream: 1.0.1
-      minizlib: 2.1.2
-      npm-package-arg: 9.1.2
-      proc-log: 2.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
     dev: false
 
   /npm-registry-fetch/14.0.2:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The external lib `libnpmaccess` was rewritten to be more aligned with npm as per this [commit](https://github.com/npm/cli/commit/854521baa49ef88ff9586ec2cc5f1fbaee7fa364) (describe below) with their new release v7.x and we use 1 method from that lib which require an update on our side

> feat(rewrite): Rewrite libnpmaccess
> BREAKING CHANGE: the api for libnpmaccess is different now

> It is aligned more with how npm uses it, consolidating the mfa functions into a
single command, and renames the functions to be easier to eventually
consolidate into a registry client library.

## Motivation and Context

To keep Lerna-Lite up to date with dependencies, we have to do some changes since the external lib `libnpmaccess` was rewritten and the since method `lsPackages()` that we use was to renamed to `getPackages()`. It should be enough for our simple usage to just go with that simple change. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
