### PR TITLE
chore(tests): cover prerelease message interpolation

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,43 +4,43 @@
     {
       "label": "Build Library",
       "type": "shell",
-      "command": "npm run build",
+      "command": "pnpm run build",
       "problemMatcher": []
     },
     {
       "label": "Full Build Library",
       "type": "shell",
-      "command": "npm run build:full",
+      "command": "pnpm run build:full",
       "problemMatcher": []
     },
     {
       "label": "Run Vitest Unit Tests (watch)",
       "type": "shell",
-      "command": "npm run test:watch",
+      "command": "pnpm run test:watch",
       "problemMatcher": []
     },
     {
       "label": "Run Vitest with Test Coverage",
       "type": "shell",
-      "command": "npm run test",
+      "command": "pnpm run test",
       "problemMatcher": []
     },
     {
       "label": "[dry-run] new Version (from dist)",
       "type": "shell",
-      "command": "npm run dist-roll-version-dry-run",
+      "command": "pnpm run dist-roll-version-dry-run",
       "problemMatcher": []
     },
     {
       "label": "Roll new Version (from dist)",
       "type": "shell",
-      "command": "npm run dist-roll-version",
+      "command": "pnpm run dist-roll-version",
       "problemMatcher": []
     },
     {
       "label": "Roll Publish Version (from dist)",
       "type": "shell",
-      "command": "npm run dist-roll-publish",
+      "command": "pnpm run dist-roll-publish",
       "problemMatcher": []
     }
   ]

--- a/package.json
+++ b/package.json
@@ -103,5 +103,5 @@
     "node": "^22.17.0 || >=24.0.0",
     "pnpm": "11.x"
   },
-  "packageManager": "pnpm@11.11.0"
+  "packageManager": "pnpm@11.17.0"
 }

--- a/packages/version/src/__tests__/version-bump-prerelease.spec.ts
+++ b/packages/version/src/__tests__/version-bump-prerelease.spec.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve as pathResolve } from 'node:path';
 
-import { promptSelectOne, promptTextInput, type VersionCommandOption, outputFile } from '@lerna-lite/core';
+import { promptSelectOne, promptTextInput, type VersionCommandOption, outputFile, readJson, writeJson } from '@lerna-lite/core';
 import { commandRunner, getCommitMessage, gitAdd, gitCommit, gitInit, gitTag, initFixtureFactory, showCommit } from '@lerna-test/helpers';
 import serializeChangelog from '@lerna-test/helpers/serializers/serialize-changelog.js';
 import { expect, test, vi, type Mock } from 'vitest';
@@ -111,6 +111,26 @@ test('version prerelease with existing preid bumps with the preid provide as arg
 
   const message = await getCommitMessage(testDir);
   expect(message).toBe('v1.0.1-rc.0');
+});
+
+test('version prerelease interpolates configured message placeholders', async () => {
+  const testDir = await initFixture('republish-prereleased');
+  const lernaConfigPath = join(testDir, 'lerna.json');
+  const lernaConfig = await readJson(lernaConfigPath);
+
+  await writeJson(lernaConfigPath, {
+    ...lernaConfig,
+    command: {
+      version: {
+        message: 'chore(release): version %s',
+      },
+    },
+  });
+  await setupChanges(testDir);
+  await lernaVersion(testDir)('prerelease', '--preid', 'rc');
+
+  const message = await getCommitMessage(testDir);
+  expect(message).toBe('chore(release): version v1.0.1-rc.0');
 });
 
 test('version prerelease with immediate graduation', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add an extra unit test to validate pre-release versioning message

## Motivation and Context

Follows PR opened in Lerna's repo:

> ## Summary
> * add regression coverage for fixed-mode prerelease versioning with a configured `command.version.message`
> * verify `%s` is interpolated to the prerelease tag in the generated version commit message
> 
> Refs #4186
> 
> ## Testing
> * `NX_DAEMON=false npm_config_cache=/tmp/lerna-4186-npm-cache npx nx test commands-version --testFile=libs/commands/version/src/lib/version-bump-prerelease.spec.ts --runInBand`
> * `NX_DAEMON=false npm_config_cache=/tmp/lerna-4186-npm-cache npx nx lint commands-version --files=libs/commands/version/src/lib/version-bump-prerelease.spec.ts` (0 errors; existing warnings)
> * `npm_config_cache=/tmp/lerna-4186-npm-cache npx prettier --check libs/commands/version/src/lib/version-bump-prerelease.spec.ts`
> * `git diff --check`



## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (change that has absolutely no effect on users)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
