### PR TITLE
fix(publish): shouldn't Comment on closed issues older than release

### DIFF
--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -188,7 +188,7 @@ When enabled, it will insert Comments on all the closed linked issues and/or mer
 
 ##### `--comment-issue [msg]`
 
-Insert Comments on all the closed linked issues that were included in the release.
+Insert Comments on all the closed linked issues that were included in the release. The issue must be been linked through a PR when it detects fix keywords in its PR title and/or description (like `"fix #123"` or `"fixes #123"`)
 
 ```sh
 # enable it and use default template

--- a/packages/publish/src/lib/comment-resolved-items.ts
+++ b/packages/publish/src/lib/comment-resolved-items.ts
@@ -27,7 +27,7 @@ export async function remoteSearchBy(
 ) {
   const q =
     type === 'issue'
-      ? `repo:${owner}/${repo}+is:issue+state:closed+linked:pr+updated:>${startDate}`
+      ? `repo:${owner}/${repo}+is:issue+linked:pr+closed:>${startDate}`
       : `repo:${owner}/${repo}+type:pr+merged:>${startDate}`;
   logger.verbose('comments', `remote PR search query: ${q}`);
   return (await client.search!.issuesAndPullRequests({ q, advanced_search: true })).data.items;
@@ -51,22 +51,47 @@ export async function commentResolvedItems({
   const filterStartDate = previousTagLastCommit.commitDate;
 
   // closed linked issues and/or merged pull requests
-  let closedLinkedIssues: TypeNumberPair[] = [];
-  let mergedPullRequests: TypeNumberPair[] = [];
+  let closedLinkedIssues = new Set<TypeNumberPair>();
+  let mergedPullRequests = new Set<TypeNumberPair>();
 
   if (templates.issue) {
-    closedLinkedIssues = (await remoteSearchBy(client, 'issue', repo.owner, repo.name, filterStartDate, logger)).map((item) => ({
-      type: 'issue',
-      number: item.number,
-    }));
-    logger.verbose('comments', `Closed linked issues: ${closedLinkedIssues.map((c) => c.number).join(', ')}`);
+    const issues = await remoteSearchBy(client, 'issue', repo.owner, repo.name, filterStartDate, logger);
+    issues.forEach((item) => closedLinkedIssues.add({ type: 'issue', number: item.number }));
   }
 
+  if (templates.pullRequest) {
+    const pullRequests = (await remoteSearchBy(client, 'pr', repo.owner, repo.name, filterStartDate, logger)).filter((item) =>
+      commentFilterKeywords.some((startWord) => item.title.toLowerCase().startsWith(startWord.toLowerCase()))
+    );
+    pullRequests.forEach((item) => mergedPullRequests.add({ type: 'pr', number: item.number }));
+    logger.verbose(
+      'comments',
+      `Merged Pull Requests: ${Array.from(mergedPullRequests)
+        .map((c) => c.number)
+        .join(', ')}`
+    );
+
+    // issues might not be linked (fix keyword via description),
+    // but the fix keyword might be in the PR title so let's add those as issues if they're not yet included
+    if (templates.issue) {
+      pullRequests.forEach((p) => {
+        const match = p.title.match(/\b(fix|fixes)\s*#(\d+)/) || [];
+        if (match.length >= 2) {
+          const issueNumber = parseInt(match[2], 10);
+          closedLinkedIssues.add({ type: 'issue', number: issueNumber });
+        }
+      });
+    }
+  }
+
+  // issues could be added in 2 places, so let's log them here
   if (templates.issue) {
-    mergedPullRequests = (await remoteSearchBy(client, 'pr', repo.owner, repo.name, filterStartDate, logger))
-      .filter((item) => commentFilterKeywords.some((startWord) => item.title.toLowerCase().startsWith(startWord.toLowerCase())))
-      .map((item) => ({ type: 'pr', number: item.number }));
-    logger.verbose('comments', `Merged Pull Requests: ${mergedPullRequests.map((c) => c.number).join(', ')}`);
+    logger.verbose(
+      'comments',
+      `Closed linked issues: ${Array.from(closedLinkedIssues)
+        .map((c) => c.number)
+        .join(', ')}`
+    );
   }
 
   const repository = `${repo.owner}/${repo.name}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

improve new Comments on issue/PR feature

## Motivation and Context

 I found some small bugs after merging the PR #1200, I detected that the original code returned closed issues that were older than the release date. It was caused by an incorrect search query, I also found that what GitHub consider "linked PR" is too strict (which is only when a `"fix #123"` is included in the PR description only), but I also want it to detect `"fix #123"` when included in PR title (e.g. `"fix: code change, fix #123"`)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
