### PR TITLE
chore: run E2E tests on all supported NodeJS versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         node: [20, 22, 24]
         platform: [ubuntu-latest]
 
-    name: "Run on Ubuntu / Node${{ matrix.node }}"
+    name: "Unit Tests on Ubuntu / Node${{ matrix.node }}"
     runs-on: ${{matrix.platform}}
     if: ${{ !startsWith(github.event.head_commit.message, 'docs:') }}
 
@@ -126,8 +126,14 @@ jobs:
           !contains(github.event.head_commit.message, 'chore(release)')
 
   e2e:
-    name: "E2E Tests on Ubuntu / Node 22"
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+        platform: [ubuntu-latest]
+        
+    name: "E2E Tests on Ubuntu / Node${{ matrix.node }}"
+    runs-on: ${{matrix.platform}}
     if: ${{ !startsWith(github.event.head_commit.message, 'docs:') }}
 
     steps:
@@ -149,7 +155,7 @@ jobs:
       - name: Set NodeJS
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: "pnpm"
 
       - run: node --version
@@ -164,8 +170,8 @@ jobs:
           path: |
             packages/*/lib
             packages/*/tsconfig.tsbuildinfo
-          key: e2e-build-${{ github.run_id }}
-          restore-keys: e2e-build-
+          key: e2e-build-${{ matrix.platform }}-${{ matrix.node }}-${{ github.run_id }}
+          restore-keys: e2e-build-${{ matrix.platform }}-${{ matrix.node }}-
 
       - name: Run full TypeScript build
         run: pnpm build:full


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

previous PR #1236 added E2E tests but I forgot to add config to run these tests on all 3 NodeJS supported platforms (not just Node 22)

## Motivation and Context

Make sure E2E tests run on all supported NodeJS platforms

same tests but runs on more platforms

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
