### PR TITLE
fix(core): forward maxBuffer through nodeOptions so large git output doesn't throw ENOBUFS

### DIFF
--- a/packages/core/src/child-process.ts
+++ b/packages/core/src/child-process.ts
@@ -274,7 +274,7 @@ function _createEnhancedError(result: any, command: string, args: string[] = [])
 
 /** Maps Lerna/TinyExec options to tinyexec Options format */
 function _mapOptions(command: string, opts?: TinyExecOptions): Options {
-  const { cwd, env, nodeOptions, ...rest } = opts || {};
+  const { cwd, env, nodeOptions, maxBuffer, ...rest } = opts || {};
 
   // Only use shell for the 'exit' command (used in status tests)
   // Using shell: true for 'git commit' causes arguments with spaces to break.
@@ -291,6 +291,14 @@ function _mapOptions(command: string, opts?: TinyExecOptions): Options {
       cwd,
       env,
       shell: useShell,
+      // tinyexec only forwards maxBuffer to Node's spawn/spawnSync through nodeOptions,
+      // so it must live here rather than at the top level (where the `--max-buffer`
+      // option currently lands, silently ignored). Without a large default, sync git
+      // calls that emit big output overflow Node's 1MB default and throw ENOBUFS —
+      // e.g. `git tag --list '*@*'` in independent mode on repos with tens of thousands
+      // of tags, which hasTags swallows as ENOTAGS -> "Assuming all packages changed".
+      // Default to 100MB to match the pre-tinyexec (execa) behavior.
+      maxBuffer: maxBuffer ?? 100 * 1024 * 1024,
       ...nodeOptions,
     },
   } as any;


### PR DESCRIPTION
## Description

Fixes #1373.

`tinyexec` only forwards `maxBuffer` to Node's `spawn`/`spawnSync` through `nodeOptions`. `_mapOptions` was spreading `maxBuffer` at the top level of the options object (via `...rest`), where tinyexec ignores it. Two consequences:

1. The `--max-buffer` option is a no-op for sync git calls.
2. There is no large default (execa used 100 MB), so any git command emitting more than Node's 1 MB default throws `ENOBUFS`.

The most visible symptom: in independent mode `hasTags` runs `git tag --list '*@*'`. On a repo with tens of thousands of tags that output exceeds 1 MB → `ENOBUFS` → thrown → caught in `hasTags` as `ENOTAGS` → `collectUpdates` falls back to `"Assuming all packages changed"`, silently breaking incremental version/publish.

## Motivation and Context

Regression from the execa → tinyexec migration (#1316). Before v5, execa's 100 MB `maxBuffer` default meant this never surfaced.

## How Has This Been Tested?

- Repro confirmed: `xSync('git', ['tag','--list','*@*'], { maxBuffer: 100*1024*1024 })` throws `ENOBUFS`; the same with `{ nodeOptions: { maxBuffer: ... } }` succeeds.
- Applied the equivalent change as a `bun patch` on `@lerna-lite/core@5.4.1` in a real independent monorepo (~54.5k tags): `hasTags('*@*')` now returns `true` and incremental detection is restored.

Happy to add a unit test around `_mapOptions` / `nodeOptions` propagation if you'd like — let me know your preferred shape (the fn isn't currently exported).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

`packages/core/src/child-process.ts` — `_mapOptions`: destructure `maxBuffer` and place it inside `nodeOptions`, defaulting to `100 * 1024 * 1024` (matches the previous execa default).
