### PR TITLE
feat(version): use npmClientArgs in npm install after lerna version

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -710,6 +710,9 @@
     "npmClient": {
       "$ref": "#/$defs/globals/npmClient"
     },
+    "npmClientArgs": {
+      "$ref": "#/$defs/globals/npmClientArgs"
+    },
     "loglevel": {
       "$ref": "#/$defs/globals/loglevel"
     },
@@ -1012,6 +1015,13 @@
         "description": "The npm client to use when running commands (either npm, pnpm or yarn). Defaults to npm if unspecified.",
         "default": "npm",
         "enum": ["npm", "pnpm", "yarn"]
+      },
+      "npmClientArgs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Arguments to pass to the npm client when running commands."
       },
       "loglevel": {
         "type": "string",

--- a/packages/cli/src/cli-commands/cli-version-commands.ts
+++ b/packages/cli/src/cli-commands/cli-version-commands.ts
@@ -244,6 +244,10 @@ export default {
         hidden: true,
         type: 'boolean',
       },
+      'npm-client-args': {
+        describe: "Additional arguments to pass to the npm client when performing 'npm install'.",
+        type: 'array',
+      },
       'no-sync-workspace-lock': {
         describe:
           'Do not run `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`.',

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -329,6 +329,9 @@ export interface VersionCommandOption {
   /** Defaults to true when found, update the project root lock file, the lib will internally read/write back to the lock file. */
   manuallyUpdateRootLockfile?: boolean;
 
+  /** Additional arguments to pass to the npm client when performing 'npm install'. */
+  npmClientArgs?: string[];
+
   /** Runs `npm install --package-lock-only` or equivalent depending on the package manager defined in `npmClient`. */
   syncWorkspaceLock?: boolean;
 

--- a/packages/version/src/lib/update-lockfile-version.ts
+++ b/packages/version/src/lib/update-lockfile-version.ts
@@ -126,7 +126,8 @@ export function updateNpmLockFileVersion2(obj: any, pkgName: string, newVersion:
  */
 export async function runInstallLockFileOnly(
   npmClient: 'npm' | 'pnpm' | 'yarn',
-  cwd: string
+  cwd: string,
+  npmClientArgs: string[]
 ): Promise<string | undefined> {
   let inputLockfileName = '';
   let outputLockfileName: string | undefined;
@@ -136,7 +137,7 @@ export async function runInstallLockFileOnly(
       inputLockfileName = 'pnpm-lock.yaml';
       if (await validateFileExists(path.join(cwd, inputLockfileName))) {
         log.verbose('lock', `updating lock file via "pnpm install --lockfile-only --ignore-scripts"`);
-        await exec('pnpm', ['install', '--lockfile-only', '--ignore-scripts'], { cwd });
+        await exec('pnpm', ['install', '--lockfile-only', '--ignore-scripts', ...npmClientArgs], { cwd });
         outputLockfileName = inputLockfileName;
       }
       break;
@@ -144,7 +145,7 @@ export async function runInstallLockFileOnly(
       inputLockfileName = 'yarn.lock';
       if (await validateFileExists(path.join(cwd, inputLockfileName))) {
         log.verbose('lock', `updating lock file via "yarn install --mode update-lockfile"`);
-        await exec('yarn', ['install', '--mode', 'update-lockfile'], { cwd });
+        await exec('yarn', ['install', '--mode', 'update-lockfile', ...npmClientArgs], { cwd });
         outputLockfileName = inputLockfileName;
       }
       break;
@@ -159,7 +160,7 @@ export async function runInstallLockFileOnly(
         // however, when lower then we need to call "npm shrinkwrap --package-lock-only" and then rename "npm-shrinkwrap.json" file back to "package-lock.json"
         if (semver.gte(localNpmVersion, '8.5.0')) {
           log.verbose('lock', `updating lock file via "npm install --package-lock-only"`);
-          await exec('npm', ['install', '--package-lock-only'], { cwd });
+          await exec('npm', ['install', '--package-lock-only', ...npmClientArgs], { cwd });
         } else {
           // TODO: remove this in the next major release
           // with npm < 8.5.0, we need to update the lock file in 2 steps
@@ -169,7 +170,7 @@ export async function runInstallLockFileOnly(
             `npm`,
             `Your npm version is lower than 8.5.0, we recommend upgrading your npm client to avoid the use of "npm shrinkwrap" instead of the regular (better) "npm install --package-lock-only".`
           );
-          await exec('npm', ['shrinkwrap', '--package-lock-only'], { cwd });
+          await exec('npm', ['shrinkwrap', '--package-lock-only', ...npmClientArgs], { cwd });
 
           // 2. rename "npm-shrinkwrap.json" back to "package-lock.json"
           log.verbose('lock', `renaming "npm-shrinkwrap.json" file back to "package-lock.json"`);

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -724,13 +724,14 @@ export class VersionCommand extends Command<VersionCommandOption> {
       );
     } else if (this.options.syncWorkspaceLock) {
       // update lock file, with npm client defined when `--sync-workspace-lock` is enabled
-      chain = chain.then(() =>
-        runInstallLockFileOnly(npmClient, this.project.manifest.location).then((lockfilePath) => {
+      chain = chain.then(() => {
+        const npmClientArgs = this.options.npmClientArgs || [];
+        runInstallLockFileOnly(npmClient, this.project.manifest.location, npmClientArgs).then((lockfilePath) => {
           if (lockfilePath) {
             changedFiles.add(lockfilePath);
           }
-        })
-      );
+        });
+      });
     }
 
     if (!independentVersions) {

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -724,14 +724,15 @@ export class VersionCommand extends Command<VersionCommandOption> {
       );
     } else if (this.options.syncWorkspaceLock) {
       // update lock file, with npm client defined when `--sync-workspace-lock` is enabled
-      chain = chain.then(() => {
-        const npmClientArgs = this.options.npmClientArgs || [];
-        runInstallLockFileOnly(npmClient, this.project.manifest.location, npmClientArgs).then((lockfilePath) => {
-          if (lockfilePath) {
-            changedFiles.add(lockfilePath);
+      chain = chain.then(() =>
+        runInstallLockFileOnly(npmClient, this.project.manifest.location, this.options.npmClientArgs || []).then(
+          (lockfilePath) => {
+            if (lockfilePath) {
+              changedFiles.add(lockfilePath);
+            }
           }
-        });
-      });
+        )
+      );
     }
 
     if (!independentVersions) {


### PR DESCRIPTION

## Description

As per Lerna PR 3434

> Adds configured npmClientArgs to the npm install command that happens at the end of lerna version.

## Motivation and Context

Addresses Lerna issue 3386

> lerna version does not take npmClientArgs into account

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
