### PR TITLE
feat: verify OIDC in both dry-run and normal publish mode

### DIFF
--- a/packages/core/src/utils/__tests__/npm-conf.spec.ts
+++ b/packages/core/src/utils/__tests__/npm-conf.spec.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as npmConfModule from '../npm-conf.js';
 import { Conf, npmConf, toNerfDart } from '../npm-conf.js';
 
 describe('@lerna/npm-conf', () => {
+  beforeEach(() => {
+    // Prevent Conf from loading real npm config files during tests
+    vi.spyOn(Conf.prototype, 'addFile').mockReturnValue({} as any);
+    vi.spyOn(Conf.prototype, 'addEnv').mockReturnValue({} as any);
+    vi.spyOn(Conf.prototype, 'loadCAFile').mockReturnValue(undefined);
+  });
+
   it('exports default factory', () => {
     expect(npmConfModule).toBeDefined();
     expect(Conf).toBeDefined();

--- a/packages/publish/src/__tests__/publish-command.spec.ts
+++ b/packages/publish/src/__tests__/publish-command.spec.ts
@@ -1,7 +1,7 @@
 import { dirname, join as pathJoin } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { collectUpdates, logOutput, promptConfirmation, type PublishCommandOption } from '@lerna-lite/core';
+import { Conf, collectUpdates, logOutput, promptConfirmation, type PublishCommandOption } from '@lerna-lite/core';
 import { getOneTimePassword } from '@lerna-lite/version';
 import { commandRunner, commitChangeToPackage, initFixtureFactory } from '@lerna-test/helpers';
 import { loggingOutput } from '@lerna-test/helpers/logging-output.js';
@@ -112,6 +112,13 @@ const createArgv = (cwd: string, ...args: any[]) => {
 (gitCheckout as Mock).mockImplementation(() => Promise.resolve());
 
 describe('PublishCommand', () => {
+  beforeEach(() => {
+    // Prevent Conf from loading real npm config files during tests
+    vi.spyOn(Conf.prototype, 'addFile').mockReturnValue({} as any);
+    vi.spyOn(Conf.prototype, 'addEnv').mockReturnValue({} as any);
+    vi.spyOn(Conf.prototype, 'loadCAFile').mockReturnValue(undefined);
+  });
+
   describe('cli validation', () => {
     let cwd: string;
 

--- a/packages/publish/src/lib/npm-publish.ts
+++ b/packages/publish/src/lib/npm-publish.ts
@@ -53,6 +53,14 @@ export async function npmPublish(
 
   let result: undefined | Response;
 
+  // OIDC trusted publishing
+  await oidc({
+    packageName: pkg.name,
+    registry: opts.registry ?? 'https://registry.npmjs.org/',
+    opts,
+    config: conf,
+  });
+
   if (!dryRun) {
     let { manifestLocation } = pkg;
 
@@ -83,14 +91,6 @@ export async function npmPublish(
     if (manifestContent.publishConfig) {
       Object.assign(opts, publishConfigToOpts(manifestContent.publishConfig));
     }
-
-    // OIDC trusted publishing
-    await oidc({
-      packageName: pkg.name,
-      registry: opts.registry ?? 'https://registry.npmjs.org/',
-      opts,
-      config: conf,
-    });
 
     result = await otplease((innerOpts) => publish(manifestContent, tarData, innerOpts), opts, otpCache as OneTimePasswordCache);
   }


### PR DESCRIPTION
## Description

* Moved the `oidc()` function out of the `!dryRun` conditional so that it runs on both dry-run and normal publish modes
* Added tests to validate expected behavior
* Fixed existing tests that would attempt to pull my machine's NPM configs for testing rather than using mock config data

## Motivation and Context

* The existing dry-run mode of `lerna publish` does not validate OIDC during the dry-run
* We recently migrated to using lerna-lite over lerna specifically for the `--dry-run` feature, and wanted to ensure our dry-run of the version and publish commands would work as expected, including OIDC validation for the latter

## How Has This Been Tested?

* Rather than mock the OIDC key from `@lerna-lite/core`, we instead import the `oidc.js` file, and then mock its response following the pattern observed with other imports
* Tested **dry-run** behavior
  * `npmPublish` calls `oidc` - `publish` does not get called
* Tested **normal** behavior
  * `npmPublish` calls `oidc` - `publish` also gets called
* Fixed other tests that tried relying on my local NPM configs rather than mock data


* I tested these changes on Node 22.19.0 and PNPM 10.10.0
* All tests were passing across the repo

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
