### PR TITLE
chore(npmlog,core): export wide-align and use in columnify

### DIFF
--- a/packages/core/src/utils/columnify.ts
+++ b/packages/core/src/utils/columnify.ts
@@ -1,4 +1,7 @@
-import { stripAnsi, stringWidth } from '@lerna-lite/npmlog';
+// replaces columnify package with a custom implementation to avoid a dependency and allow for better control over formatting, especially ANSI handling
+// https://github.com/timoxley/columnify/blob/master/index.js
+
+import { stripAnsi, stringWidth, alignLeft, alignRight } from '@lerna-lite/npmlog';
 
 export function columnify(data: any, options: any = {}): string {
   const opts = Object.assign(
@@ -60,16 +63,14 @@ export function columnify(data: any, options: any = {}): string {
     const align = cfg?.align === 'right' ? 'right' : 'left';
     const width = widths[col] || 0;
     const raw = String(val);
-    const visible = stripAnsi(raw);
-    const visibleWidth = stringWidth(visible);
-    // compute target code-unit length to pad to. raw.length includes ANSI
-    // sequences, so add the delta between desired visible width and actual
-    // visible width to raw.length to get the proper pad target.
-    const delta = width - visibleWidth;
-    const target = raw.length + (delta > 0 ? delta : 0);
-    if (target <= raw.length) return raw;
-    if (align === 'right') return raw.padStart(target, ' ');
-    return raw.padEnd(target, ' ');
+
+    // Delegate alignment to npmlog's wideAlign helpers which
+    // correctly account for ANSI sequences and wide characters.
+    if (align === 'right') {
+      return alignRight(raw, width);
+    }
+
+    return alignLeft(raw, width);
   };
 
   const lines: string[] = [];

--- a/packages/npmlog/src/index.ts
+++ b/packages/npmlog/src/index.ts
@@ -1,3 +1,5 @@
 export * from './npmlog.js';
 export * from './gauge/has-unicode.js';
 export * from './ansi-width.js';
+export * from './gauge/wide-align.js';
+export { wideTruncate } from './gauge/wide-truncate.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

follow-up of previous PR #1330 

## Motivation and Context

Exported the named alignment helpers from index.ts and replaced the manual padding in columnify.ts to call `alignLeft`/`alignRight` from `@lerna-lite/npmlog`; this centralizes ANSI- and wide-character width handling (via `fast-string-width`), removes duplicated padding logic, and ensures consistent alignment across packages. I ran the columnify tests and updated snapshots where alignment semantics changed.

## How Has This Been Tested?

existing tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
