### PR TITLE
fix: Version/Publish --yes log should show only after all Changes logged

### DIFF
--- a/packages/publish/src/__tests__/publish-canary.spec.ts
+++ b/packages/publish/src/__tests__/publish-canary.spec.ts
@@ -518,3 +518,16 @@ test('publish throws error when --build-metadata and --canary are both applied',
     })
   );
 });
+
+test('publish --canary --yes logs auto-confirmed after listing changes', async () => {
+  const cwd = await initTaggedFixture('normal');
+  await setupChanges(cwd, ['packages/package-1/all-your-base.js', 'belong to us']);
+
+  await new PublishCommand(createArgv(cwd, '--canary', '--yes'));
+  const logMessages = loggingOutput('info');
+
+  // Ensure we await the deferred logger.info call
+  await new Promise((resolve) => process.nextTick(resolve));
+
+  expect(logMessages).toContain('auto-confirmed');
+});

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -522,7 +522,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
     }));
   }
 
-  confirmPublish() {
+  confirmPublish(): Promise<boolean> {
     const logPrefix = this.options.dryRun ? c.bgMagenta('[dry-run]') : '';
     const count = this.packagesToPublish?.length;
     const message = this.packagesToPublish?.map((pkg) => ` - ${pkg.name} => ${this.updatesVersions?.get(pkg.name)}`) ?? [];
@@ -533,8 +533,11 @@ export class PublishCommand extends Command<PublishCommandOption> {
     logOutput('');
 
     if (this.options.yes) {
-      this.logger.info('auto-confirmed', '');
-      return true;
+      // Defer the info log to the next microtask to avoid interleaving the auto-confirm log with all changes shown above
+      return Promise.resolve().then(() => {
+        this.logger.info('auto-confirmed', '');
+        return true;
+      });
     }
 
     let confirmMessage = this.options.dryRun ? c.bgMagenta('[dry-run]') : '';

--- a/packages/version/src/__tests__/version-command.spec.ts
+++ b/packages/version/src/__tests__/version-command.spec.ts
@@ -719,6 +719,22 @@ describe('VersionCommand', () => {
       const message = await getCommitMessage(testDir);
       expect(message).toBe('v1.0.1');
     });
+
+    it('logs auto-confirmed after listing changes', async () => {
+      const testDir = await initFixture('normal');
+      await new VersionCommand(createArgv(testDir, '--bump', 'patch', '--yes'));
+
+      // Ensure we await the deferred logger.info call
+      await new Promise((resolve) => process.nextTick(resolve));
+
+      // npmlog info should include auto-confirmed
+      const infoLogs = loggingOutput('info');
+      expect(infoLogs).toContain('auto-confirmed');
+
+      // npmlog info should include auto-confirmed
+      const consoleOut = (logOutput as any).logged();
+      expect(consoleOut).toMatch(/Changes \(\d+ packages\):/);
+    });
   });
 
   describe('--exact', () => {

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -630,7 +630,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
     return versions;
   }
 
-  confirmVersions(): Promise<boolean> | boolean {
+  confirmVersions(): Promise<boolean> {
     const changes = this.packagesToVersion.map((pkg) => {
       let line = ` - ${pkg.name ?? '[n/a]'}: ${pkg.version} => ${c.cyan(this.updatesVersions?.get(pkg.name ?? ''))}`;
       if (pkg.private) {
@@ -645,8 +645,11 @@ export class VersionCommand extends Command<VersionCommandOption> {
     logOutput('');
 
     if (this.options.yes) {
-      this.logger.info('auto-confirmed', '');
-      return true;
+      // Defer the info log to the next microtask to avoid interleaving the auto-confirm log with all changes shown above
+      return Promise.resolve().then(() => {
+        this.logger.info('auto-confirmed', '');
+        return true;
+      });
     }
 
     // When composed from `lerna publish`, use this opportunity to confirm publishing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes #1213

## Motivation and Context

The `--yes` CLI option to auto-confirm changes, was sometime showing in the middle of the changes but it should really show at the end. So let's resolve the auto-confirm after a next tick cycle so that we are 100% sure that it's always shown at the end of the Changes list. 

The issue can be seen in #1213 but also in this [release](https://github.com/lerna-lite/lerna-lite/actions/runs/20183496045/job/57948896508) (in the Lerna Version section)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
