### PR TITLE
fix: supress log file generation when terminating the prompt

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -108,14 +108,13 @@ export class Command<T extends AvailableCommandOption> {
 
           // ValidationError does not trigger a log dump, nor do external package errors
           if (err.name !== 'ValidationError' && !err.pkg) {
-            writeLogFile(this.project.rootPath);
-
             // Suppress ExitPromptError when terminating the prompt (sending SIGINT)
             if (err.name === 'ExitPromptError') {
               console.error('Termination call detected, exiting command');
               resolve(null);
               return;
             }
+            writeLogFile(this.project.rootPath);
           }
 
           warnIfHanging();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

HI,

ref: https://github.com/lerna-lite/lerna-lite/pull/1174

This PR prevented errors from being displayed when exiting the prompt with Ctrl-C/Ctrl-D, 
but lerna-debug.log were still generated.
(I'm sorry I did not notice this at that time)

If the prompt is terminated using Ctrl-C or Ctrl-D, it is considered a normal exit, 
and lerna-debug.log will not be generated.

## Motivation and Context

Steps to reproduce

- hit `lerna version --no-git-tag-version --no-push` command
- A prompt to select the version is displayed
- Hit Ctrl-C or Ctrl-D, `Termination call detected, exiting command` is displayed
- hit `ls`, lerna-debug.log is generated

https://github.com/user-attachments/assets/80cc4cc5-85b3-40f1-aecb-8dbef94ee7db

Solution
Move `writeLogFile(this.project.rootPath);` after the ExitPromptError check.


https://github.com/user-attachments/assets/d1067d7d-48b8-4852-a76e-80e3a92b4996

environment
macOS, VSCode terminal

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I replaced the build-generated files with the test project and confirmed its behavior with the CLI 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
