### PR TITLE
fix(version): honor 0.x major-to-minor in prerelease bumps

### DIFF
--- a/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
+++ b/packages/version/src/conventional-commits/__tests__/conventional-commits.spec.ts
@@ -348,6 +348,43 @@ describe('conventional-commits', () => {
         const bump = await recommendVersion(pkg0, 'independent', {});
         expect(bump).toBe('0.2.0');
       });
+
+      it('keeps breaking changes in prerelease series by default when prereleaseId is set', async () => {
+        const cwd = await initFixture('major-zero');
+        const [pkg0] = await Project.getPackages(cwd);
+
+        await pkg0.set('version', '0.1.0-alpha.0').serialize();
+        await gitAdd(cwd, pkg0.manifestLocation);
+        await gitCommit(cwd, 'chore: set prerelease version');
+
+        // make a change in package-0
+        await pkg0.set('changed', 1).serialize();
+        await gitAdd(cwd, pkg0.manifestLocation);
+        await gitCommit(cwd, 'feat: changed\n\nBREAKING CHANGE: changed');
+
+        const bump = await recommendVersion(pkg0, 'independent', { prereleaseId: 'alpha' });
+        expect(bump).toBe('0.1.0-alpha.1');
+      });
+
+      it('treats breaking changes as preminor when prereleaseId is set and conventionalBumpPrerelease is enabled', async () => {
+        const cwd = await initFixture('major-zero');
+        const [pkg0] = await Project.getPackages(cwd);
+
+        await pkg0.set('version', '0.1.0-alpha.0').serialize();
+        await gitAdd(cwd, pkg0.manifestLocation);
+        await gitCommit(cwd, 'chore: set prerelease version');
+
+        // make a change in package-0
+        await pkg0.set('changed', 1).serialize();
+        await gitAdd(cwd, pkg0.manifestLocation);
+        await gitCommit(cwd, 'feat: changed\n\nBREAKING CHANGE: changed');
+
+        const bump = await recommendVersion(pkg0, 'independent', {
+          prereleaseId: 'alpha',
+          conventionalBumpPrerelease: true,
+        });
+        expect(bump).toBe('0.2.0-alpha.0');
+      });
     });
 
     describe('prerelease bumps', () => {

--- a/packages/version/src/conventional-commits/recommend-version.ts
+++ b/packages/version/src/conventional-commits/recommend-version.ts
@@ -84,39 +84,40 @@ export async function recommendVersion(
       const bumpResult = (await bumper.bump(whatBumpFn)) as BumperRecommendation;
       let releaseType = (bumpResult?.releaseType || 'patch') as ReleaseType;
 
+      if (semver.major(pkg.version) === 0) {
+        // According to semver, major version zero (0.y.z) is for initial
+        // development. Anything MAY change at any time. The public API
+        // SHOULD NOT be considered stable. The version 1.0.0 defines
+        // the (initial stable) public API.
+        //
+        // To allow monorepos to use major version zero meaningfully,
+        // the transition from 0.x to 1.x must be explicitly requested
+        // by the user. Breaking changes MUST NOT automatically bump
+        // the major version from 0.x to 1.x.
+        //
+        // The usual convention is to use semver-patch bumps for bugfix
+        // releases and semver-minor for everything else, including
+        // breaking changes. This matches the behavior of `^` operator
+        // as implemented by `npm`.
+        //
+        // In node-semver, it is however also documented that
+        // "Many authors treat a 0.x version as if the x were the major "breaking-change" indicator."
+        // and all other features or bug fixes as semver-patch bumps
+        // this can be enabled in lerna through `premajorVersionBump = "force-patch"`
+        /* v8 ignore else */
+        if (releaseType === 'major') {
+          releaseType = 'minor';
+        } else if (premajorVersionBump === 'force-patch') {
+          releaseType = 'patch';
+        }
+      }
+
       if (prereleaseId) {
         const shouldBump = conventionalBumpPrerelease || shouldBumpPrerelease(releaseType, pkg.version);
         const prereleaseType = (shouldBump ? `pre${releaseType}` : 'prerelease') as ReleaseType;
         log.verbose(type, 'increment %s by %s - %s', pkg.version, prereleaseType, pkg.name);
         resolve(applyBuildMetadata(semver.inc(pkg.version, prereleaseType, prereleaseId), buildMetadata));
       } else {
-        if (semver.major(pkg.version) === 0) {
-          // According to semver, major version zero (0.y.z) is for initial
-          // development. Anything MAY change at any time. The public API
-          // SHOULD NOT be considered stable. The version 1.0.0 defines
-          // the (initial stable) public API.
-          //
-          // To allow monorepos to use major version zero meaningfully,
-          // the transition from 0.x to 1.x must be explicitly requested
-          // by the user. Breaking changes MUST NOT automatically bump
-          // the major version from 0.x to 1.x.
-          //
-          // The usual convention is to use semver-patch bumps for bugfix
-          // releases and semver-minor for everything else, including
-          // breaking changes. This matches the behavior of `^` operator
-          // as implemented by `npm`.
-          //
-          // In node-semver, it is however also documented that
-          // "Many authors treat a 0.x version as if the x were the major "breaking-change" indicator."
-          // and all other features or bug fixes as semver-patch bumps
-          // this can be enabled in lerna through `premajorVersionBump = "force-patch"`
-          /* v8 ignore else */
-          if (releaseType === 'major') {
-            releaseType = 'minor';
-          } else if (premajorVersionBump === 'force-patch') {
-            releaseType = 'patch';
-          }
-        }
         log.verbose(type, 'increment %s by %s - %s', pkg.version, releaseType, pkg.name);
         resolve(applyBuildMetadata(semver.inc(pkg.version, releaseType), buildMetadata));
       }


### PR DESCRIPTION
## Description

Adjusted conventional version recommendation so 0.x major handling is applied before prerelease branching. This ensures breaking changes on 0.x do not escalate to 1.0.0 during prerelease recommendation paths.

Also added tests to cover the prerelease behavior for major-zero packages in both default and conventional bump prerelease modes.

## Motivation and Context

> **Note** this bug fix was originally created as a patch in the Agoric SDK repo via this [commit](https://github.com/Agoric/agoric-sdk/commit/ae1039bd40e6c50cbf8626e4d9a20220a64b11a1), so I'm just replicating it in Lerna-Lite

A logic gap allowed prerelease flows to bypass the 0.x compatibility rule that maps major to minor. That could produce premajor bumps from 0.x prereleases, which breaks expected zero-major compatibility behavior.

This change keeps prerelease and non-prerelease paths consistent for 0.x packages.


## How Has This Been Tested?

Ran targeted tests for conventional commits recommendation behavior:

- pnpm vitest run conventional-commits.spec.ts --pool forks --no-watch --config vitest.config.ts

Result:
- Exit Code: 0

## Types of changes

- [ ] Chore (change that has absolutely no effect on users)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.