### PR TITLE
feat(deps): drop `new-github-release-url` replace with internal code

### DIFF
--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -45,7 +45,6 @@
     "conventional-recommended-bump": "^11.2.0",
     "dedent": "catalog:",
     "git-url-parse": "^16.1.0",
-    "new-github-release-url": "^2.0.0",
     "npm-package-arg": "catalog:",
     "semver": "catalog:",
     "write-json-file": "catalog:dependencies",

--- a/packages/version/src/lib/create-release.ts
+++ b/packages/version/src/lib/create-release.ts
@@ -2,12 +2,12 @@ import type { RemoteClientType } from '@lerna-lite/core';
 import { colorize, ValidationError } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import type parseGitUrl from 'git-url-parse';
-import newGithubReleaseUrl from 'new-github-release-url';
 import semver from 'semver';
 
 import { createGitHubClient, parseGitRepo } from '../git-clients/github-client.js';
 import { createGitLabClient } from '../git-clients/gitlab-client.js';
 import type { GitClientReleaseOption, OctokitClientOutput, ReleaseCommandProps, ReleaseOptions } from '../interfaces.js';
+import newGithubReleaseUrl from './new-github-release-url.js';
 
 export async function createReleaseClient(type: 'github' | 'gitlab'): Promise<OctokitClientOutput> {
   switch (type) {

--- a/packages/version/src/lib/new-github-release-url.ts
+++ b/packages/version/src/lib/new-github-release-url.ts
@@ -1,0 +1,29 @@
+// reimplement new-github-release-url to avoid adding it as a dependency
+// https://github.com/sindresorhus/new-github-release-url
+export interface NewGithubReleaseOptions {
+  repoUrl?: string;
+  user: string;
+  repo: string;
+  tag: string;
+  target?: string;
+  title: string;
+  body: string;
+  isPrerelease: boolean | string | number;
+}
+
+export default function newGithubReleaseUrl(options: NewGithubReleaseOptions): string {
+  const repoUrl = options.repoUrl ?? `https://github.com/${options.user}/${options.repo}`;
+  const url = new URL(`${repoUrl.replace(/\/$/, '')}/releases/new`);
+  const keys = ['tag', 'target', 'title', 'body', 'isPrerelease'] as const;
+
+  for (const key of keys) {
+    const val = (options as any)[key];
+    if (val === undefined) {
+      continue;
+    }
+    const param = key === 'isPrerelease' ? 'prerelease' : key;
+    url.searchParams.set(param, String(val));
+  }
+
+  return url.toString();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,9 +554,6 @@ importers:
       git-url-parse:
         specifier: ^16.1.0
         version: 16.1.0
-      new-github-release-url:
-        specifier: ^2.0.0
-        version: 2.0.0
       npm-package-arg:
         specifier: 'catalog:'
         version: 13.0.2
@@ -2142,10 +2139,6 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  new-github-release-url@2.0.0:
-    resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   node-gyp@12.1.0:
     resolution: {integrity: sha512-W+RYA8jBnhSr2vrTtlPYPc1K+CSjGpVDRZxcqJcERZ8ND3A1ThWPHRwctTx3qC3oW99jt726jhdz3Y6ky87J4g==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2494,10 +2487,6 @@ packages:
   tuf-js@4.0.0:
     resolution: {integrity: sha512-Lq7ieeGvXDXwpoSmOSgLWVdsGGV9J4a77oDTAPe/Ltrqnnm/ETaRlBAQTH5JatEh8KXuE6sddf9qAv1Q2282Hg==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -4042,10 +4031,6 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  new-github-release-url@2.0.0:
-    dependencies:
-      type-fest: 2.19.0
-
   node-gyp@12.1.0:
     dependencies:
       env-paths: 2.2.1
@@ -4460,8 +4445,6 @@ snapshots:
       make-fetch-happen: 15.0.2
     transitivePeerDependencies:
       - supports-color
-
-  type-fest@2.19.0: {}
 
   uglify-js@3.19.3:
     optional: true


### PR DESCRIPTION
## Summary 
**Removed packages:** 
`new-github-release-url` replaced with internal implementation

Dropping an external dependency and simplify our local implementation quite a lot since we know that most inputs are already defined (e.g. user, repo, tag, body)

## Files changed

- create-release.ts
- new-github-release-url.ts

_vibe coded with ChatGPT mini 5_

## How Has This Been Tested?

existing unit tests and E2E tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.