### PR TITLE
fix(version): `whatBump` must be a function, fixes #1217

### DIFF
--- a/packages/version/src/conventional-commits/get-changelog-config.ts
+++ b/packages/version/src/conventional-commits/get-changelog-config.ts
@@ -7,7 +7,7 @@ import type { ChangelogConfig, ChangelogPresetConfig } from '../interfaces.js';
 
 /** @deprecated this is a temporary workaround until `config?.conventionalChangelog`, `parserOpts` and `writerOpts` are officially removed */
 function flattenConfigResult(config: any): ChangelogConfig {
-  const flatConfig = config?.conventionalChangelog || config;
+  const flatConfig = config?.recommendedBumpOpts ?? config?.conventionalChangelog ?? config;
   flatConfig.parser = flatConfig.parserOpts || flatConfig.parser;
   flatConfig.writer = flatConfig.writerOpts || flatConfig.writer;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes #1217

## Motivation and Context

in some cases, conventional-changelog shows "`whatBump` must be a function", this PR should fix the issue

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
