### PR TITLE
fix(schema): add the other format changelogPreset can assume

### DIFF
--- a/packages/cli/schemas/lerna-schema.json
+++ b/packages/cli/schemas/lerna-schema.json
@@ -1348,7 +1348,12 @@
           "description": "During `lerna version`, add a custom message as a prefix to each new version in your \"changelog.md\" which is located in the root of your project. This option is only available when using --conventional-commits with changelogs."
         },
         "changelogPreset": {
-          "type": "string",
+          "anyOf": [
+            { "type": "string" },
+            {
+              "$ref": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json"
+            }
+          ],
           "description": "For `lerna version`, the custom conventional-changelog preset."
         },
         "dryRun": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per Lerna PR 3441
> This references the version 2.2.0 from the following repository. https://github.com/conventional-changelog/conventional-changelog-config-spec

## Motivation and Context

> The current schema only allow for a string based "changelogPreset", but lerna also supports an object syntax for this property.

## How Has This Been Tested?

> Linked the proposed changes to one of my monorepos' `lerna.json` by adding a `$schema` at the beginning of the file, it works.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
