### PR TITLE
fix: allow Bun "catalog" and "catalogs" in top-level `package.json`

### DIFF
--- a/packages/core/src/__fixtures__/package-catalog/lerna.json
+++ b/packages/core/src/__fixtures__/package-catalog/lerna.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "npmClient": "pnpm"
+}

--- a/packages/core/src/__fixtures__/package-catalog/package.json
+++ b/packages/core/src/__fixtures__/package-catalog/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "workspace-protocol-specs",
+  "description": "workspace protocol specifiers should act just like recognized semver ranges",
+  "private": true,
+  "version": "0.0.0-lerna",
+  "dependencies": {
+    "package-2": "catalog:"
+  },
+  "catalog": {
+    "package-1": "2.3.4",
+    "fs-extra": "^11.2.0",
+    "pkg-1": "1.0.0",
+    "p-map": "^7.0.3",
+    "tinyrainbow": "^2.0.0"
+  },
+  "catalogs": {
+    "react17": {
+      "react": "^17.0.2",
+      "react-dom": "^17.0.2"
+    },
+    "react18": {
+      "react": "^18.2.0",
+      "react-dom": "^18.2.0"
+    }
+  },
+  "workspaces": {
+    "packages": ["packages/**"]
+  }
+}

--- a/packages/core/src/utils/catalog-utils.ts
+++ b/packages/core/src/utils/catalog-utils.ts
@@ -54,8 +54,8 @@ export function getClientConfigFilename(npmClient: NpmClient): string {
 }
 
 /**
- * Extract catalog config from the `workspaces` located in the project root `package.json`.
- * From a file content that is either provided as argument or read it from the 'package.json' when null,
+ * Extract catalog config from the `workspaces` located in the project root `package.json` (it also works at the top-level `package.json`).
+ * From a file content that is either provided as argument or read it from the `package.json` when null,
  * it will then parse that file content and return all pnpm catalog(s) config
  * @param {String} [pkgContent] - optional JSON stringified package file content
  * @returns
@@ -70,10 +70,11 @@ export function extractCatalogConfigFromPkg(pkgContent?: string): CatalogConfig 
   }
 
   const pkg = looselyJsonParse(fileContent) || {};
-  const ws = pkg.workspaces || {};
+
+  // get catalog(s) from `workspaces` field and/or from top-level `package.json`
   return {
-    catalog: ws.catalog || {},
-    catalogs: ws.catalogs || {},
+    catalog: pkg.workspaces?.catalog ?? pkg.catalog ?? {},
+    catalogs: pkg.workspaces?.catalogs ?? pkg.catalogs ?? {},
   };
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bun is now allowing catalog(s) from top-level of `package.json`

## Motivation and Context

We should support both approach of defining them in a `workspaces` object and/or from top-level `package.json`, see Bun's PR
https://github.com/oven-sh/bun/pull/21009 from more info.

```ts
  "name": "monorepo-root",
  "catalog": {
    "react": "19.0.2",
    "react-dom": "^19.0.0"
  },
  "catalogs": {
    "react18": {
      "react": "^18.2.0",
      "react-dom": "^18.2.0"
    }
  },
  "workspaces": {
    "packages": ["packages/**"]
  }
}
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
