### PR TITLE
fix(version): comment on issues/PRs should work on Windows

### DIFF
--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -71,6 +71,7 @@ export interface DescribeRefDetailedResult {
 export interface ExecOpts {
   cwd: string;
   maxBuffer?: number;
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface LifecycleConfig {

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -283,7 +283,7 @@ permissions:
   pull-requests: write # to be able to comment on released pull requests
 ```
 
-> **Note** this will possibly execute many API calls and this option will also require a valid `GH_TOKEN` (or `GITHUB_TOKEN`) with write access permissions to the GitHub API so that it can execute the query to fetch all commit details and insert comments, for more info refer to the [`Remote Client Auth Tokens`](#remote-client-auth-tokens) below.
+> **Note** this will possibly execute many API calls and this option will also require a valid `GH_TOKEN` (or `GITHUB_TOKEN`) with write access permissions to the GitHub API so that it can execute the query to fetch all commit details and insert comments, for more info refer to the [`Remote Client Auth Tokens`](#remote-client-auth-tokens) below. Also note that it will only fetch a maximum of 100 issues/PRs (max handled by octokit API) and I think that is more than enough.
 
 > [!NOTE]
 > This feature works best with a single global version and might not work as expected with `independent` mode, there is just no easy ways to detect which issues/PRs belongs to which package. You could still use it with `independent` but none of the tokens shown above will be available (or at least won't provide the correct info) and so in that case using a generic message is the only suggestion we have (e.g.: `"This PR is included in latest [release](http://release-url)"`).

--- a/packages/version/src/interfaces.ts
+++ b/packages/version/src/interfaces.ts
@@ -122,7 +122,12 @@ export interface OctokitClientOutput {
   };
   repos: GitClient;
   search?: {
-    issuesAndPullRequests: (options: { q; advanced_search: true }) => Promise<{ data: { items: any[] } }>;
+    issuesAndPullRequests: (options: {
+      q: string;
+      advanced_search?: boolean;
+      per_page?: number;
+      page?: number;
+    }) => Promise<{ data: { items: any[] } }>;
   };
 }
 

--- a/packages/version/src/lib/get-tag.ts
+++ b/packages/version/src/lib/get-tag.ts
@@ -25,12 +25,14 @@ export function getPreviousTag(execOpts?: ExecOpts, isIndependent?: boolean) {
     const tagShaArgs = ['rev-list', '-n', '1', name];
     const sha = execSync('git', tagShaArgs, execOpts);
 
-    // Get the date of the last tag
-    const tagDateArgs = ['log', '-1', '--format=%cd', '--date=iso-strict'];
+    // Get the date of the last tag with Z (UTC) format, converting from local time
+    const tagDateArgs = ['log', '-1', '--format=%cd', '--date=format-local:%Y-%m-%dT%H:%M:%SZ'];
     if (name) {
       tagDateArgs.push(name);
     }
-    const date = execSync('git', tagDateArgs, execOpts);
+
+    // Use TZ=UTC to ensure correct UTC conversion
+    const date = execSync('git', tagDateArgs, { ...execOpts, env: { ...process.env, TZ: 'UTC' } });
 
     return { name, date, sha };
   } catch (error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Commenting on issues/PRs should work on Windows platform

## Motivation and Context

It was running fine in CI with Ubuntu but it wasn't working well on Windows and the reason was mostly because getting the last tag date returned a date with an offset `...+05:00` and that didn't work with the GitHub API, what works though is with a TZ format like `2025-12-27T16:37:16Z`. I also added an explicit `per_page: 100` because that is the maximum allowed by the API. Finally I also tweaked the PR octokit query to include PR keywords to filters so that this help fetching less unrelated PRs (for example there's no need to include any `chore` PRs) and that will help to be within the max limit of 100 results.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
