### PR TITLE
chore(ci): fix Vitest junit test-report location

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          files: ./test-report.junit.xml
+          files: ./coverage/test-report.junit.xml
 
       - name: Upload test coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/vitest/vitest.config.ts
+++ b/vitest/vitest.config.ts
@@ -33,11 +33,11 @@ export default defineConfig({
         '**/models.ts',
         '**/types.ts',
       ],
-      reporters: ['default', 'junit'],
-      outputFile: {
-        junit: './test-report.junit.xml',
-      },
       provider: 'v8',
+    },
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './coverage/test-report.junit.xml',
     },
   },
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

new codecov feature to read test report should work

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Vitest config was incorrect and didn't produce the expected new test-report.xml and so codecov couldn't find it

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
