### PR TITLE
feat(deps): drop dedent replace with native code

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,6 @@
     "@lerna-lite/core": "workspace:*",
     "@lerna-lite/init": "workspace:*",
     "@lerna-lite/npmlog": "workspace:*",
-    "dedent": "catalog:",
     "dotenv": "catalog:",
     "import-local": "^3.2.0",
     "yargs": "catalog:dependencies"

--- a/packages/cli/src/filter-options.ts
+++ b/packages/cli/src/filter-options.ts
@@ -1,5 +1,4 @@
 import { type log } from '@lerna-lite/npmlog';
-import dedent from 'dedent';
 import type { Argv, Options } from 'yargs';
 
 export interface FilterOptions {
@@ -38,33 +37,24 @@ export function filterOptions<T extends FilterOptions>(yargs: Argv<object>): Arg
       type: 'boolean',
     },
     since: {
-      describe: dedent`
-        Only include packages that have been changed since the specified [ref].
-        If no ref is passed, it defaults to the most-recent tag.
-      `,
+      describe:
+        'Only include packages that have been changed since the specified [ref].\n' +
+        'If no ref is passed, it defaults to the most-recent tag.',
       type: 'string',
     },
     'exclude-dependents': {
-      describe: dedent`
-        Exclude all transitive dependents when running a command
-        with --since, overriding the default 'changed' algorithm.
-      `,
+      describe:
+        "Exclude all transitive dependents when running a command\nwith --since, overriding the default 'changed' algorithm.",
       conflicts: 'include-dependents',
       type: 'boolean',
     },
     'include-dependents': {
-      describe: dedent`
-        Include all transitive dependents when running a command
-        regardless of --scope, --ignore, or --since.
-      `,
+      describe: 'Include all transitive dependents when running a command\nregardless of --scope, --ignore, or --since.',
       conflicts: 'exclude-dependents',
       type: 'boolean',
     },
     'include-dependencies': {
-      describe: dedent`
-        Include all transitive dependencies when running a command
-        regardless of --scope, --ignore, or --since.
-      `,
+      describe: 'Include all transitive dependencies when running a command\nregardless of --scope, --ignore, or --since.',
       type: 'boolean',
     },
     'include-merged-tags': {

--- a/packages/cli/src/lerna-cli.ts
+++ b/packages/cli/src/lerna-cli.ts
@@ -1,5 +1,4 @@
 import { log } from '@lerna-lite/npmlog';
-import dedent from 'dedent';
 import yargs from 'yargs/yargs';
 
 import { globalOptions } from './global-options.js';
@@ -38,11 +37,11 @@ function lernaCLI(argv?: any[], cwd?: string) {
     })
     .alias('h', 'help')
     .alias('v', 'version')
-    .wrap(cli.terminalWidth()).epilogue(dedent`
-      When a command fails, all logs are written to lerna-debug.log in the current working directory.
-
-      For more information, find our manual at https://github.com/lerna/lerna
-    `);
+    .wrap(cli.terminalWidth())
+    .epilogue(
+      'When a command fails, all logs are written to lerna-debug.log in the current working directory.\n\n' +
+        'For more information, find our manual at https://github.com/lerna/lerna'
+    );
 }
 
 export default lernaCLI;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,6 @@
     "@lerna-lite/npmlog": "workspace:*",
     "@npmcli/run-script": "^10.0.4",
     "ci-info": "catalog:",
-    "dedent": "catalog:",
     "json5": "^2.2.3",
     "lilconfig": "^3.1.3",
     "npm-package-arg": "catalog:",
@@ -54,7 +53,6 @@
     "zeptomatch": "catalog:dependencies"
   },
   "devDependencies": {
-    "@types/dedent": "catalog:devDependencies",
     "@types/inquirer": "^9.0.9",
     "@types/npm-package-arg": "catalog:devDependencies",
     "@types/semver": "catalog:devDependencies",

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -3,7 +3,6 @@ import { cpus } from 'node:os';
 import type { Logger } from '@lerna-lite/npmlog';
 import { log } from '@lerna-lite/npmlog';
 import { isCI } from 'ci-info';
-import dedent from 'dedent';
 import { xSync } from 'tinyexec';
 
 import { logExecCommand } from './child-process.js';
@@ -309,11 +308,9 @@ export class Command<T extends AvailableCommandOption> {
     if ((this.options as InitCommandOption).independent && !this.project.isIndependent()) {
       throw new ValidationError(
         'EVERSIONMODE',
-        dedent`
-          You ran lerna-lite with --independent or -i, but the repository is not set to independent mode.
-          To use independent mode you need to set lerna.json's "version" property to "independent".
-          Then you won't need to pass the --independent or -i flags.
-        `
+        'You ran lerna-lite with --independent or -i, but the repository is not set to independent mode.\n' +
+          'To use independent mode you need to set lerna.json\'s "version" property to "independent".\n' +
+          "Then you won't need to pass the --independent or -i flags."
       );
     }
   }

--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -2,7 +2,6 @@ import { globSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, normalize, resolve as pathResolve } from 'node:path';
 
 import { log } from '@lerna-lite/npmlog';
-import dedent from 'dedent';
 import JSON5 from 'json5';
 import { lilconfigSync } from 'lilconfig';
 import { writeJsonFile } from 'write-json-file';
@@ -105,10 +104,8 @@ export class Project {
       if (!workspaces) {
         throw new ValidationError(
           'EWORKSPACES',
-          dedent`
-            Yarn workspaces need to be defined in the root package.json.
-            See: https://github.com/lerna/lerna/blob/master/commands/bootstrap/README.md#--use-workspaces
-          `
+          'Yarn workspaces need to be defined in the root package.json.\n' +
+            'See: https://github.com/lerna/lerna/blob/master/commands/bootstrap/README.md#--use-workspaces'
         );
       }
 

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -43,7 +43,6 @@
     "conventional-changelog-writer": "^8.4.0",
     "conventional-commits-parser": "^6.4.0",
     "conventional-recommended-bump": "^11.2.0",
-    "dedent": "catalog:",
     "git-url-parse": "^16.1.0",
     "npm-package-arg": "catalog:",
     "semver": "catalog:",
@@ -52,7 +51,6 @@
   },
   "devDependencies": {
     "@npm/types": "^2.1.0",
-    "@types/dedent": "catalog:devDependencies",
     "@types/npm-package-arg": "catalog:devDependencies",
     "@types/semver": "catalog:devDependencies",
     "@types/yargs-parser": "catalog:devDependencies",

--- a/packages/version/src/__tests__/version-create-release.spec.ts
+++ b/packages/version/src/__tests__/version-create-release.spec.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path';
 import { colorize, logOutput, type VersionCommandOption, outputFile } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
 import { commandRunner, initFixtureFactory } from '@lerna-test/helpers';
-import dedent from 'dedent';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import yargParser from 'yargs-parser';
 
@@ -246,14 +245,16 @@ describe.each([
 
     await new VersionCommand(createArgv(cwd, '--create-release', type, '--conventional-commits', '--dry-run'));
 
-    expect((logOutput as any).logged()).toMatch(dedent`
-    Changes (5 packages):
-     - package-1: 1.0.0 => 1.1.0
-     - package-2: 1.0.0 => 1.1.0
-     - package-3: 1.0.0 => 1.1.0
-     - package-4: 1.0.0 => 1.1.0
-     - package-5: 1.0.0 => 1.1.0 (private)
-    `);
+    expect((logOutput as any).logged()).toMatch(
+      `
+Changes (5 packages):
+ - package-1: 1.0.0 => 1.1.0
+ - package-2: 1.0.0 => 1.1.0
+ - package-3: 1.0.0 => 1.1.0
+ - package-4: 1.0.0 => 1.1.0
+ - package-5: 1.0.0 => 1.1.0 (private)
+`.trim()
+    );
   });
 });
 

--- a/packages/version/src/conventional-commits/get-github-commits.ts
+++ b/packages/version/src/conventional-commits/get-github-commits.ts
@@ -1,7 +1,6 @@
 import type { ExecOpts } from '@lerna-lite/core';
 import { getComplexObjectValue } from '@lerna-lite/core';
 import { log } from '@lerna-lite/npmlog';
-import dedent from 'dedent';
 
 import { createGitHubClient, parseGitRepo } from '../git-clients/github-client.js';
 import type { RemoteCommit } from '../interfaces.js';
@@ -54,16 +53,20 @@ export async function getGithubCommits(
 
   do {
     const afterCursorStr = afterCursor ? `, after: "${afterCursor}"` : '';
-    const queryStr = dedent`
-      query getCommits($repo: String!, $owner: String!, $branchName: String!, $pageSize: Int!, $since: GitTimestamp!) {
-          repository(name: $repo, owner: $owner) {
-            ref(qualifiedName: $branchName) {
-              target { ... on Commit {
-                  history(first: $pageSize, since: $since ${afterCursorStr}) {
-                    nodes { oid, message, author { name, user { login }}}
-                    pageInfo { hasNextPage, endCursor }
-        }}}}}}
-        `.trim();
+    const queryStr = `
+query getCommits($repo: String!, $owner: String!, $branchName: String!, $pageSize: Int!, $since: GitTimestamp!) {
+  repository(name: $repo, owner: $owner) {
+    ref(qualifiedName: $branchName) {
+      target { ... on Commit {
+        history(first: $pageSize, since: $since ${afterCursorStr}) {
+          nodes { oid, message, author { name, user { login }}}
+          pageInfo { hasNextPage, endCursor }
+        }
+      }}
+    }
+  }
+}
+`.trim();
 
     const response: GraphqlCommitClientData = await octokit.graphql(queryStr, {
       owner: repo.owner,

--- a/packages/version/src/version-command.ts
+++ b/packages/version/src/version-command.ts
@@ -22,7 +22,6 @@ import {
   type UpdateCollectorOptions,
   type VersionCommandOption,
 } from '@lerna-lite/core';
-import dedent from 'dedent';
 import semver from 'semver';
 import zeptomatch from 'zeptomatch';
 
@@ -218,10 +217,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
       if (this.pushToRemote && !remoteBranchExists(this.gitRemote, this.currentBranch, this.execOpts, this.options.dryRun)) {
         throw new ValidationError(
           'ENOREMOTEBRANCH',
-          dedent`
-            Branch "${this.currentBranch}" doesn't exist in remote "${this.gitRemote}".
-            If this is a new branch, please make sure you push it to the remote first.
-          `
+          `Branch "${this.currentBranch}" doesn't exist in remote "${this.gitRemote}".\n` +
+            'If this is a new branch, please make sure you push it to the remote first.'
         );
       }
 
@@ -231,10 +228,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
       ) {
         throw new ValidationError(
           'ENOTALLOWED',
-          dedent`
-            Branch "${this.currentBranch}" is restricted from versioning due to allowBranch config.
-            Please consider the reasons for this restriction before overriding the option.
-          `
+          `Branch "${this.currentBranch}" is restricted from versioning due to allowBranch config.\n` +
+            'Please consider the reasons for this restriction before overriding the option.'
         );
       }
 
@@ -249,10 +244,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
           // interrupt interactive execution
           throw new ValidationError(
             'EBEHIND',
-            dedent`
-              ${message}
-              Please merge remote changes into "${this.currentBranch}" with "git pull"
-            `
+            `${message}\nPlease merge remote changes into "${this.currentBranch}" with "git pull"`
           );
         }
 
@@ -267,29 +259,17 @@ export class VersionCommand extends Command<VersionCommandOption> {
     }
 
     if (this.options.conventionalPrerelease && this.options.conventionalGraduate) {
-      throw new ValidationError(
-        'ENOTALLOWED',
-        dedent`
-          --conventional-prerelease cannot be combined with --conventional-graduate.
-        `
-      );
+      throw new ValidationError('ENOTALLOWED', '--conventional-prerelease cannot be combined with --conventional-graduate.');
     }
 
     if (this.options.manuallyUpdateRootLockfile && this.options.syncWorkspaceLock) {
-      throw new ValidationError(
-        'ENOTALLOWED',
-        dedent`
-          --manually-update-root-lockfile cannot be combined with --sync-workspace-lock.
-        `
-      );
+      throw new ValidationError('ENOTALLOWED', '--manually-update-root-lockfile cannot be combined with --sync-workspace-lock.');
     }
 
     if (this.changelogIncludeCommitsClientLogin && this.changelogIncludeCommitsGitAuthor) {
       throw new ValidationError(
         'ENOTALLOWED',
-        dedent`
-          --changelog-include-commits-client-login cannot be combined with --changelog-include-commits-git-author.
-        `
+        '--changelog-include-commits-client-login cannot be combined with --changelog-include-commits-git-author.'
       );
     }
 
@@ -302,9 +282,7 @@ export class VersionCommand extends Command<VersionCommandOption> {
       if (!remoteClient) {
         throw new ValidationError(
           'EMISSINGCLIENT',
-          dedent`
-            --changelog-include-commits-client-login requires one of these two option --remote-client or --create-release to be defined.
-          `
+          '--changelog-include-commits-client-login requires one of these two option --remote-client or --create-release to be defined.'
         );
       }
 
@@ -335,10 +313,8 @@ export class VersionCommand extends Command<VersionCommandOption> {
         } else {
           throw new ValidationError(
             'ENOVERSION',
-            dedent`
-              A version field is required in ${node.name}'s package.json file.
-              If you wish to keep the package unversioned, it must be made private.
-            `
+            `A version field is required in ${node.name}'s package.json file.\n` +
+              'If you wish to keep the package unversioned, it must be made private.'
           );
         }
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,6 @@ catalogs:
     ci-info:
       specifier: ^4.4.0
       version: 4.4.0
-    dedent:
-      specifier: ^1.7.2
-      version: 1.7.2
     dotenv:
       specifier: ^17.4.2
       version: 17.4.2
@@ -41,9 +38,6 @@ catalogs:
       specifier: ^2.1.0
       version: 2.1.0
   devDependencies:
-    '@types/dedent':
-      specifier: ^0.7.2
-      version: 0.7.2
     '@types/node':
       specifier: ^24.12.4
       version: 24.12.4
@@ -199,9 +193,6 @@ importers:
       '@lerna-lite/npmlog':
         specifier: workspace:*
         version: link:../npmlog
-      dedent:
-        specifier: 'catalog:'
-        version: 1.7.2
       dotenv:
         specifier: 'catalog:'
         version: 17.4.2
@@ -239,9 +230,6 @@ importers:
       ci-info:
         specifier: 'catalog:'
         version: 4.4.0
-      dedent:
-        specifier: 'catalog:'
-        version: 1.7.2
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -270,9 +258,6 @@ importers:
         specifier: catalog:dependencies
         version: 2.1.0
     devDependencies:
-      '@types/dedent':
-        specifier: catalog:devDependencies
-        version: 0.7.2
       '@types/inquirer':
         specifier: ^9.0.9
         version: 9.0.9
@@ -548,9 +533,6 @@ importers:
       conventional-recommended-bump:
         specifier: ^11.2.0
         version: 11.2.0
-      dedent:
-        specifier: 'catalog:'
-        version: 1.7.2
       git-url-parse:
         specifier: ^16.1.0
         version: 16.1.0
@@ -570,9 +552,6 @@ importers:
       '@npm/types':
         specifier: ^2.1.0
         version: 2.1.0
-      '@types/dedent':
-        specifier: catalog:devDependencies
-        version: 0.7.2
       '@types/npm-package-arg':
         specifier: catalog:devDependencies
         version: 6.1.4
@@ -1292,9 +1271,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/dedent@0.7.2':
-    resolution: {integrity: sha512-kRiitIeUg1mPV9yH4VUJ/1uk2XjyANfeL8/7rH1tsjvHeO9PJLBHJIYsFWmAvmGj5u8rj+1TZx7PZzW2qLw3Lw==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1614,14 +1590,6 @@ packages:
       supports-color: '*'
     peerDependenciesMeta:
       supports-color:
-        optional: true
-
-  dedent@1.7.2:
-    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
-    peerDependencies:
-      babel-plugin-macros: ^3.1.0
-    peerDependenciesMeta:
-      babel-plugin-macros:
         optional: true
 
   delayed-stream@1.0.0:
@@ -3240,8 +3208,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/dedent@0.7.2': {}
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -3562,8 +3528,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  dedent@1.7.2: {}
 
   delayed-stream@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,6 @@ minimumReleaseAgeExclude:
 # Define a catalog of version ranges.
 catalog:
   ci-info: ^4.4.0
-  dedent: ^1.7.2
   dotenv: ^17.4.2
   has-unicode: ^2.0.1
   npm-package-arg: ^13.0.2
@@ -30,7 +29,6 @@ catalog:
 catalogs:
   # Can be referenced through "catalog:devDependencies"
   devDependencies:
-    "@types/dedent": ^0.7.2
     "@types/node": ^24.12.4
     "@types/npm-package-arg": ^6.1.4
     "@types/npmcli__package-json": ^4.0.4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary

The existing `dedent` call sites were simple enough to replace with plain strings / template literals, so no custom `dedent` helper was needed. Replace all dedent strings with plain strings.

### What files were updated

- lerna-cli.ts
- filter-options.ts
- command.ts
- project.ts
- get-github-commits.ts
- version-command.ts
- version-create-release.spec.ts

### What files were removed
- `dedent` 
- `@types/dedent`

## How Has This Been Tested?

existing unit tests and E2E tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
