### PR TITLE
refactor: use native object spreading

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,6 @@
     "@lerna-lite/npmlog": "workspace:*",
     "@npmcli/run-script": "^9.1.0",
     "ci-info": "^4.3.0",
-    "clone-deep": "^4.0.1",
     "config-chain": "^1.1.13",
     "dedent": "catalog:",
     "execa": "catalog:",
@@ -67,7 +66,6 @@
     "zeptomatch": "catalog:dependencies"
   },
   "devDependencies": {
-    "@types/clone-deep": "^4.0.4",
     "@types/dedent": "catalog:devDependencies",
     "@types/fs-extra": "catalog:devDependencies",
     "@types/glob-parent": "^5.1.3",

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -3,7 +3,6 @@ import { cpus } from 'node:os';
 import type { Logger } from '@lerna-lite/npmlog';
 import { log } from '@lerna-lite/npmlog';
 import { isCI } from 'ci-info';
-import cloneDeep from 'clone-deep';
 import dedent from 'dedent';
 import type { SyncOptions } from 'execa';
 import { execaSync } from 'execa';
@@ -61,11 +60,11 @@ export class Command<T extends AvailableCommandOption> {
   packageGraph!: PackageGraph;
   runner?: Promise<any>;
 
-  constructor(_argv: AvailableCommandOption) {
+  constructor(readonly _argv: AvailableCommandOption) {
     log.pause();
     log.heading = 'lerna-lite';
 
-    const argv = cloneDeep(_argv) as ProjectConfig;
+    const argv = { ..._argv } as ProjectConfig;
     log.silly('argv', argv.toString());
 
     // 'FooCommand' => 'foo'

--- a/packages/core/src/utils/__tests__/object-utils.spec.ts
+++ b/packages/core/src/utils/__tests__/object-utils.spec.ts
@@ -1,5 +1,4 @@
 import { log } from '@lerna-lite/npmlog';
-import cloneDeep from 'clone-deep';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { deleteComplexObjectProp, getComplexObjectValue, isEmpty } from '../object-utils.js';
@@ -11,13 +10,13 @@ describe('deleteComplexObjectProp method', () => {
   });
 
   it('should expect the same object as the original object when no path is provided', () => {
-    const originalObj = cloneDeep(obj);
+    const originalObj = { ...obj };
     deleteComplexObjectProp(obj, undefined as any);
     expect(originalObj).toEqual(obj);
   });
 
   it('should expect the same object as the original object when search argument is not part of the input object', () => {
-    const originalObj = cloneDeep(obj);
+    const originalObj = { ...obj };
     deleteComplexObjectProp(obj, 'users');
     expect(originalObj).toEqual(obj as any);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,9 +309,6 @@ importers:
       ci-info:
         specifier: ^4.3.0
         version: 4.3.0
-      clone-deep:
-        specifier: ^4.0.1
-        version: 4.0.1
       config-chain:
         specifier: ^1.1.13
         version: 1.1.13
@@ -379,9 +376,6 @@ importers:
         specifier: catalog:dependencies
         version: 2.0.2
     devDependencies:
-      '@types/clone-deep':
-        specifier: ^4.0.4
-        version: 4.0.4
       '@types/dedent':
         specifier: catalog:devDependencies
         version: 0.7.2
@@ -1491,9 +1485,6 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
-  '@types/clone-deep@4.0.4':
-    resolution: {integrity: sha512-vXh6JuuaAha6sqEbJueYdh5zNBPPgG1OYumuz2UvLvriN6ABHDSW8ludREGWJb1MLIzbwZn4q4zUbUCerJTJfA==}
-
   '@types/dedent@0.7.2':
     resolution: {integrity: sha512-kRiitIeUg1mPV9yH4VUJ/1uk2XjyANfeL8/7rH1tsjvHeO9PJLBHJIYsFWmAvmGj5u8rj+1TZx7PZzW2qLw3Lw==}
 
@@ -1878,10 +1869,6 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
-
-  clone-deep@4.0.1:
-    resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
-    engines: {node: '>=6'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -2456,10 +2443,6 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
-    engines: {node: '>=0.10.0'}
-
   is-ssh@1.4.1:
     resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
 
@@ -2477,10 +2460,6 @@ packages:
   isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
-
-  isobject@3.0.1:
-    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
-    engines: {node: '>=0.10.0'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -2554,10 +2533,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
 
   lcid@1.0.0:
     resolution: {integrity: sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==}
@@ -3206,10 +3181,6 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
-  shallow-clone@3.0.1:
-    resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
-    engines: {node: '>=8'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4246,8 +4217,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
-  '@types/clone-deep@4.0.4': {}
-
   '@types/dedent@0.7.2': {}
 
   '@types/deep-eql@4.0.2': {}
@@ -4689,12 +4658,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
-
-  clone-deep@4.0.1:
-    dependencies:
-      is-plain-object: 2.0.4
-      kind-of: 6.0.3
-      shallow-clone: 3.0.1
 
   clone@1.0.4: {}
 
@@ -5282,10 +5245,6 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-plain-object@2.0.4:
-    dependencies:
-      isobject: 3.0.1
-
   is-ssh@1.4.1:
     dependencies:
       protocols: 2.0.2
@@ -5297,8 +5256,6 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.1: {}
-
-  isobject@3.0.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -5368,8 +5325,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  kind-of@6.0.3: {}
 
   lcid@1.0.0:
     dependencies:
@@ -6012,10 +5967,6 @@ snapshots:
   semver@7.7.2: {}
 
   set-blocking@2.0.0: {}
-
-  shallow-clone@3.0.1:
-    dependencies:
-      kind-of: 6.0.3
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Motivation and Context

~~[`structuredClone`](https://nodejs.org/api/globals.html#structuredclonevalue-options) is natively available as of Node v17, so no need to have an extra dependency for this anymore~~

We could use object spreading since we're only accessing root properties

As per e18e initiative
https://github.com/e18e/ecosystem-issues/issues/187


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

I'm sure people from the wider @e18e ecosystem cleanup (like @43081j, @benmccann, @Fuzzyma, @outslept & @talentlessguy) will be very happy to see these kind of changes as well
