### PR TITLE
feat(deps): drop tinyglobby replace with native code

### DIFF
--- a/helpers/npm/index.ts
+++ b/helpers/npm/index.ts
@@ -1,5 +1,5 @@
 import { globSync, lstatSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve as pathResolve } from 'node:path';
 
 import { loadJsonFile } from 'load-json-file';
 
@@ -22,11 +22,11 @@ export function loadManifests(cwd) {
     withFileTypes: false,
   }).filter((file) => {
     try {
-      return !lstatSync(resolve(cwd, file)).isSymbolicLink();
+      return !lstatSync(pathResolve(cwd, file)).isSymbolicLink();
     } catch {
       return false;
     }
   });
 
-  return Promise.all(files.sort().map((fp) => loadJsonFile(resolve(cwd, fp))));
+  return Promise.all(files.sort().map((fp) => loadJsonFile(pathResolve(cwd, fp))));
 }

--- a/helpers/npm/index.ts
+++ b/helpers/npm/index.ts
@@ -1,20 +1,32 @@
+import { globSync, lstatSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { loadJsonFile } from 'load-json-file';
-import { glob } from 'tinyglobby';
 
 export function loadManifests(cwd) {
-  return glob(
-    [
-      // all child packages, at any level
-      '**/package.json',
-      // but not the root
-      '!package.json',
-      // and not installed
-      '!**/node_modules',
-    ],
-    {
-      cwd,
-      absolute: true,
-      followSymbolicLinks: false,
+  const patterns = [
+    // all child packages, at any level
+    '**/package.json',
+    // but not the root
+    '!package.json',
+    // and not installed
+    '!**/node_modules',
+  ];
+
+  const positivePatterns = patterns.filter((pattern) => !pattern.startsWith('!'));
+  const negativePatterns = patterns.filter((pattern) => pattern.startsWith('!')).map((pattern) => pattern.slice(1));
+
+  const files = globSync(positivePatterns, {
+    cwd,
+    exclude: ['**/.git/**', '**/.git', '**/node_modules/**', '**/node_modules', ...negativePatterns],
+    withFileTypes: false,
+  }).filter((file) => {
+    try {
+      return !lstatSync(resolve(cwd, file)).isSymbolicLink();
+    } catch {
+      return false;
     }
-  ).then((files) => Promise.all(files.sort().map((fp) => loadJsonFile(fp))));
+  });
+
+  return Promise.all(files.sort().map((fp) => loadJsonFile(resolve(cwd, fp))));
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "remove-glob": "^1.2.0",
     "semver": "catalog:",
     "tinyexec": "catalog:dependencies",
-    "tinyglobby": "catalog:dependencies",
     "tslib": "^2.8.1",
     "vitest": "^5.0.0-beta.3",
     "write-json-file": "catalog:dependencies"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,6 @@
     "npm-package-arg": "catalog:",
     "semver": "catalog:",
     "tinyexec": "catalog:dependencies",
-    "tinyglobby": "catalog:dependencies",
     "write-file-atomic": "^7.0.1",
     "write-json-file": "catalog:dependencies",
     "yaml": "catalog:dependencies",

--- a/packages/core/src/__tests__/child-process.spec.ts
+++ b/packages/core/src/__tests__/child-process.spec.ts
@@ -3,7 +3,7 @@ import { constants } from 'node:os';
 import { log } from '@lerna-lite/npmlog';
 import { describe, expect, it, vi } from 'vitest';
 
-import { exec, execSync, getChildProcessCount, getExitCode, spawn, spawnStreaming } from '../child-process.js';
+import { exec, execSync, getChildProcessCount, getExitCode, spawn, spawnStreaming, logExecCommand } from '../child-process.js';
 import { colorize } from '../index.js';
 import type { Package } from '../package.js';
 
@@ -265,6 +265,15 @@ describe('childProcess', () => {
 
     it('throws TypeError for unexpected exit code values', () => {
       expect(() => getExitCode({} as any)).toThrow(TypeError);
+    });
+  });
+
+  describe('logExecCommand()', () => {
+    it('handles array command/args gracefully', () => {
+      const logSpy = vi.spyOn(log, 'info');
+      // call with array command to hit Array.isArray branch
+      (logExecCommand as any)(['echo', '-n'], ['one', 'two']);
+      expect(logSpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/project/__tests__/make-file-finder.spec.ts
+++ b/packages/core/src/project/__tests__/make-file-finder.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+// Mock node:fs before importing the module under test to allow replacing
+// functions like globSync which are non-configurable in ESM module namespace.
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    globSync: vi.fn((_pattern: any, _opts: any) => ['pkg1/file.txt', 'pkg2/file.txt', 'pkg-link/file.txt']),
+    lstatSync: vi.fn((p: any) => ({ isSymbolicLink: () => String(p).includes('pkg-link') })),
+    statSync: vi.fn((p: any) => ({ isDirectory: () => String(p).includes('pkg1') })),
+  } as any;
+});
+
+import { isAbsolute } from 'node:path';
+
+import { makeSyncFileFinder } from '../../project/lib/make-file-finder.js';
+
+describe('make-file-finder (native glob adapter)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when package config uses ** and node_modules', () => {
+    expect(() => makeSyncFileFinder('/root', ['node_modules/**'])).toThrow(/node_modules/);
+  });
+
+  it('filters symlinks and non-directories correctly and returns absolute paths when requested', () => {
+    const root = '/tmp/project';
+    const packageConfigs = ['packages/*'];
+    const finder = makeSyncFileFinder(root, packageConfigs);
+
+    // The mocked node:fs implementation above applies
+    const results = finder('file.txt', (v) => v, { cwd: root, onlyDirectories: true, followSymbolicLinks: false, absolute: true } as any);
+
+    // Should only include pkg1 (pkg2 is file, pkg-link filtered due to symlink)
+    expect(results.length).toBeGreaterThan(0);
+    // Use path.isAbsolute so tests work on Windows and POSIX
+    expect(results.every((r) => isAbsolute(r))).toBe(true);
+    expect(results.some((r) => r.includes('pkg1'))).toBe(true);
+    expect(results.every((r) => !r.includes('pkg-link'))).toBe(true);
+  });
+
+  it('forwards caseSensitiveMatch to the native glob options', async () => {
+    const fs = await import('node:fs');
+    const root = '/tmp/project';
+    const packageConfigs = ['packages/*'];
+    const finder = makeSyncFileFinder(root, packageConfigs);
+
+    // call with caseSensitiveMatch set
+    finder('file.txt', undefined as any, { cwd: root, caseSensitiveMatch: true } as any);
+
+    expect((fs as any).globSync).toHaveBeenCalled();
+    const calledOpts = (fs as any).globSync.mock.calls[0][1];
+    expect(calledOpts.caseSensitiveMatch).toBe(true);
+  });
+
+  it('does not lstat when followSymbolicLinks is not false (explicit override)', async () => {
+    const root = '/tmp/project';
+    const packageConfigs = ['packages/*'];
+    const finder = makeSyncFileFinder(root, packageConfigs);
+
+    // pass followSymbolicLinks: true via custom options (overrides defaults)
+    const results = finder('file.txt', undefined as any, { cwd: root, followSymbolicLinks: true } as any);
+
+    // globSync returned entries and when followSymbolicLinks is true we should not filter symlinks
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.includes('pkg-link'))).toBe(true);
+  });
+});

--- a/packages/core/src/project/lib/make-file-finder.ts
+++ b/packages/core/src/project/lib/make-file-finder.ts
@@ -2,6 +2,7 @@ import type { GlobOptions as NativeGlobOptions } from 'node:fs';
 import { globSync, lstatSync, statSync } from 'node:fs';
 import { normalize as pathNormalize, posix, resolve } from 'node:path';
 
+import { tryOrFalse } from '../../utils/fs-utils.js';
 import { pMap } from '../../utils/p-map.js';
 import { ValidationError } from '../../validation-error.js';
 
@@ -71,11 +72,7 @@ function globFiles(pattern: string | readonly string[], options: any) {
     .filter((result) => {
       const absolutePath = resolve(cwd, result);
       if (options.followSymbolicLinks === false) {
-        try {
-          return !lstatSync(absolutePath).isSymbolicLink();
-        } catch {
-          return false;
-        }
+        return tryOrFalse(() => !lstatSync(absolutePath).isSymbolicLink());
       }
       return true;
     })
@@ -84,11 +81,7 @@ function globFiles(pattern: string | readonly string[], options: any) {
         return true;
       }
 
-      try {
-        return statSync(resolve(cwd, result)).isDirectory();
-      } catch {
-        return false;
-      }
+      return tryOrFalse(() => statSync(resolve(cwd, result)).isDirectory());
     })
     .map((result) => (options.absolute ? resolve(cwd, result) : result));
 }
@@ -97,7 +90,7 @@ export function makeFileFinder(rootPath: string, packageConfigs: string[]) {
   const globOpts = getGlobOpts(rootPath, packageConfigs);
 
   return (fileName: string, fileMapper: any, customGlobOpts?: any) => {
-    const options = Object.assign({}, customGlobOpts, globOpts);
+    const options = Object.assign({}, globOpts, customGlobOpts);
     const promise = pMap(
       Array.from(packageConfigs).sort(),
       (globPath: string) => {
@@ -131,7 +124,7 @@ export function makeSyncFileFinder(rootPath: string, packageConfigs: string[]) {
     fileMapper: (value: string, index: number, array: string[]) => any,
     customGlobOpts?: NativeGlobOptions
   ) => {
-    const options: any = Object.assign({}, customGlobOpts, globOpts);
+    const options: any = Object.assign({}, globOpts, customGlobOpts);
     const patterns = packageConfigs.map((globPath) => posix.join(globPath, fileName)).sort();
 
     let results: string[] = globFiles(patterns, options);

--- a/packages/core/src/project/lib/make-file-finder.ts
+++ b/packages/core/src/project/lib/make-file-finder.ts
@@ -1,7 +1,6 @@
-import { normalize as pathNormalize, posix } from 'node:path';
-
-import type { GlobOptions as TinyGlobbyOptions } from 'tinyglobby';
-import { glob, globSync } from 'tinyglobby';
+import type { GlobOptions as NativeGlobOptions } from 'node:fs';
+import { globSync, lstatSync, statSync } from 'node:fs';
+import { normalize as pathNormalize, posix, resolve } from 'node:path';
 
 import { pMap } from '../../utils/p-map.js';
 import { ValidationError } from '../../validation-error.js';
@@ -19,7 +18,12 @@ function getGlobOpts(rootPath: string, packageConfigs: string[]) {
     absolute: true,
     expandDirectories: false,
     followSymbolicLinks: false,
-  } as TinyGlobbyOptions;
+  } as NativeGlobOptions & {
+    ignore?: string[];
+    absolute?: boolean;
+    onlyDirectories?: boolean;
+    followSymbolicLinks?: boolean;
+  };
 
   if (packageConfigs.some((cfg) => cfg.indexOf('**') > -1)) {
     if (packageConfigs.some((cfg) => cfg.indexOf('node_modules') > -1)) {
@@ -36,6 +40,59 @@ function getGlobOpts(rootPath: string, packageConfigs: string[]) {
   return globOpts;
 }
 
+function createGlobSyncOptions(options: any) {
+  const globOpts: any = {
+    cwd: options.cwd,
+    exclude: options.ignore,
+    withFileTypes: false,
+  };
+
+  if (globOpts.exclude === undefined) {
+    delete globOpts.exclude;
+  }
+
+  if (options.onlyDirectories || options.followSymbolicLinks === false) {
+    globOpts.withFileTypes = false;
+  }
+
+  if (options.caseSensitiveMatch !== undefined) {
+    globOpts.caseSensitiveMatch = options.caseSensitiveMatch;
+  }
+
+  return globOpts;
+}
+
+function globFiles(pattern: string | readonly string[], options: any) {
+  const globOpts = createGlobSyncOptions(options);
+  const results = globSync(pattern, globOpts as NativeGlobOptions & { withFileTypes?: false }) as string[];
+  const cwd = options.cwd || process.cwd();
+
+  return results
+    .filter((result) => {
+      const absolutePath = resolve(cwd, result);
+      if (options.followSymbolicLinks === false) {
+        try {
+          return !lstatSync(absolutePath).isSymbolicLink();
+        } catch {
+          return false;
+        }
+      }
+      return true;
+    })
+    .filter((result) => {
+      if (!options.onlyDirectories) {
+        return true;
+      }
+
+      try {
+        return statSync(resolve(cwd, result)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .map((result) => (options.absolute ? resolve(cwd, result) : result));
+}
+
 export function makeFileFinder(rootPath: string, packageConfigs: string[]) {
   const globOpts = getGlobOpts(rootPath, packageConfigs);
 
@@ -44,9 +101,9 @@ export function makeFileFinder(rootPath: string, packageConfigs: string[]) {
     const promise = pMap(
       Array.from(packageConfigs).sort(),
       (globPath: string) => {
-        let chain: Promise<any> = glob(posix.join(globPath, fileName), options);
+        let chain: Promise<any> = Promise.resolve(globFiles(posix.join(globPath, fileName), options));
 
-        // fast-glob does not respect pattern order, so we re-sort by absolute path
+        // native glob may not preserve pattern order, so we re-sort by absolute path
         chain = chain.then((results) => results.sort());
 
         // POSIX results always need to be normalized
@@ -72,15 +129,16 @@ export function makeSyncFileFinder(rootPath: string, packageConfigs: string[]) {
   return (
     fileName: string,
     fileMapper: (value: string, index: number, array: string[]) => any,
-    customGlobOpts?: TinyGlobbyOptions
+    customGlobOpts?: NativeGlobOptions
   ) => {
-    const options: TinyGlobbyOptions = Object.assign({}, customGlobOpts, globOpts);
+    const options: any = Object.assign({}, customGlobOpts, globOpts);
     const patterns = packageConfigs.map((globPath) => posix.join(globPath, fileName)).sort();
 
-    let results: string[] = globSync(patterns, options);
+    let results: string[] = globFiles(patterns, options);
 
     // POSIX results always need to be normalized
     results = normalize(results);
+    results = results.sort();
 
     if (fileMapper) {
       results = results.map(fileMapper);

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { globSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, normalize, resolve as pathResolve } from 'node:path';
 
 import { log } from '@lerna-lite/npmlog';
@@ -6,7 +6,6 @@ import dedent from 'dedent';
 import JSON5 from 'json5';
 import { lilconfigSync } from 'lilconfig';
 import { loadJsonFile, loadJsonFileSync } from 'load-json-file';
-import { globSync } from 'tinyglobby';
 import { writeJsonFile } from 'write-json-file';
 
 import { globParent } from '../glob-utils/glob-parent.js';
@@ -31,6 +30,7 @@ export class Project {
   rootPath: string;
   static PACKAGE_GLOB = 'packages/*';
   static LICENSE_GLOB = 'LICEN{S,C}E{,.*}';
+  static LICENSE_FILE_RE = /^licen[sc]e(?:\..*)?$/i;
 
   /**
    * @param {string} [cwd] Defaults to process.cwd()
@@ -161,19 +161,14 @@ export class Project {
     let licensePath: string | undefined;
 
     try {
-      const search = globSync(Project.LICENSE_GLOB, {
+      const search = globSync('*', {
         cwd: this.rootPath,
-        absolute: true,
-        caseSensitiveMatch: false,
-        // Project license is always a sibling of the root manifest
-        deep: 0,
-      });
+      }).filter((file) => Project.LICENSE_FILE_RE.test(file));
 
       licensePath = search.shift();
 
       if (licensePath) {
-        // POSIX results always need to be normalized
-        licensePath = normalize(licensePath);
+        licensePath = normalize(pathResolve(this.rootPath, licensePath));
 
         // redefine getter to lazy-loaded value
         Object.defineProperty(this, 'licensePath', {
@@ -221,7 +216,9 @@ export class Project {
   }
 
   getPackageLicensePaths(): Promise<string[]> {
-    return this.fileFinder(Project.LICENSE_GLOB, null, { caseSensitiveMatch: false });
+    return this.fileFinder('*', null).then((paths: string[]) =>
+      paths.filter((path) => Project.LICENSE_FILE_RE.test(path.replace(/^.*[\\/]/, '')))
+    );
   }
 
   isIndependent() {

--- a/packages/core/src/utils/__tests__/fs-utils.spec.ts
+++ b/packages/core/src/utils/__tests__/fs-utils.spec.ts
@@ -23,6 +23,7 @@ import {
   writeJsonSync,
   pathExists,
   pathExistsSync,
+  tryOrFalse,
 } from '../fs-utils.js';
 
 const TEST_DIR_PREFIX = join(tmpdir(), 'fs-utils-test-');
@@ -162,5 +163,18 @@ describe('fs-utils', () => {
     await writeJson(file2, { b: 2 });
     expect(readJsonSync(file1)).toEqual({ a: 1 });
     expect(await readJson(file2)).toEqual({ b: 2 });
+  });
+
+  it('tryOrFalse returns predicate result when predicate succeeds', () => {
+    expect(tryOrFalse(() => true)).toBe(true);
+    expect(tryOrFalse(() => false)).toBe(false);
+  });
+
+  it('tryOrFalse returns false when predicate throws', () => {
+    expect(
+      tryOrFalse(() => {
+        throw new Error('boom');
+      })
+    ).toBe(false);
   });
 });

--- a/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/collect-updates.spec.ts
@@ -13,7 +13,7 @@ vi.mock('../lib/make-diff-predicate');
 
 const { globMock } = vi.hoisted(() => ({ globMock: vi.fn() }));
 vi.mock('glob', async () => ({
-  ...(await vi.importActual('tinyglobby')),
+  ...(await vi.importActual('node:fs')),
   globSync: globMock,
 }));
 

--- a/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
+++ b/packages/core/src/utils/collect-updates/__tests__/lib-make-diff-predicate.spec.ts
@@ -6,15 +6,12 @@ import { diffWorkspaceCatalog, makeDiffPredicate } from '../lib/make-diff-predic
 
 vi.mock('../../../child-process');
 
-const { globMock } = vi.hoisted(() => ({ globMock: vi.fn() }));
-vi.mock('tinyglobby', async () => ({
-  ...(await vi.importActual('tinyglobby')),
-  globSync: globMock,
-}));
+const { globSyncMock } = vi.hoisted(() => ({ globSyncMock: vi.fn() }));
 const { existsFileMock } = vi.hoisted(() => ({ existsFileMock: vi.fn() }));
 const { readFileMock } = vi.hoisted(() => ({ readFileMock: vi.fn() }));
 vi.mock('node:fs', async () => ({
   ...(await vi.importActual('node:fs')),
+  globSync: globSyncMock,
   existsSync: existsFileMock,
   readFileSync: readFileMock,
 }));
@@ -24,6 +21,7 @@ function setup(changes: string | string[]) {
 }
 
 beforeEach(() => {
+  globSyncMock.mockReset();
   readFileMock.mockReset();
   (childProcesses.execSync as Mock).mockReset();
 });
@@ -102,7 +100,7 @@ test('ignore changes (match base)', () => {
 });
 
 test('exclude subpackages when --independent-subpackages option is enabled and nested package.json is found', () => {
-  globMock.mockReturnValueOnce(['packages/pkg-2/and-another-thing/package.json']);
+  globSyncMock.mockReturnValueOnce(['packages/pkg-2/and-another-thing/package.json']);
 
   setup(['packages/pkg-2/package.json', 'packages/pkg-2/do-a-thing/index.js', 'packages/pkg-2/and-another-thing/package.json']);
 
@@ -126,7 +124,7 @@ test('exclude subpackages when --independent-subpackages option is enabled and n
 });
 
 test('not exclude any subpackages when --independent-subpackages option is enabled but no nested package.json are found', () => {
-  globMock.mockReturnValueOnce([]);
+  globSyncMock.mockReturnValueOnce([]);
 
   setup(['packages/pkg-2/package.json', 'packages/pkg-2/do-a-thing/index.js', 'packages/pkg-2/and-another-thing/method.js']);
 

--- a/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
+++ b/packages/core/src/utils/collect-updates/lib/make-diff-predicate.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { globSync } from 'node:fs';
 import { basename, dirname, join, relative } from 'node:path';
 
 import { log } from '@lerna-lite/npmlog';
-import { globSync } from 'tinyglobby';
 import zeptomatch from 'zeptomatch';
 
 import { execSync } from '../../../child-process.js';
@@ -146,8 +146,7 @@ function diffSinceIn(committish: string, location: string, execOpts: ExecOpts, d
     if (diffOpts?.independentSubpackages) {
       independentSubpackages = globSync('**/*/package.json', {
         cwd: formattedLocation,
-        onlyDirectories: false,
-        ignore: ['**/node_modules/**'],
+        exclude: ['**/node_modules/**'],
       }).map((file) => `:^${formattedLocation}/${dirname(file)}`);
     }
 

--- a/packages/core/src/utils/fs-utils.ts
+++ b/packages/core/src/utils/fs-utils.ts
@@ -122,6 +122,23 @@ export async function remove(path: string) {
 }
 
 /**
+ * Executes a boolean predicate callback and returns its result.
+ * Returns `false` if the callback throws any error, allowing safe use
+ * in filter predicates where file-system operations may fail (e.g. on
+ * missing or inaccessible paths).
+ *
+ * @param predicate - A callback that returns a boolean value.
+ * @returns The boolean result of the callback, or `false` if it throws.
+ */
+export function tryOrFalse(predicate: () => boolean): boolean {
+  try {
+    return predicate();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Writes a JSON object to a file (async). 
  * @param file The path to the file to write.
  * @param obj The JSON object to write.

--- a/packages/core/src/utils/p-map.ts
+++ b/packages/core/src/utils/p-map.ts
@@ -1,5 +1,6 @@
 /**
  * Native Node.js replacement for the `p-map` package.
+ * https://github.com/sindresorhus/p-map
  * Maps over an iterable with an optional concurrency limit.
  */
 export async function pMap<T, R>(
@@ -16,7 +17,7 @@ export async function pMap<T, R>(
     return Promise.all(items.map((item, i) => mapper(item, i)));
   }
 
-  const results = new Array<R>(items.length);
+  const results: R[] = Array.from({ length: items.length });
   let nextIndex = 0;
   let activeCount = 0;
   let settled = false;

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "@types/yargs-parser": "catalog:devDependencies",
-    "tinyglobby": "catalog:dependencies",
     "yargs": "catalog:dependencies",
     "yargs-parser": "catalog:devDependencies"
   },

--- a/packages/exec/src/__tests__/exec-command.spec.ts
+++ b/packages/exec/src/__tests__/exec-command.spec.ts
@@ -1,9 +1,9 @@
-import { basename, join } from 'node:path';
+import { glob } from 'node:fs/promises';
+import { basename, join, resolve as pathResolve } from 'node:path';
 
 import { logOutput, spawn, spawnStreaming, type ExecCommandOption, pathExists, readJson } from '@lerna-lite/core';
 import { commandRunner, initFixtureFactory, normalizeRelativeDir } from '@lerna-test/helpers';
 import { loggingOutput } from '@lerna-test/helpers/logging-output.js';
-import { glob } from 'tinyglobby';
 import { afterEach, beforeAll, describe, expect, it, vi, type Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -260,7 +260,12 @@ describe('ExecCommand', () => {
 
       await lernaExec(cwd)('--profile', '--', 'ls');
 
-      const [profileLocation] = await glob('Lerna-Profile-*.json', { cwd, absolute: true });
+      // Convert async iterable to array
+      const files: string[] = [];
+      for await (const file of glob('Lerna-Profile-*.json', { cwd })) {
+        files.push(file);
+      }
+      const profileLocation = pathResolve(cwd, files[0]);
       const json = await readJson(profileLocation);
 
       expect(json).toMatchObject([
@@ -283,7 +288,12 @@ describe('ExecCommand', () => {
 
       await lernaExec(cwd)('--profile', '--profile-location', 'foo/bar', '--', 'ls');
 
-      const [profileLocation] = await glob('foo/bar/Lerna-Profile-*.json', { cwd, absolute: true });
+      // FIX: Added 'foo/bar/' directory mapping to match the custom output location
+      const files: string[] = [];
+      for await (const file of glob('foo/bar/Lerna-Profile-*.json', { cwd })) {
+        files.push(file);
+      }
+      const profileLocation = pathResolve(cwd, files[0]);
       const isExists = await pathExists(profileLocation);
 
       expect(isExists).toBe(true);

--- a/packages/exec/src/exec-command.ts
+++ b/packages/exec/src/exec-command.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import 'dotenv/config';
 import type { CommandType, ExecCommandOption, FilterOptions, Package, ProjectConfig } from '@lerna-lite/core';
 import {
@@ -144,7 +146,9 @@ export class ExecCommand extends Command<ExecCommandOption & FilterOptions> {
       profiler = new Profiler({
         concurrency: this.concurrency,
         log: this.logger,
-        outputDirectory: this.options.profileLocation || this.project.rootPath,
+        outputDirectory: this.options.profileLocation
+          ? resolve(this.project.rootPath, this.options.profileLocation)
+          : this.project.rootPath,
       });
 
       const callback = this.getRunner();

--- a/packages/exec/src/exec-command.ts
+++ b/packages/exec/src/exec-command.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import { resolve as pathResolve } from 'node:path';
 
 import 'dotenv/config';
 import type { CommandType, ExecCommandOption, FilterOptions, Package, ProjectConfig } from '@lerna-lite/core';
@@ -147,7 +147,7 @@ export class ExecCommand extends Command<ExecCommandOption & FilterOptions> {
         concurrency: this.concurrency,
         log: this.logger,
         outputDirectory: this.options.profileLocation
-          ? resolve(this.project.rootPath, this.options.profileLocation)
+          ? pathResolve(this.project.rootPath, this.options.profileLocation)
           : this.project.rootPath,
       });
 

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -47,8 +47,7 @@
     "pacote": "^21.5.0",
     "semver": "catalog:",
     "ssri": "^13.0.1",
-    "tar": "^7.5.15",
-    "tinyglobby": "catalog:dependencies"
+    "tar": "^7.5.15"
   },
   "devDependencies": {
     "@types/npmcli__package-json": "catalog:devDependencies",

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { realpathSync } from 'node:fs';
+import { globSync, realpathSync, statSync } from 'node:fs';
 import { EOL, tmpdir } from 'node:os';
 import { normalize, join as pathJoin, relative } from 'node:path';
 
@@ -37,7 +37,6 @@ import { pMap } from '@lerna-lite/core';
 import type { OneTimePasswordCache } from '@lerna-lite/version';
 import { getOneTimePassword, VersionCommand } from '@lerna-lite/version';
 import semver from 'semver';
-import { glob } from 'tinyglobby';
 
 import type { Tarball } from './interfaces.js';
 import { createTempLicenses } from './lib/create-temp-licenses.js';
@@ -333,13 +332,16 @@ export class PublishCommand extends Command<PublishCommandOption> {
     if (this.options.cleanupTempFiles) {
       const tempDirPath = realpathSync(tmpdir());
       const normalizedLernaPath = pathJoin(tempDirPath, 'lerna-*').replace(/\\/g, '/');
-      glob(normalizedLernaPath, { absolute: true, cwd: tempDirPath, onlyDirectories: true })
-        .then((deleteFolders) => {
-          // silently delete all files/folders that startsWith "lerna-"
-          deleteFolders.forEach((folder) => removeSync(folder));
-          this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);
-        })
-        .catch(/* v8 ignore next - do nothing */ () => {});
+      const deleteFolders = globSync(normalizedLernaPath, { withFileTypes: false }).filter((folder) => {
+        try {
+          return statSync(folder).isDirectory();
+        } catch {
+          return false;
+        }
+      });
+
+      deleteFolders.forEach((folder) => removeSync(folder));
+      this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);
     }
   }
 

--- a/packages/publish/src/publish-command.ts
+++ b/packages/publish/src/publish-command.ts
@@ -31,6 +31,7 @@ import {
   readWorkspaceCatalogConfig,
   runTopologically,
   throwIfUncommitted,
+  tryOrFalse,
   ValidationError,
 } from '@lerna-lite/core';
 import { pMap } from '@lerna-lite/core';
@@ -332,13 +333,9 @@ export class PublishCommand extends Command<PublishCommandOption> {
     if (this.options.cleanupTempFiles) {
       const tempDirPath = realpathSync(tmpdir());
       const normalizedLernaPath = pathJoin(tempDirPath, 'lerna-*').replace(/\\/g, '/');
-      const deleteFolders = globSync(normalizedLernaPath, { withFileTypes: false }).filter((folder) => {
-        try {
-          return statSync(folder).isDirectory();
-        } catch {
-          return false;
-        }
-      });
+      const deleteFolders = globSync(normalizedLernaPath, { withFileTypes: false }).filter((folder) =>
+        tryOrFalse(() => statSync(folder).isDirectory())
+      );
 
       deleteFolders.forEach((folder) => removeSync(folder));
       this.logger.verbose('publish', `Found ${deleteFolders.length} temp folders to cleanup after publish.`);

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@types/yargs-parser": "catalog:devDependencies",
     "perf_hooks": "^0.0.1",
-    "tinyglobby": "catalog:dependencies",
     "yargs": "catalog:dependencies",
     "yargs-parser": "catalog:devDependencies"
   },

--- a/packages/run/src/__tests__/run-command.spec.ts
+++ b/packages/run/src/__tests__/run-command.spec.ts
@@ -1,6 +1,8 @@
+import { glob } from 'node:fs/promises';
+import { resolve as pathResolve } from 'node:path';
+
 import { logOutput, type RunCommandOption, pathExists, readJson } from '@lerna-lite/core';
 import { commandRunner, initFixtureFactory, loggingOutput, normalizeRelativeDir } from '@lerna-test/helpers';
-import { glob } from 'tinyglobby';
 import { afterEach, beforeAll, describe, expect, it, vi, type Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -230,7 +232,15 @@ describe('RunCommand', () => {
 
       await lernaRun(cwd)('my-script', '--profile');
 
-      const [profileLocation] = await glob('Lerna-Profile-*.json', { cwd, absolute: true });
+      // Convert async iterable to array
+      const files: string[] = [];
+      for await (const file of glob('Lerna-Profile-*.json', { cwd })) {
+        files.push(file);
+      }
+
+      // Ensure a file was found before proceeding
+      expect(files.length).toBeGreaterThan(0);
+      const profileLocation = pathResolve(cwd, files[0]);
       const json = await readJson(profileLocation);
 
       expect(json).toMatchObject([
@@ -253,7 +263,15 @@ describe('RunCommand', () => {
 
       await new RunCommand(createArgv(cwd, 'my-script', '--profile', '--profile-location', 'foo/bar'));
 
-      const [profileLocation] = await glob('foo/bar/Lerna-Profile-*.json', { cwd, absolute: true });
+      // Convert async iterable to array using correct subdirectory pattern
+      const files: string[] = [];
+      for await (const file of glob('foo/bar/Lerna-Profile-*.json', { cwd })) {
+        files.push(file);
+      }
+
+      // Ensure a file was found before proceeding
+      expect(files.length).toBeGreaterThan(0);
+      const profileLocation = pathResolve(cwd, files[0]);
       const isExists = await pathExists(profileLocation);
 
       expect(isExists).toBe(true);

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
 
 import type { CommandType, FilterOptions, Package, ProjectConfig, RunCommandOption } from '@lerna-lite/core';
 import { colorize, Command, getFilteredPackages, logOutput, runTopologically, ValidationError } from '@lerna-lite/core';
@@ -173,7 +174,9 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
       profiler = new Profiler({
         concurrency: this.concurrency,
         log: this.logger,
-        outputDirectory: this.options.profileLocation,
+        outputDirectory: this.options.profileLocation
+          ? resolve(this.project.rootPath, this.options.profileLocation)
+          : this.project.rootPath,
       });
 
       const callback = this.getRunner();

--- a/packages/run/src/run-command.ts
+++ b/packages/run/src/run-command.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
+import { resolve as pathResolve } from 'node:path';
 
 import type { CommandType, FilterOptions, Package, ProjectConfig, RunCommandOption } from '@lerna-lite/core';
 import { colorize, Command, getFilteredPackages, logOutput, runTopologically, ValidationError } from '@lerna-lite/core';
@@ -175,7 +175,7 @@ export class RunCommand extends Command<RunCommandOption & FilterOptions> {
         concurrency: this.concurrency,
         log: this.logger,
         outputDirectory: this.options.profileLocation
-          ? resolve(this.project.rootPath, this.options.profileLocation)
+          ? pathResolve(this.project.rootPath, this.options.profileLocation)
           : this.project.rootPath,
       });
 

--- a/packages/watch/README.md
+++ b/packages/watch/README.md
@@ -198,7 +198,7 @@ $ lerna watch --ignored=\"/(^|[/\\])\../\" -- <command>
 > **Note** the `lerna watch` command skips `.git/`, `dist/` and `node_modules/` directories by default. If you want to watch files inside any of these directories, you can pass a negated glob pattern, that is `lerna watch --ignored=\"!**/node_modules/**\"`
 
 > [!NOTE]
-> The watch `ignored` option only accept glob patterns (string or array of strings) and then internally we use [`tinyglobby`](https://www.npmjs.com/package/tinyglobby) to find out the file list of files to watch (or ignore). Please also note that this option is no longer the same as Chokidar@4 `ignored` option because their implementation no longer accept globs but Lerna-Lite watch still do.
+> The watch `ignored` option accepts glob patterns (string or array of strings). Lerna-Lite expands those globs using Node's built-in glob functionality (`fs.globSync`) to compute the list of files to watch or ignore. Note that this behavior differs from Chokidar@4's `ignored` option, which no longer accepts globs directly.
 
 ### `--stream`
 

--- a/packages/watch/package.json
+++ b/packages/watch/package.json
@@ -35,7 +35,6 @@
     "@lerna-lite/cli": "workspace:*",
     "@lerna-lite/core": "workspace:*",
     "chokidar": "^5.0.0",
-    "tinyglobby": "catalog:dependencies",
     "zeptomatch": "catalog:dependencies"
   },
   "devDependencies": {

--- a/packages/watch/src/__tests__/posixify.spec.ts
+++ b/packages/watch/src/__tests__/posixify.spec.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { WatchCommand } from '../watch-command.js';
+
+test('posixifyPath normalizes windows-style paths and _watchedFiles contains POSIX entries', () => {
+  const testDir = mkdtempSync(join(tmpdir(), 'watch-test-'));
+
+  const pkg1 = join(testDir, 'packages', 'package-1');
+  const pkg2 = join(testDir, 'packages', 'package-2');
+
+  // create minimal package files so glob finds something
+  mkdirSync(join(pkg1, 'src'), { recursive: true });
+  mkdirSync(join(pkg2, 'src'), { recursive: true });
+  writeFileSync(join(pkg1, 'src', 'file1.txt'), 'x');
+  writeFileSync(join(pkg2, 'src', 'file2.txt'), 'y');
+
+  const cmd = new WatchCommand({} as any);
+  (cmd as any).project = { rootPath: testDir };
+  (cmd as any)._filteredPackages = [
+    { location: join(testDir, 'packages', 'package-1'), name: 'package-1' },
+    { location: join(testDir, 'packages', 'package-2'), name: 'package-2' },
+  ];
+
+  // direct posixify behavior
+  expect((cmd as any).posixifyPath('a\\b\\c')).toBe('a/b/c');
+
+  // regenerate watch paths and assert normalization
+  (cmd as any).regenerateWatchGlobPaths();
+
+  const watchedFiles = Array.from((cmd as any)._watchedFiles as Set<string>);
+  expect(watchedFiles.length).toBeGreaterThan(0);
+  for (const p of watchedFiles) {
+    expect(p).not.toContain('\\');
+  }
+});

--- a/packages/watch/src/__tests__/watch-command.spec.ts
+++ b/packages/watch/src/__tests__/watch-command.spec.ts
@@ -1,6 +1,7 @@
 import { basename, join } from 'node:path';
 
 import type { WatchCommandOption } from '@lerna-lite/core';
+import * as core from '@lerna-lite/core';
 import { spawn, spawnStreaming } from '@lerna-lite/core';
 import { commandRunner, initFixtureFactory, normalizeRelativeDir } from '@lerna-test/helpers';
 import { watch as chokidarWatch } from 'chokidar';
@@ -206,6 +207,20 @@ describe('Watch Command', () => {
       expect(command.watchedFiles.has('packages/package-2/file-2.ts')).toBeTruthy();
       expect(command.watchedFiles.has('packages/package-1/package.json')).toBeFalsy();
       expect(command.watchedFiles.has('packages/package-2/package.json')).toBeFalsy();
+    });
+
+    it('should handle no packages to watch (empty package list)', async () => {
+      // construct command directly and simulate no filtered packages
+      const command = new WatchCommand(createArgv(testDir, '--debounce', '0', '--', 'echo') as WatchCommandOption);
+      (command as any).project = { rootPath: testDir };
+      // ensure getFilteredPackages returns an empty array so initialize() doesn't override our value
+      vi.spyOn(core as any, 'getFilteredPackages').mockResolvedValueOnce([]);
+      (command as any)._filteredPackages = [];
+
+      await command;
+
+      expect(chokidarWatch).toHaveBeenCalledWith([], expect.objectContaining({ cwd: testDir }));
+      expect(command.watchedFiles.size).toBe(0);
     });
 
     it('should be able to take --await-write-finish options as a boolean', async () => {

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -7,6 +7,7 @@ import {
   pluralize,
   spawn,
   spawnStreaming,
+  tryOrFalse,
   ValidationError,
   type FilterOptions,
   type Package,
@@ -129,7 +130,9 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       // Initialize chokidar watcher by adding all package folders to the watcher.
       // We'll use all directories so that when new files are being added, they will also be inspected.
       const rootPath = this.project.rootPath;
-      let pkgFolders = this._filteredPackages.map((pkg) => this.posixifyPath(pkg.location));
+      // Use native package locations for filesystem-relative calculations,
+      // then normalize to POSIX only for pattern building/matching.
+      let pkgFolders = this._filteredPackages.map((pkg) => pkg.location);
       // Filter out any empty/undefined globs.
       pkgFolders = pkgFolders.filter(Boolean);
       const relativePkgFolders = pkgFolders.map((folder) => this.posixifyPath(relative(rootPath, folder))).filter(Boolean);
@@ -141,14 +144,8 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       const foldersToWatch =
         relativePkgFolders.length > 0
           ? (globSync(relativePkgFolders, globOptions) as unknown as string[])
-              .filter((folder) => {
-                try {
-                  return statSync(join(rootPath, folder)).isDirectory();
-                } catch {
-                  return false;
-                }
-              })
-              .map((folder) => folder.replace(/\/?$/, '/'))
+              .filter((folder) => tryOrFalse(() => statSync(join(rootPath, folder)).isDirectory()))
+              .map((folder) => this.posixifyPath(folder.replace(/\/?$/, '/')))
           : [];
       this._watcher = watch(foldersToWatch, {
         ...chokidarOptions,
@@ -171,8 +168,10 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
           }
 
           // make sure that the file is in the watch before calling the callback
-          if (this._watchedFiles.has(this.posixifyPath(relativeFilePath))) {
-            return this.changeEventListener(relativeFilePath);
+          // posixify once here and reuse in changeEventListener to avoid double normalization
+          const posixRelativeFilePath = this.posixifyPath(relativeFilePath);
+          if (this._watchedFiles.has(posixRelativeFilePath)) {
+            return this.changeEventListener(posixRelativeFilePath);
           }
         })
         .on('error', (error) => this.onError(error));
@@ -190,14 +189,16 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
   protected changeEventListener(relativeFilePath: string) {
     // find the package that the filepath is associated to
     const rootPath = this.project.rootPath;
-    const pkg = this._filteredPackages.find((p) => relativeFilePath.includes(relative(rootPath, p.location)));
+    const posixRelative = this.posixifyPath(relativeFilePath);
+    const pkg = this._filteredPackages.find((p) => posixRelative.includes(this.posixifyPath(relative(rootPath, p.location))));
 
     if (pkg) {
       // changes structure sample: { '@lerna-lite/watch': { pkg: Package, changeFiles: ['path1', 'path2'] }
       if (!this._changes[pkg.name]?.changeFiles) {
         this._changes[pkg.name] = { pkg, changeFiles: new Set<string>(), timestamp: Date.now() }; // use Set to avoid duplicate entries
       }
-      this._changes[pkg.name].changeFiles.add(relativeFilePath);
+      // store POSIX-normalized relative path to match `_watchedFiles` entries
+      this._changes[pkg.name].changeFiles.add(posixRelative);
 
       return this.executeCommandCallback();
     }
@@ -331,12 +332,13 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
   protected regenerateWatchGlobPaths() {
     const rootPath = this.project.rootPath;
     const patterns: string[] = [];
+    const opts = this.options || {};
 
     this._filteredPackages.forEach((pkg) => {
       // does user have a glob defined, if so append it to the pkg location. Glob example for TS files: /**/*.ts
       let watchingPath = pkg.location;
-      if (this.options.glob) {
-        const globPattern = this.options.glob.replace(/^\/+/, '');
+      if (opts.glob) {
+        const globPattern = opts.glob.replace(/^\/+/, '');
         watchingPath = join(pkg.location, '/', globPattern); // append glob to pkg location
       } else {
         watchingPath = join(pkg.location, '/**/*');
@@ -350,14 +352,10 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
       if (this._ignoredGlobs.some((pattern) => pattern !== '**' && zeptomatch(pattern, normalized))) {
         return false;
       }
-      try {
-        return statSync(join(rootPath, path)).isFile();
-      } catch {
-        return false;
-      }
+      return tryOrFalse(() => statSync(join(rootPath, path)).isFile());
     });
 
-    this._watchedFiles = new Set(pathsToWatch);
+    this._watchedFiles = new Set(pathsToWatch.map((p) => this.posixifyPath(p)));
   }
 
   protected runCommandInPackageStreaming(pkg: Package, changedFile: string) {

--- a/packages/watch/src/watch-command.ts
+++ b/packages/watch/src/watch-command.ts
@@ -1,3 +1,4 @@
+import { globSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 import {
@@ -13,7 +14,6 @@ import {
   type WatchCommandOption,
 } from '@lerna-lite/core';
 import { watch, type ChokidarOptions, type FSWatcher } from 'chokidar';
-import { globSync } from 'tinyglobby';
 import zeptomatch from 'zeptomatch';
 
 import { CHOKIDAR_AVAILABLE_OPTIONS, DEBOUNCE_DELAY, FILE_DELIMITER } from './constants.js';
@@ -128,18 +128,31 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
 
       // Initialize chokidar watcher by adding all package folders to the watcher.
       // We'll use all directories so that when new files are being added, they will also be inspected.
+      const rootPath = this.project.rootPath;
       let pkgFolders = this._filteredPackages.map((pkg) => this.posixifyPath(pkg.location));
       // Filter out any empty/undefined globs.
       pkgFolders = pkgFolders.filter(Boolean);
+      const relativePkgFolders = pkgFolders.map((folder) => this.posixifyPath(relative(rootPath, folder))).filter(Boolean);
 
-      const globOptions: any = { onlyDirectories: true, cwd: process.cwd() };
+      const globOptions: any = { cwd: rootPath };
       if (this._ignoredGlobs && this._ignoredGlobs.length > 0) {
-        globOptions.ignore = this._ignoredGlobs;
+        globOptions.exclude = this._ignoredGlobs;
       }
-      const foldersToWatch = pkgFolders.length > 0 ? globSync(pkgFolders, globOptions) : [];
+      const foldersToWatch =
+        relativePkgFolders.length > 0
+          ? (globSync(relativePkgFolders, globOptions) as unknown as string[])
+              .filter((folder) => {
+                try {
+                  return statSync(join(rootPath, folder)).isDirectory();
+                } catch {
+                  return false;
+                }
+              })
+              .map((folder) => folder.replace(/\/?$/, '/'))
+          : [];
       this._watcher = watch(foldersToWatch, {
         ...chokidarOptions,
-        cwd: process.cwd(),
+        cwd: rootPath,
         ignored: ignoredMatchers,
       });
 
@@ -176,7 +189,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
 
   protected changeEventListener(relativeFilePath: string) {
     // find the package that the filepath is associated to
-    const rootPath = process.cwd();
+    const rootPath = this.project.rootPath;
     const pkg = this._filteredPackages.find((p) => relativeFilePath.includes(relative(rootPath, p.location)));
 
     if (pkg) {
@@ -211,7 +224,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
 
           // execute command callback when file changes are found
           if (change.changeFiles?.size > 0) {
-            const changedFiles = Array.from<string>(change.changeFiles).map((f) => join(process.cwd(), f));
+            const changedFiles = Array.from<string>(change.changeFiles).map((f) => join(this.project.rootPath, f));
             const changedFilesCsv = changedFiles.join(this._fileDelimiter);
 
             // make sure there's nothing in progress before executing the next callback
@@ -271,8 +284,7 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
 
   /**
    * take any path (windows/posix) and normalize it as a posix path,
-   * note that we have this in place because tinyglobby returns posix paths even on windows,
-   * see: https://github.com/SuperchupuDev/tinyglobby/issues/102
+   * note that we use normalized paths for consistent matching across platforms.
    */
   protected posixifyPath(filePath: string) {
     return filePath.replace(/\\/g, '/');
@@ -317,19 +329,35 @@ export class WatchCommand extends Command<WatchCommandOption & FilterOptions> {
   }
 
   protected regenerateWatchGlobPaths() {
+    const rootPath = this.project.rootPath;
     const patterns: string[] = [];
 
     this._filteredPackages.forEach((pkg) => {
       // does user have a glob defined, if so append it to the pkg location. Glob example for TS files: /**/*.ts
       let watchingPath = pkg.location;
       if (this.options.glob) {
-        watchingPath = join(pkg.location, '/', this.options.glob); // append glob to pkg location
+        const globPattern = this.options.glob.replace(/^\/+/, '');
+        watchingPath = join(pkg.location, '/', globPattern); // append glob to pkg location
+      } else {
+        watchingPath = join(pkg.location, '/**/*');
       }
-      const unixPath = this.posixifyPath(watchingPath);
+      const unixPath = this.posixifyPath(relative(rootPath, watchingPath));
       patterns.push(unixPath);
     });
 
-    this._watchedFiles = new Set(globSync(patterns, { cwd: process.cwd(), ignore: this._ignoredGlobs }));
+    const pathsToWatch = (globSync(patterns, { cwd: rootPath }) as unknown as string[]).filter((path) => {
+      const normalized = this.posixifyPath(path);
+      if (this._ignoredGlobs.some((pattern) => pattern !== '**' && zeptomatch(pattern, normalized))) {
+        return false;
+      }
+      try {
+        return statSync(join(rootPath, path)).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+    this._watchedFiles = new Set(pathsToWatch);
   }
 
   protected runCommandInPackageStreaming(pkg: Package, changedFile: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,6 @@ catalogs:
     tinyexec:
       specifier: ^1.2.2
       version: 1.2.2
-    tinyglobby:
-      specifier: ^0.2.16
-      version: 0.2.16
     write-json-file:
       specifier: ^7.0.0
       version: 7.0.0
@@ -163,9 +160,6 @@ importers:
       tinyexec:
         specifier: catalog:dependencies
         version: 1.2.2
-      tinyglobby:
-        specifier: catalog:dependencies
-        version: 0.2.16
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -275,9 +269,6 @@ importers:
       tinyexec:
         specifier: catalog:dependencies
         version: 1.2.2
-      tinyglobby:
-        specifier: catalog:dependencies
-        version: 0.2.16
       write-file-atomic:
         specifier: ^7.0.1
         version: 7.0.1
@@ -359,9 +350,6 @@ importers:
       '@types/yargs-parser':
         specifier: catalog:devDependencies
         version: 21.0.3
-      tinyglobby:
-        specifier: catalog:dependencies
-        version: 0.2.16
       yargs:
         specifier: catalog:dependencies
         version: 18.0.0
@@ -489,9 +477,6 @@ importers:
       tar:
         specifier: ^7.5.15
         version: 7.5.15
-      tinyglobby:
-        specifier: catalog:dependencies
-        version: 0.2.16
     devDependencies:
       '@types/npmcli__package-json':
         specifier: catalog:devDependencies
@@ -536,9 +521,6 @@ importers:
       perf_hooks:
         specifier: ^0.0.1
         version: 0.0.1
-      tinyglobby:
-        specifier: catalog:dependencies
-        version: 0.2.16
       yargs:
         specifier: catalog:dependencies
         version: 18.0.0
@@ -645,9 +627,6 @@ importers:
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
-      tinyglobby:
-        specifier: catalog:dependencies
-        version: 0.2.16
       zeptomatch:
         specifier: catalog:dependencies
         version: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,6 @@ catalogs:
   dependencies:
     load-json-file: ^7.0.1
     tinyexec: ^1.2.2
-    tinyglobby: ^0.2.16
     write-json-file: ^7.0.0
     yaml: ^2.9.0
     yargs: ^18.0.0

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -1,8 +1,6 @@
-import { realpathSync, rmSync } from 'node:fs';
+import { realpathSync, rmSync, statSync, globSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join as pathJoin } from 'node:path';
-
-import { glob } from 'tinyglobby';
 
 export function removeSync(path) {
   rmSync(path, { recursive: true, force: true });
@@ -11,12 +9,14 @@ export function removeSync(path) {
 const tempDirPath = realpathSync(tmpdir());
 const normalizedLernaPath = pathJoin(tempDirPath, 'lerna-*').replace(/\\/g, '/');
 console.log('cleanup Lerna temp folders from', normalizedLernaPath);
-glob(normalizedLernaPath, { absolute: true, cwd: tempDirPath, onlyDirectories: true })
-  .then((deleteFolders) => {
-    // silently delete all files/folders that startsWith "lerna-"
-    console.log(`Found ${deleteFolders.length} temp folders to cleanup.`);
-    deleteFolders.forEach((folder) => removeSync(folder));
-  })
-  .catch((error) => {
-    console.error('Error occurred while cleaning up temp folders:', error);
-  });
+const deleteFolders = globSync('lerna-*', { cwd: tempDirPath, absolute: true });
+const directoryFolders = deleteFolders.filter((folder) => {
+  try {
+    return statSync(folder).isDirectory();
+  } catch {
+    return false;
+  }
+});
+
+console.log(`Found ${directoryFolders.length} temp folders to cleanup.`);
+directoryFolders.forEach((folder) => removeSync(folder));

--- a/scripts/cleanup-temp-files.mjs
+++ b/scripts/cleanup-temp-files.mjs
@@ -7,9 +7,8 @@ export function removeSync(path) {
 }
 
 const tempDirPath = realpathSync(tmpdir());
-const normalizedLernaPath = pathJoin(tempDirPath, 'lerna-*').replace(/\\/g, '/');
-console.log('cleanup Lerna temp folders from', normalizedLernaPath);
-const deleteFolders = globSync('lerna-*', { cwd: tempDirPath, absolute: true });
+console.log('cleanup Lerna temp folders from', pathJoin(tempDirPath, 'lerna-*'));
+const deleteFolders = globSync('lerna-*', { cwd: tempDirPath }).map((f) => pathJoin(tempDirPath, f));
 const directoryFolders = deleteFolders.filter((folder) => {
   try {
     return statSync(folder).isDirectory();


### PR DESCRIPTION
## Summary 
**Removed packages:** 
`tinyglobby`

**Native replacements:**
`tinyglobby` replaced with native NodeJS code

## Files changed

- publish-command.ts
- index.ts
- fs-utils.ts
- make-file-finder.ts
- project.ts
- watch-command.ts
- make-diff-predicate.ts

_vibe coded with Claude Haiku 4.5 and Claude Sonnet 4.6_

drop external dependencies (3 deps) which helps decreasing build size and also potential external attacks
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies

tinyglobby install size
https://node-modules.dev/grid/depth#install=tinyglobby - 179.08Kb

## How Has This Been Tested?

existing unit tests and E2E tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
