### PR TITLE
fix: use args to run `git show` command

### DIFF
--- a/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
+++ b/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
@@ -176,14 +176,14 @@ export function diffWorkspaceCatalog(prevTag: string, npmClient: NpmClient): str
       const yamlFilename = getClientConfigFilename(npmClient);
       const yamlPath = join(cwd, yamlFilename);
       if (existsSync(yamlPath)) {
-        const prevYamlStr = execSync(`git show ${prevTag}:${yamlFilename}`);
+        const prevYamlStr = execSync('git', ['show', `${prevTag}:${yamlFilename}`]);
         const currYamlStr = readFileSync(yamlPath, 'utf8');
         prevConfig = extractCatalogConfigFromYaml(npmClient, prevYamlStr);
         currConfig = extractCatalogConfigFromYaml(npmClient, currYamlStr);
       }
     } else if (npmClient === 'bun' && existsSync(rootPkgPath)) {
       // Bun catalogs
-      const prevJsonStr = execSync(`git show ${prevTag}:package.json`);
+      const prevJsonStr = execSync('git', ['show', `${prevTag}:package.json`]);
       const currJsonStr = readFileSync(rootPkgPath, 'utf8');
       prevConfig = extractCatalogConfigFromPkg(prevJsonStr);
       currConfig = extractCatalogConfigFromPkg(currJsonStr);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hello 👋 
This pull request change the way `diffWorkspaceCatalog` execute git command under the hood.

When you call `execaSync` from `execa` you have to pass the process with args instead of the command including args.

The original error is catch by this [line](https://github.com/lerna-lite/lerna-lite/blob/77c98044dd761755f92b33a818abad6558991251/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts#L196)

## Motivation and Context

Without this change `lerna-lite` will not detect changes if you update the `pnpm-workspace.yaml`

## How Has This Been Tested?

I created a pnpm patch to test the fix see https://github.com/ghoullier/lerna-lite-pnpm-catalog-issue

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
