### PR TITLE
feat: make npm-publish to override publishConfig

### DIFF
--- a/packages/publish/src/__tests__/npm-publish.spec.ts
+++ b/packages/publish/src/__tests__/npm-publish.spec.ts
@@ -175,6 +175,35 @@ describe('npm-publish', () => {
     );
   });
 
+  it('overrides pkg.publishConfig fields into manifest', async () => {
+    (readJSON as jest.Mock).mockImplementationOnce((file, cb) =>
+      cb(null, {
+        main: './src/index.ts',
+        types: './src/index.ts',
+        publishConfig: {
+          main: './dist/index.js',
+          types: './dist/index.d.ts',
+        },
+      })
+    );
+
+    await npmPublish(pkg, tarFilePath);
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publishConfig: {
+          main: './dist/index.js',
+          types: './dist/index.d.ts',
+        },
+      }),
+      mockTarData,
+      expect.objectContaining({
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+      })
+    );
+  });
+
   it('respects opts.dryRun', async () => {
     const opts = { dryRun: true };
 

--- a/packages/publish/src/lib/pack-directory.ts
+++ b/packages/publish/src/lib/pack-directory.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import packlist from 'npm-packlist';
 import log from 'npmlog';
 import tar from 'tar';
+import fs from 'fs-extra';
 
 import { LifecycleConfig, Package, PackConfig, runLifecycle, tempWrite } from '@lerna-lite/core';
 import { getPacked } from './get-packed';
@@ -41,6 +42,9 @@ export async function packDirectory(_pkg: Package, dir: string, options: PackCon
   await runLifecycle(pkg, 'prepack', opts);
   await pkg.refresh();
 
+  await overwritePublishConfig(pkg.manifestLocation);
+  await pkg.refresh();
+
   const arborist = new Arborist({ path: pkg.contents });
   const tree = await arborist.loadActual();
   const files: string[] = await packlist(tree);
@@ -67,6 +71,47 @@ export async function packDirectory(_pkg: Package, dir: string, options: PackCon
       .then(() => runLifecycle(pkg, 'postpack', opts))
       .then(() => packed)
   );
+}
+
+export const PUBLISH_CONFIG_FIELDS = [
+  'bin',
+  'main',
+  'exports',
+  'types',
+  'typings',
+  'module',
+  'browser',
+  'esnext',
+  'es2015',
+  'unpkg',
+  'umd:main',
+  'cpu',
+  'os',
+];
+
+async function overwritePublishConfig(manifestLocation: string) {
+  const manifest = await fs.readJSON(manifestLocation);
+
+  if (manifest.publishConfig === undefined) {
+    return;
+  }
+
+  const publishConfig = { ...manifest.publishConfig };
+
+  PUBLISH_CONFIG_FIELDS.forEach((key) => {
+    if (key in publishConfig) {
+      manifest[key] = publishConfig[key];
+      delete publishConfig[key];
+    }
+  });
+
+  if (Object.keys(publishConfig).length === 0) {
+    delete manifest.publishConfig;
+  } else {
+    manifest.publishConfig = publishConfig;
+  }
+
+  return fs.writeJSON(manifestLocation, manifest);
 }
 
 function getTarballName(pkg: Package) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Make npm-publish function to ovveride manifest by publishConfig.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/ghiscoding/lerna-lite/issues/404

As described in an issue above, yarn and pnpm has it's own logic to overwrite publishConfig to manifest.
So I added that logic into npm-publish function.
Added ones doesn't effect existing publishConfig related logics.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added an test code.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
