### PR TITLE
chore: add local npm script to check for missing ".js" on local imports

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,11 +23,6 @@
       groupName: 'Inquirer packages',
     },
     {
-      // blocked by oxlint issue: https://github.com/oxc-project/oxc/issues/19431
-      packageNames: ['oxlint'],
-      allowedVersions: '1.47.0',
-    },
-    {
       matchManagers: ['github-actions'],
       matchDepNames: ['pnpm/action-setup'],
       allowedVersions: '< 6.0.0',

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["import", "oxc", "typescript", "vitest"],
-  "extends": ["recommended", "recommended-module"],
   "env": {
     "es2025": true,
     "node": true,
@@ -14,7 +13,6 @@
     "typescript/consistent-type-definitions": "error",
     "typescript/consistent-type-exports": "error",
     "typescript/consistent-type-imports": "error",
-    "typescript/member-ordering": "error",
     "typescript/no-empty-function": "off",
     "typescript/no-empty-object-type": ["error", { "allowInterfaces": "with-single-extends" }],
     "typescript/no-explicit-any": "off",
@@ -30,13 +28,13 @@
         "caughtErrors": "none"
       }
     ],
-    "import/extensions": ["error", "always", { "ignorePackages": true }],
     "import/no-self-import": "error",
-    "import/no-useless-path-segments": ["error", { "noUselessIndex": true }],
 
     // vitest rules
+    "vitest/prefer-snapshot-hint": "off",
     "vitest/no-conditional-expect": "off",
     "vitest/no-standalone-expect": "off",
+    "vitest/require-mock-type-parameters": "off",
 
     // Additional rules
     "no-async-promise-executor": "off",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
     "new-publish": "lerna publish from-package",
     "roll-new-release": "pnpm build:full && pnpm new-version && pnpm new-publish",
     "test-verdaccio": "lerna publish from-package --registry http://localhost:4873/ --yes --no-git-tag-version --no-push",
-    "lint": "oxlint .",
+    "lint": "oxlint . && pnpm lint:local-js-imports",
     "lint:fix": "oxlint . --fix",
     "lint-type": "oxlint . --type-aware",
+    "lint:local-js-imports": "node ./scripts/lint-local-js-imports.mjs",
     "format": "oxfmt .",
     "format:check": "oxfmt . --check",
     "outdated:ws": "pnpm -r --stream outdated",
@@ -89,7 +90,7 @@
     "empathic": "^2.0.0",
     "load-json-file": "catalog:dependencies",
     "oxfmt": "^0.47.0",
-    "oxlint": "~1.47.0",
+    "oxlint": "^1.62.0",
     "oxlint-tsgolint": "^0.22.1",
     "remove-glob": "^1.2.0",
     "semver": "catalog:",
@@ -103,5 +104,5 @@
     "node": "^22.17.0 || >=24.0.0",
     "pnpm": "10.x"
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.30.0"
 }

--- a/packages/cli/src/cli-commands/__tests__/cli-version-commands.spec.ts
+++ b/packages/cli/src/cli-commands/__tests__/cli-version-commands.spec.ts
@@ -14,7 +14,7 @@ describe('Version Command CLI options', () => {
 
   const patchedVersionCommand = {
     ...cliVersion,
-    handler: function (...args: any[]) {
+    handler: (...args: any[]) => {
       // @ts-ignore
       return cliVersion.handler.call(this, ...args).catch(() => {});
     },

--- a/packages/core/src/__mocks__/run-lifecycle.ts
+++ b/packages/core/src/__mocks__/run-lifecycle.ts
@@ -1,6 +1,6 @@
 import { vi, type Mock } from 'vitest';
 
-import { type Package } from '../../src/package';
+import { type Package } from '../../src/package.js';
 
 const mockRunLifecycle = vi.fn((pkg) => Promise.resolve(pkg));
 const mockCreateRunner = vi.fn((opts) => (pkg: Package, stage: string) => {

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -230,7 +230,7 @@ export interface VersionCommandOption {
   gitTagCommand?: string;
 
   /** Defaults to 'origin', push git changes to the specified remote. */
-  gitRemote: string;
+  gitRemote?: string;
 
   /**
    * Ignore changes in files matched by glob(s) when detecting changed packages.

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -158,7 +158,7 @@ export interface VersionCommandOption {
 
   /** conventional commit version bump type */
   // prettier-ignore
-  bump?: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease' | 'from-git' | 'from-package';
+  bump: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease' | 'from-git' | 'from-package';
 
   /** Comment issue template (requires either `createRelease` or `remoteClient`), when `true` is provided we'll use the default template: "🎉 _This issue has been resolved in %v. See [%s](%u) for release notes._" */
   commentIssues?: boolean | string;

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -158,7 +158,7 @@ export interface VersionCommandOption {
 
   /** conventional commit version bump type */
   // prettier-ignore
-  bump: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease' | 'from-git' | 'from-package';
+  bump?: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease' | 'from-git' | 'from-package';
 
   /** Comment issue template (requires either `createRelease` or `remoteClient`), when `true` is provided we'll use the default template: "🎉 _This issue has been resolved in %v. See [%s](%u) for release notes._" */
   commentIssues?: boolean | string;

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -230,7 +230,7 @@ export interface VersionCommandOption {
   gitTagCommand?: string;
 
   /** Defaults to 'origin', push git changes to the specified remote. */
-  gitRemote?: string;
+  gitRemote: string;
 
   /**
    * Ignore changes in files matched by glob(s) when detecting changed packages.

--- a/packages/core/src/models/command-options.ts
+++ b/packages/core/src/models/command-options.ts
@@ -158,7 +158,7 @@ export interface VersionCommandOption {
 
   /** conventional commit version bump type */
   // prettier-ignore
-  bump: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease' | 'from-git' | 'from-package';
+  bump?: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch' | 'prerelease' | 'from-git' | 'from-package';
 
   /** Comment issue template (requires either `createRelease` or `remoteClient`), when `true` is provided we'll use the default template: "🎉 _This issue has been resolved in %v. See [%s](%u) for release notes._" */
   commentIssues?: boolean | string;
@@ -230,7 +230,7 @@ export interface VersionCommandOption {
   gitTagCommand?: string;
 
   /** Defaults to 'origin', push git changes to the specified remote. */
-  gitRemote: string;
+  gitRemote?: string;
 
   /**
    * Ignore changes in files matched by glob(s) when detecting changed packages.

--- a/packages/core/src/utils/config-chain.ts
+++ b/packages/core/src/utils/config-chain.ts
@@ -160,7 +160,7 @@ export class ConfigChain {
     name = name || file;
     const marker = { __source__: name };
 
-    this.sources[name] = { path: file, type: type };
+    this.sources[name] = { path: file, type };
     this.list.push(marker as any);
 
     try {

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -425,7 +425,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
   detectCanaryVersions() {
     const { cwd } = this.execOpts;
-    const { bump = 'prepatch', preid = 'alpha', ignoreChanges, forcePublish, includeMergedTags } = this.options;
+    const { bump, preid = 'alpha', ignoreChanges, forcePublish, includeMergedTags } = this.options;
     // 'prerelease' and 'prepatch' are identical, for our purposes
     const release = bump.startsWith('pre') ? bump.replace('release', 'patch') : `pre${bump}`;
 

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -425,7 +425,7 @@ export class PublishCommand extends Command<PublishCommandOption> {
 
   detectCanaryVersions() {
     const { cwd } = this.execOpts;
-    const { bump, preid = 'alpha', ignoreChanges, forcePublish, includeMergedTags } = this.options;
+    const { bump = 'prepatch', preid = 'alpha', ignoreChanges, forcePublish, includeMergedTags } = this.options;
     // 'prerelease' and 'prepatch' are identical, for our purposes
     const release = bump.startsWith('pre') ? bump.replace('release', 'patch') : `pre${bump}`;
 

--- a/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.ts
+++ b/packages/version/src/conventional-commits/__fixtures__/fixed/scripts/local-preset-async.ts
@@ -5,8 +5,8 @@ import writer from './writer-opts.js';
 
 export default async function createPreset(_config: any) {
   return {
-    parser: parser,
-    writer: writer,
+    parser,
+    writer,
     whatBump,
   };
 }

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -114,7 +114,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       changelogIncludeCommitsClientLogin,
       changelogIncludeCommitsGitAuthor,
       commitHooks = true,
-      gitRemote = 'origin',
+      gitRemote,
       gitTagVersion = true,
       granularPathspec = true,
       push = true,
@@ -950,7 +950,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       const client = this.releaseClient || (await createReleaseClient(clientType));
       const {
         dryRun = false,
-        gitRemote = 'origin',
+        gitRemote,
         tagVersionPrefix = 'v',
         commentIssues,
         commentPullRequests,

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -114,7 +114,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       changelogIncludeCommitsClientLogin,
       changelogIncludeCommitsGitAuthor,
       commitHooks = true,
-      gitRemote,
+      gitRemote = 'origin',
       gitTagVersion = true,
       granularPathspec = true,
       push = true,
@@ -311,7 +311,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
 
       this.commitsSinceLastRelease = await getCommitsSinceLastRelease(
         remoteClient,
-        this.options.gitRemote,
+        this.options.gitRemote || 'origin',
         this.currentBranch,
         isIndependent,
         this.execOpts
@@ -414,7 +414,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
             releaseNotes: this.releaseNotes,
           },
           {
-            gitRemote: this.options.gitRemote,
+            gitRemote: this.options.gitRemote || 'origin',
             execOpts: this.execOpts,
             releaseFooterMessage: this.options.releaseFooterMessage,
             releaseHeaderMessage: this.options.releaseHeaderMessage,
@@ -950,7 +950,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       const client = this.releaseClient || (await createReleaseClient(clientType));
       const {
         dryRun = false,
-        gitRemote,
+        gitRemote = 'origin',
         tagVersionPrefix = 'v',
         commentIssues,
         commentPullRequests,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,8 +152,8 @@ importers:
         specifier: ^0.47.0
         version: 0.47.0
       oxlint:
-        specifier: ~1.47.0
-        version: 1.47.0(oxlint-tsgolint@0.22.1)
+        specifier: ^1.62.0
+        version: 1.63.0(oxlint-tsgolint@0.22.1)
       oxlint-tsgolint:
         specifier: ^0.22.1
         version: 0.22.1
@@ -1103,116 +1103,116 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.47.0':
-    resolution: {integrity: sha512-UHqo3te9K/fh29brCuQdHjN+kfpIi9cnTPABuD5S9wb9ykXYRGTOOMVuSV/CK43sOhU4wwb2nT1RVjcbrrQjFw==}
+  '@oxlint/binding-android-arm-eabi@1.63.0':
+    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.47.0':
-    resolution: {integrity: sha512-xh02lsTF1TAkR+SZrRMYHR/xCx8Wg2MAHxJNdHVpAKELh9/yE9h4LJeqAOBbIb3YYn8o/D97U9VmkvkfJfrHfw==}
+  '@oxlint/binding-android-arm64@1.63.0':
+    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.47.0':
-    resolution: {integrity: sha512-OSOfNJqabOYbkyQDGT5pdoL+05qgyrmlQrvtCO58M4iKGEQ/xf3XkkKj7ws+hO+k8Y4VF4zGlBsJlwqy7qBcHA==}
+  '@oxlint/binding-darwin-arm64@1.63.0':
+    resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.47.0':
-    resolution: {integrity: sha512-hP2bOI4IWNS+F6pVXWtRshSTuJ1qCRZgDgVUg6EBUqsRy+ExkEPJkx+YmIuxgdCduYK1LKptLNFuQLJP8voPbQ==}
+  '@oxlint/binding-darwin-x64@1.63.0':
+    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.47.0':
-    resolution: {integrity: sha512-F55jIEH5xmGu7S661Uho8vGiLFk0bY3A/g4J8CTKiLJnYu/PSMZ2WxFoy5Hji6qvFuujrrM9Q8XXbMO0fKOYPg==}
+  '@oxlint/binding-freebsd-x64@1.63.0':
+    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.47.0':
-    resolution: {integrity: sha512-wxmOn/wns/WKPXUC1fo5mu9pMZPVOu8hsynaVDrgmmXMdHKS7on6bA5cPauFFN9tJXNdsjW26AK9lpfu3IfHBQ==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.47.0':
-    resolution: {integrity: sha512-KJTmVIA/GqRlM2K+ZROH30VMdydEU7bDTY35fNg3tOPzQRIs2deLZlY/9JWwdWo1F/9mIYmpbdCmPqtKhWNOPg==}
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.47.0':
-    resolution: {integrity: sha512-PF7ELcFg1GVlS0X0ZB6aWiXobjLrAKer3T8YEkwIoO8RwWiAMkL3n3gbleg895BuZkHVlJ2kPRUwfrhHrVkD1A==}
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+    resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-musl@1.47.0':
-    resolution: {integrity: sha512-4BezLRO5cu0asf0Jp1gkrnn2OHiXrPPPEfBTxq1k5/yJ2zdGGTmZxHD2KF2voR23wb8Elyu3iQawXo7wvIZq0Q==}
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
+    resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.47.0':
-    resolution: {integrity: sha512-aI5ds9jq2CPDOvjeapiIj48T/vlWp+f4prkxs+FVzrmVN9BWIj0eqeJ/hV8WgXg79HVMIz9PU6deI2ki09bR1w==}
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.47.0':
-    resolution: {integrity: sha512-mO7ycp9Elvgt5EdGkQHCwJA6878xvo9tk+vlMfT1qg++UjvOMB8INsOCQIOH2IKErF/8/P21LULkdIrocMw9xA==}
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxlint/binding-linux-riscv64-musl@1.47.0':
-    resolution: {integrity: sha512-24D0wsYT/7hDFn3Ow32m3/+QT/1ZwrUhShx4/wRDAmz11GQHOZ1k+/HBuK/MflebdnalmXWITcPEy4BWTi7TCA==}
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxlint/binding-linux-s390x-gnu@1.47.0':
-    resolution: {integrity: sha512-8tPzPne882mtML/uy3mApvdCyuVOpthJ7xUv3b67gVfz63hOOM/bwO0cysSkPyYYFDFRn6/FnUb7Jhmsesntvg==}
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@oxlint/binding-linux-x64-gnu@1.47.0':
-    resolution: {integrity: sha512-q58pIyGIzeffEBhEgbRxLFHmHfV9m7g1RnkLiahQuEvyjKNiJcvdHOwKH2BdgZxdzc99Cs6hF5xTa86X40WzPw==}
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
+    resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/binding-linux-x64-musl@1.47.0':
-    resolution: {integrity: sha512-e7DiLZtETZUCwTa4EEHg9G+7g3pY+afCWXvSeMG7m0TQ29UHHxMARPaEQUE4mfKgSqIWnJaUk2iZzRPMRdga5g==}
+  '@oxlint/binding-linux-x64-musl@1.63.0':
+    resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/binding-openharmony-arm64@1.47.0':
-    resolution: {integrity: sha512-3AFPfQ0WKMleT/bKd7zsks3xoawtZA6E/wKf0DjwysH7wUiMMJkNKXOzYq1R/00G98JFgSU1AkrlOQrSdNNhlg==}
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.47.0':
-    resolution: {integrity: sha512-cLMVVM6TBxp+N7FldQJ2GQnkcLYEPGgiuEaXdvhgvSgODBk9ov3jed+khIXSAWtnFOW0wOnG3RjwqPh0rCuheA==}
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.47.0':
-    resolution: {integrity: sha512-VpFOSzvTnld77/Edje3ZdHgZWnlTb5nVWXyTgjD3/DKF/6t5bRRbwn3z77zOdnGy44xAMvbyAwDNOSeOdVUmRA==}
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.47.0':
-    resolution: {integrity: sha512-+q8IWptxXx2HMTM6JluR67284t0h8X/oHJgqpxH1siowxPMqZeIpAcWCUq+tY+Rv2iQK8TUugjZnSBQAVV5CmA==}
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
+    resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2279,12 +2279,12 @@ packages:
     resolution: {integrity: sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==}
     hasBin: true
 
-  oxlint@1.47.0:
-    resolution: {integrity: sha512-v7xkK1iv1qdvTxJGclM97QzN8hHs5816AneFAQ0NGji1BMUquhiDAhXpMwp8+ls16uRVJtzVHxP9pAAXblDeGA==}
+  oxlint@1.63.0:
+    resolution: {integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.11.2'
+      oxlint-tsgolint: '>=0.22.1'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -3178,61 +3178,61 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@0.22.1':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.47.0':
+  '@oxlint/binding-android-arm-eabi@1.63.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.47.0':
+  '@oxlint/binding-android-arm64@1.63.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.47.0':
+  '@oxlint/binding-darwin-arm64@1.63.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.47.0':
+  '@oxlint/binding-darwin-x64@1.63.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.47.0':
+  '@oxlint/binding-freebsd-x64@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.47.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.47.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.47.0':
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.47.0':
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.47.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.47.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.47.0':
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.47.0':
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.47.0':
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.47.0':
+  '@oxlint/binding-linux-x64-musl@1.63.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.47.0':
+  '@oxlint/binding-openharmony-arm64@1.63.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.47.0':
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.47.0':
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.47.0':
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
     optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.5':
@@ -4270,27 +4270,27 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.22.1
       '@oxlint-tsgolint/win32-x64': 0.22.1
 
-  oxlint@1.47.0(oxlint-tsgolint@0.22.1):
+  oxlint@1.63.0(oxlint-tsgolint@0.22.1):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.47.0
-      '@oxlint/binding-android-arm64': 1.47.0
-      '@oxlint/binding-darwin-arm64': 1.47.0
-      '@oxlint/binding-darwin-x64': 1.47.0
-      '@oxlint/binding-freebsd-x64': 1.47.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.47.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.47.0
-      '@oxlint/binding-linux-arm64-gnu': 1.47.0
-      '@oxlint/binding-linux-arm64-musl': 1.47.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.47.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.47.0
-      '@oxlint/binding-linux-riscv64-musl': 1.47.0
-      '@oxlint/binding-linux-s390x-gnu': 1.47.0
-      '@oxlint/binding-linux-x64-gnu': 1.47.0
-      '@oxlint/binding-linux-x64-musl': 1.47.0
-      '@oxlint/binding-openharmony-arm64': 1.47.0
-      '@oxlint/binding-win32-arm64-msvc': 1.47.0
-      '@oxlint/binding-win32-ia32-msvc': 1.47.0
-      '@oxlint/binding-win32-x64-msvc': 1.47.0
+      '@oxlint/binding-android-arm-eabi': 1.63.0
+      '@oxlint/binding-android-arm64': 1.63.0
+      '@oxlint/binding-darwin-arm64': 1.63.0
+      '@oxlint/binding-darwin-x64': 1.63.0
+      '@oxlint/binding-freebsd-x64': 1.63.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
+      '@oxlint/binding-linux-arm64-gnu': 1.63.0
+      '@oxlint/binding-linux-arm64-musl': 1.63.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-musl': 1.63.0
+      '@oxlint/binding-linux-s390x-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-musl': 1.63.0
+      '@oxlint/binding-openharmony-arm64': 1.63.0
+      '@oxlint/binding-win32-arm64-msvc': 1.63.0
+      '@oxlint/binding-win32-ia32-msvc': 1.63.0
+      '@oxlint/binding-win32-x64-msvc': 1.63.0
       oxlint-tsgolint: 0.22.1
 
   p-limit@2.3.0:

--- a/scripts/lint-local-js-imports.mjs
+++ b/scripts/lint-local-js-imports.mjs
@@ -1,0 +1,102 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { styleText } from 'node:util';
+
+// temp script to check for missing ".js" extensions in relative local imports
+// related oxlint issue: https://github.com/oxc-project/oxc/issues/19431
+
+const roots = ['frameworks', 'frameworks-plugins', 'packages'];
+const excludedFolders = ['frameworks/angular-slickgrid'];
+const allowedExtPattern = /\.(js|json|mjs|vue)$/;
+const fromPattern = /from\s+['\"](\.\.?\/[^'\"]+)['\"]/g;
+
+function color(text, format) {
+  return process.stdout.isTTY ? styleText(format, text) : text;
+}
+
+function normalizeSlashes(value) {
+  return value.replaceAll('\\', '/');
+}
+
+function isExcluded(fullPath) {
+  const normalized = normalizeSlashes(fullPath);
+  return excludedFolders.some((excludedPath) => normalized === excludedPath || normalized.startsWith(`${excludedPath}/`));
+}
+
+/** @param {string} dir */
+function walk(dir, acc) {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (isExcluded(fullPath)) {
+        continue;
+      }
+      if (entry.name === 'node_modules' || entry.name === 'generated-parser' || entry.name === 'dist') {
+        continue;
+      }
+      walk(fullPath, acc);
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.ts')) {
+      acc.push(fullPath);
+    }
+  }
+}
+
+const files = [];
+for (const root of roots) {
+  walk(root, files);
+}
+
+const scopedFiles = files.filter((filePath) => {
+  if (filePath.startsWith(`packages${path.sep}`)) {
+    return filePath.includes(`${path.sep}src${path.sep}`);
+  }
+  return true;
+});
+
+const errors = [];
+for (const filePath of scopedFiles) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    fromPattern.lastIndex = 0;
+
+    for (let match = fromPattern.exec(line); match !== null; match = fromPattern.exec(line)) {
+      const importPath = match[1];
+      if (!allowedExtPattern.test(importPath)) {
+        errors.push({
+          filePath,
+          lineNumber: i + 1,
+          line: line.trim(),
+        });
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(color(`Found ${errors.length} relative imports missing a file extension (.js, .json, .mjs, or .vue).`, ['red', 'bold']));
+  console.error(color('Add the appropriate extension to the import path in the following lines:', 'yellow'));
+  console.error('');
+
+  for (const error of errors) {
+    console.error(`${color('', 'red')}${color(`${error.filePath}:${error.lineNumber}`, 'cyan')}`);
+    console.error(` - ${color(`${error.line}`, 'red')}`);
+    console.error('');
+  }
+
+  console.error('');
+  console.error(color(`Total violations: ${errors.length}`, ['red', 'bold']));
+  process.exit(1);
+}
+
+console.log(color('All relative imports have file extensions.', 'green'));

--- a/scripts/lint-local-js-imports.mjs
+++ b/scripts/lint-local-js-imports.mjs
@@ -84,7 +84,9 @@ for (const filePath of scopedFiles) {
 }
 
 if (errors.length > 0) {
-  console.error(color(`Found ${errors.length} relative imports missing a file extension (.js, .json, .mjs, or .vue).`, ['red', 'bold']));
+  console.error(
+    color(`Found ${errors.length} relative imports missing a file extension (.js, .json, .mjs, or .vue).`, ['red', 'bold'])
+  );
   console.error(color('Add the appropriate extension to the import path in the following lines:', 'yellow'));
   console.error('');
 

--- a/scripts/lint-local-js-imports.mjs
+++ b/scripts/lint-local-js-imports.mjs
@@ -5,8 +5,8 @@ import { styleText } from 'node:util';
 // temp script to check for missing ".js" extensions in relative local imports
 // related oxlint issue: https://github.com/oxc-project/oxc/issues/19431
 
-const roots = ['frameworks', 'frameworks-plugins', 'packages'];
-const excludedFolders = ['frameworks/angular-slickgrid'];
+const roots = ['e2e', 'helpers', 'packages'];
+const excludedFolders = [];
 const allowedExtPattern = /\.(js|json|mjs|vue)$/;
 const fromPattern = /from\s+['\"](\.\.?\/[^'\"]+)['\"]/g;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add a temp script to check for missing `.js` extension in local imports

## Motivation and Context

add a temp script to check for missing `.js` extensions in relative local imports, so that I can later update oxlint to latest version. I'm adding this temp script because of issue with oxlint rule "import/extensions" giving false positive errors.

related to oxlint issue: https://github.com/oxc-project/oxc/issues/19431

## How Has This Been Tested?

existing unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
