### PR TITLE
refactor: add option to change Rate Limiter first run max calls

### DIFF
--- a/packages/version/src/lib/comment-resolved-items.ts
+++ b/packages/version/src/lib/comment-resolved-items.ts
@@ -101,6 +101,7 @@ export async function commentResolvedItems({
   // Create a rate limiter for GitHub API
   const rateLimiter = new RateLimiter({
     maxCalls: 30, // 30 calls per minute
+    firstRunMaxCalls: 27, // 27/min since we need to remove 3 calls that were called before (1x graphql, 1x issues, 1x PRs)
     perMilliseconds: 60000, // per minute
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

improve Rate Limiter to avoid hitting the limit too early on the first iteration set

## Motivation and Context

Rate Limiter first initial run max calls per iteration (30/min) should be lower since we already used 3 calls for other purposes (1x GraphQL/login, 1x issues and 1x PRs). So for that use case, let's add a new option named `firstRunMaxCalls` and set it to 27 (30-3) and all other loops will be 30. This is to avoid hitting the limit too early on the first iteration set

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
