### PR TITLE
chore(tests): add extra E2E test related to conventional changelogs

### DIFF
--- a/e2e/version/version.spec.ts
+++ b/e2e/version/version.spec.ts
@@ -100,6 +100,23 @@ describe('lerna-version', () => {
       const version = JSON.parse(packageJson).version;
       expect(version).toMatch(/0\.0\.1/);
     });
+
+    it('should generate a changelog entry for conventional commits', async () => {
+      await fixture.createPackage({ name: 'package-conv-changelog', version: '0.0.0' });
+      await fixture.createInitialGitCommit();
+
+      await fixture.exec('echo "fix" > packages/package-conv-changelog/fix.txt');
+      await fixture.exec('git add .');
+      await fixture.exec('git commit -m "fix: bug fix"');
+
+      const output = await fixture.lerna('version --conventional-commits -y --no-push');
+
+      expect(output.combinedOutput).toContain('lerna');
+
+      const changelog = await fixture.readWorkspaceFile('CHANGELOG.md');
+      expect(changelog).toContain('bug fix');
+      expect(changelog).toContain('0.0.1');
+    });
   });
 
   describe('--no-git-tag-version', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I asked copilot to compare code against latest changes in Lerna's repo which were related to support latest conventional changelogs (which we already support in here). 

## Motivation and Context

Copilot confirmed that our code is already fine but it could be valuable to add an extra E2E test 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
