### PR TITLE
fix(watch): always set cwd for tinyglobby to support latest version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,10 +33,6 @@
       allowedVersions: '< 6.0.0',
       description: 'Keep pnpm action at v5 until we migrate to pnpm v11',
     },
-    {
-      packageNames: ['tinyglobby'],
-      allowedVersions: '0.2.15',
-    },
   ],
   ignoreDeps: ['node', 'pnpm'],
   ignorePaths: ['helpers', '**/__fixtures__/**', '**/__mocks__/**', '**/fixtures/**', '**/mocks/**'],

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -126,10 +126,17 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
         return pattern;
       });
 
-      // initialize chokidar watcher by adding all package folders to the watcher,
-      // we'll use all directories so that when new files are being added, they will also be inspected
-      const pkgFolders = this._filteredPackages.map((pkg) => this.posixifyPath(pkg.location));
-      const foldersToWatch = globSync(pkgFolders, { onlyDirectories: true, ignore: this._ignoredGlobs });
+      // Initialize chokidar watcher by adding all package folders to the watcher.
+      // We'll use all directories so that when new files are being added, they will also be inspected.
+      let pkgFolders = this._filteredPackages.map((pkg) => this.posixifyPath(pkg.location));
+      // Filter out any empty/undefined globs.
+      pkgFolders = pkgFolders.filter(Boolean);
+
+      const globOptions: any = { onlyDirectories: true, cwd: process.cwd() };
+      if (this._ignoredGlobs && this._ignoredGlobs.length > 0) {
+        globOptions.ignore = this._ignoredGlobs;
+      }
+      const foldersToWatch = pkgFolders.length > 0 ? globSync(pkgFolders, globOptions) : [];
       this._watcher = watch(foldersToWatch, {
         ...chokidarOptions,
         cwd: process.cwd(),
@@ -322,7 +329,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       patterns.push(unixPath);
     });
 
-    this._watchedFiles = new Set(globSync(patterns, { ignore: this._ignoredGlobs }));
+    this._watchedFiles = new Set(globSync(patterns, { cwd: process.cwd(), ignore: this._ignoredGlobs }));
   }
 
   protected runCommandInPackageStreaming(pkg: Package, changedFile: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     tinyglobby:
-      specifier: ^0.2.15
-      version: 0.2.15
+      specifier: ^0.2.16
+      version: 0.2.16
     write-json-file:
       specifier: ^7.0.0
       version: 7.0.0
@@ -189,7 +189,7 @@ importers:
         version: 7.7.4
       tinyglobby:
         specifier: catalog:dependencies
-        version: 0.2.15
+        version: 0.2.16
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -310,7 +310,7 @@ importers:
         version: 7.7.4
       tinyglobby:
         specifier: catalog:dependencies
-        version: 0.2.15
+        version: 0.2.16
       write-file-atomic:
         specifier: ^7.0.1
         version: 7.0.1
@@ -412,7 +412,7 @@ importers:
         version: 11.3.4
       tinyglobby:
         specifier: catalog:dependencies
-        version: 0.2.15
+        version: 0.2.16
       yargs:
         specifier: catalog:dependencies
         version: 18.0.0
@@ -566,7 +566,7 @@ importers:
         version: 7.5.13
       tinyglobby:
         specifier: catalog:dependencies
-        version: 0.2.15
+        version: 0.2.16
     devDependencies:
       '@types/fs-extra':
         specifier: catalog:devDependencies
@@ -625,7 +625,7 @@ importers:
         version: 0.0.1
       tinyglobby:
         specifier: catalog:dependencies
-        version: 0.2.15
+        version: 0.2.16
       yargs:
         specifier: catalog:dependencies
         version: 18.0.0
@@ -746,7 +746,7 @@ importers:
         version: 5.0.0
       tinyglobby:
         specifier: catalog:dependencies
-        version: 0.2.15
+        version: 0.2.16
       zeptomatch:
         specifier: catalog:dependencies
         version: 2.1.0
@@ -2684,6 +2684,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -4369,7 +4373,7 @@ snapshots:
       proc-log: 6.0.0
       semver: 7.7.4
       tar: 7.5.13
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       which: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4788,6 +4792,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -4869,7 +4878,7 @@ snapshots:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.0-beta.15(@types/node@24.12.2)(yaml@2.8.3)
       why-is-node-running: 2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ catalogs:
   dependencies:
     columnify: ^1.6.0
     load-json-file: ^7.0.1
-    tinyglobby: ^0.2.15
+    tinyglobby: ^0.2.16
     write-json-file: ^7.0.0
     yaml: ^2.8.3
     yargs: ^18.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

latest version of tinyglobby no longer assign `cwd: process.cwd()`, so this required a change in the code to support newest version

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
