### PR TITLE
chore: re-enable oxlint rule "import/extensions" to test .js extension

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -30,7 +30,7 @@
         "caughtErrors": "none"
       }
     ],
-    "import/extensions": ["error", "always", { "ts": "never", "ignorePackages": true }],
+    "import/extensions": ["error", "always", { "ignorePackages": true }],
     "import/no-self-import": "error",
     "import/no-useless-path-segments": ["error", { "noUselessIndex": true }],
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

re-enable oxlint `import/extensions` rule to properly lint `.js` extensions for local imports

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
