### PR TITLE
fix(core): replace deprecated url.parse with WHATWG URL API

### DIFF
--- a/packages/core/src/utils/__tests__/conf.spec.ts
+++ b/packages/core/src/utils/__tests__/conf.spec.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Conf } from '../conf.js';
 import * as defaults from '../defaults.js';
+import { toNerfDart } from '../npm-conf.js';
 
 describe('conf', () => {
   describe('loadPrefix()', () => {
@@ -348,5 +349,10 @@ MIIBkTCB+wIJAKHHCgVZU3KhMA0GCSqGSIb3DQEBBAUAMA0xCzAJBgNVBAYTAlVT
         })
       ).toThrow('must include email address');
     });
+  });
+
+  it('should add trailing slash for URLs without one (toNerfDart)', () => {
+    expect(toNerfDart('https://npm.example.com')).toBe('//npm.example.com/');
+    expect(toNerfDart('https://npm.example.com/some-path')).toBe('//npm.example.com/some-path/');
   });
 });

--- a/packages/core/src/utils/nerf-dart.ts
+++ b/packages/core/src/utils/nerf-dart.ts
@@ -1,12 +1,13 @@
 // https://github.com/npm/npm/blob/0cc9d89/lib/config/nerf-dart.js
 // Use WHATWG URL API to normalize and strip sensitive parts
+// Normalize and strip sensitive parts from a registry URL, returning //host/path
 export function toNerfDart(uri) {
   const u = new URL(uri);
   u.username = '';
   u.password = '';
   u.search = '';
   u.hash = '';
-  let result = u.origin + u.pathname;
+  let result = '//' + u.host + u.pathname;
   if (!result.endsWith('/')) {
     result += '/';
   }

--- a/packages/core/src/utils/nerf-dart.ts
+++ b/packages/core/src/utils/nerf-dart.ts
@@ -1,14 +1,14 @@
-import url from 'node:url';
-
 // https://github.com/npm/npm/blob/0cc9d89/lib/config/nerf-dart.js
+// Use WHATWG URL API to normalize and strip sensitive parts
 export function toNerfDart(uri) {
-  const parsed = url.parse(uri) as any;
-
-  delete parsed.protocol;
-  delete parsed.auth;
-  delete parsed.query;
-  delete parsed.search;
-  delete parsed.hash;
-
-  return url.resolve(url.format(parsed), '.');
+  const u = new URL(uri);
+  u.username = '';
+  u.password = '';
+  u.search = '';
+  u.hash = '';
+  let result = u.origin + u.pathname;
+  if (!result.endsWith('/')) {
+    result += '/';
+  }
+  return result;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix some CI warnings

> [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.

## Motivation and Context

Use WHATWG URL API to normalize and strip sensitive parts instead of previously using `url.parse()` which is deprecated and caused some warnings to show up in the CI

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
